### PR TITLE
ctl: elem_id/elem_value: add APIs to check whether two instances have the same meaning

### DIFF
--- a/src/ctl/alsactl.map
+++ b/src/ctl/alsactl.map
@@ -76,6 +76,7 @@ ALSA_GOBJECT_0_0_0 {
     "alsactl_elem_value_get_iec60958";
     "alsactl_elem_value_set_int64";
     "alsactl_elem_value_get_int64";
+    "alsactl_elem_value_equal";
   local:
     *;
 };

--- a/src/ctl/alsactl.map
+++ b/src/ctl/alsactl.map
@@ -40,6 +40,7 @@ ALSA_GOBJECT_0_0_0 {
     "alsactl_elem_id_get_subdevice_id";
     "alsactl_elem_id_get_name";
     "alsactl_elem_id_get_index";
+    "alsactl_elem_id_equal";
 
     "alsactl_elem_info_get_type";
 

--- a/src/ctl/elem-id.c
+++ b/src/ctl/elem-id.c
@@ -129,3 +129,25 @@ void alsactl_elem_id_get_index(const ALSACtlElemId *self, guint *index)
 {
     *index = self->index;
 }
+
+/**
+ * alsactl_elem_id_equal:
+ * @self: A #ALSACtlElemId.
+ * @target: A #ALSACtlElemId to compare.
+ *
+ * Returns: whether the given object indicates the same element.
+ */
+gboolean alsactl_elem_id_equal(const ALSACtlElemId *self,
+                               const ALSACtlElemId *target) {
+    const struct snd_ctl_elem_id *lhs, *rhs;
+
+    lhs = (const struct snd_ctl_elem_id *)self;
+    rhs = (const struct snd_ctl_elem_id *)target;
+
+    return lhs->numid == rhs->numid ||
+           (lhs->iface == rhs->iface &&
+            lhs->device == rhs->device &&
+            lhs->subdevice == rhs->subdevice &&
+            !strcmp((const char *)lhs->name, (const char *)rhs->name) &&
+            lhs->index == rhs->index);
+}

--- a/src/ctl/elem-id.h
+++ b/src/ctl/elem-id.h
@@ -31,6 +31,9 @@ void alsactl_elem_id_get_subdevice_id(const ALSACtlElemId *self,
 void alsactl_elem_id_get_name(const ALSACtlElemId *self, const gchar **name);
 void alsactl_elem_id_get_index(const ALSACtlElemId *self, guint *index);
 
+gboolean alsactl_elem_id_equal(const ALSACtlElemId *self,
+                               const ALSACtlElemId *target);
+
 G_END_DECLS
 
 #endif

--- a/src/ctl/elem-value.c
+++ b/src/ctl/elem-value.c
@@ -398,3 +398,23 @@ void alsactl_elem_value_get_int64(ALSACtlElemValue *self,
     for (i = 0; i < *value_count; ++i)
         (*values)[i] = (gint64)value->value.integer64.value[i];
 }
+
+/**
+ * alsactl_elem_value_equal:
+ * @self: A #ALSACtlElemValue.
+ * @target: A #ALSACtlElemValue to compare.
+ *
+ * Returns: whether the given object includes the same values as the instance.
+ *          The other fields are ignored to be compared.
+ */
+gboolean alsactl_elem_value_equal(const ALSACtlElemValue *self,
+                                  const ALSACtlElemValue *target) {
+    const ALSACtlElemValuePrivate *lhs, *rhs;
+
+    g_return_val_if_fail(ALSACTL_IS_ELEM_VALUE(self), FALSE);
+    g_return_val_if_fail(ALSACTL_IS_ELEM_VALUE(target), FALSE);
+    lhs = alsactl_elem_value_get_instance_private((ALSACtlElemValue *)self);
+    rhs = alsactl_elem_value_get_instance_private((ALSACtlElemValue *)target);
+
+    return !memcmp(&lhs->value, &rhs->value, sizeof(lhs->value));
+}

--- a/src/ctl/elem-value.h
+++ b/src/ctl/elem-value.h
@@ -81,6 +81,9 @@ void alsactl_elem_value_set_int64(ALSACtlElemValue *self, const gint64 *values,
 void alsactl_elem_value_get_int64(ALSACtlElemValue *self,
                                   gint64 *const *values, gsize *value_count);
 
+gboolean alsactl_elem_value_equal(const ALSACtlElemValue *self,
+                                  const ALSACtlElemValue *target);
+
 G_END_DECLS
 
 #endif

--- a/tests/alsactl-elem-id
+++ b/tests/alsactl-elem-id
@@ -10,15 +10,15 @@ gi.require_version('ALSACtl', '0.0')
 from gi.repository import ALSACtl
 
 target = ALSACtl.ElemId()
-props = (
-    'numid',
-    'iface',
-    'device',
-    'subdevice',
-    'name',
-    'index',
+props = ()
+methods = (
+    'get_numid',
+    'get_iface',
+    'get_device',
+    'get_subdevice',
+    'get_name',
+    'get_index',
 )
-methods = ()
 signals = ()
 
 if not test(target, props, methods, signals):

--- a/tests/alsactl-elem-id
+++ b/tests/alsactl-elem-id
@@ -18,6 +18,7 @@ methods = (
     'get_subdevice',
     'get_name',
     'get_index',
+    'equals',
 )
 signals = ()
 

--- a/tests/alsactl-elem-value
+++ b/tests/alsactl-elem-value
@@ -27,6 +27,7 @@ methods = (
     'get_iec60958',
     'set_int64',
     'get_int64',
+    'equal',
 )
 signals = ()
 


### PR DESCRIPTION
For some cases, it's convenient for users to check whether two instances of elem_id/elem_value have the same meaning. In glib, APIs for comparison of content of objects are named as equal. This commit adds equal APIs for this purpose.