### PR TITLE
ctl: elem_info_int: fix wrong assignment to private value

### DIFF
--- a/src/ctl/elem-info-int.c
+++ b/src/ctl/elem-info-int.c
@@ -29,10 +29,10 @@ static void ctl_elem_info_int_set_property(GObject *obj, guint id,
         info->value.integer.min = (long)g_value_get_int(val);
         break;
     case CTL_ELEM_INFO_INT_PROP_MAX:
-        info->value.integer.min = (long)g_value_get_int(val);
+        info->value.integer.max = (long)g_value_get_int(val);
         break;
     case CTL_ELEM_INFO_INT_PROP_STEP:
-        info->value.integer.min = (long)g_value_get_int(val);
+        info->value.integer.step = (long)g_value_get_int(val);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(obj, id, spec);


### PR DESCRIPTION
ALSACtl::ElemInfoInt has properties for 'min', 'max' and 'step' but their
assignments are not proper. This commit fixes the bug.

Fixes: aac870451a89 ("ctl: elem_info_int: add properties for type-dependent parameters and constructor")
Signed-off-by: Takashi Sakamoto <o-takashi@sakamocchi.jp>