### PR TITLE
ctl: misc fixes

### DIFF
--- a/doc/reference/ctl/alsactl.types
+++ b/doc/reference/ctl/alsactl.types
@@ -2,7 +2,7 @@ alsactl_elem_type_get_type
 alsactl_elem_iface_type_get_type
 alsactl_elem_access_flag_get_type
 alsactl_event_type_get_type
-alsactl_event_mask_flag_get_type
+alsactl_elem_event_mask_get_type
 alsactl_card_get_type
 alsactl_card_info_get_type
 alsactl_elem_id_get_type

--- a/src/ctl/alsactl-enum-types.h
+++ b/src/ctl/alsactl-enum-types.h
@@ -91,22 +91,22 @@ typedef enum
 } ALSACtlEventType;
 
 /**
- * ALSACtlEventMaskFlag:
- * @ALSACTL_EVENT_MASK_FLAG_VALUE:      The event notifies any change of value for the element.
- * @ALSACTL_EVENT_MASK_FLAG_INFO:       The event notifies any change of information for the element.
- * @ALSACTL_EVENT_MASK_FLAG_ADD:        The element notifies addition of the element.
- * @ALSACTL_EVENT_MASK_FLAG_TLV:        The element notifies any change of Type-Length-Value data for the element.
- * @ALSACTL_EVENT_MASK_FLAG_REMOVE:     The element notifies removal of the element.
+ * ALSACtlElemEventMask:
+ * @ALSACTL_ELEM_EVENT_MASK_VALUE:  The event notifies any change of value for the element.
+ * @ALSACTL_ELEM_EVENT_MASK_INFO:   The event notifies any change of information for the element.
+ * @ALSACTL_ELEM_EVENT_MASK_ADD:    The element notifies addition of the element.
+ * @ALSACTL_ELEM_EVENT_MASK_TLV:    The element notifies any change of Type-Length-Value data for the element.
+ * @ALSACTL_ELEM_EVENT_MASK_REMOVE: The element notifies removal of the element.
  *
  * A set of flags for the content of event for the element.
  */
 typedef enum /*< flags >*/
 {
-    ALSACTL_EVENT_MASK_FLAG_VALUE   = SNDRV_CTL_EVENT_MASK_VALUE,
-    ALSACTL_EVENT_MASK_FLAG_INFO    = SNDRV_CTL_EVENT_MASK_INFO,
-    ALSACTL_EVENT_MASK_FLAG_ADD     = SNDRV_CTL_EVENT_MASK_ADD,
-    ALSACTL_EVENT_MASK_FLAG_TLV     = SNDRV_CTL_EVENT_MASK_TLV,
-    ALSACTL_EVENT_MASK_FLAG_REMOVE  = SNDRV_CTL_EVENT_MASK_TLV << 1,
-} ALSACtlEventMaskFlag;
+    ALSACTL_ELEM_EVENT_MASK_VALUE   = SNDRV_CTL_EVENT_MASK_VALUE,
+    ALSACTL_ELEM_EVENT_MASK_INFO    = SNDRV_CTL_EVENT_MASK_INFO,
+    ALSACTL_ELEM_EVENT_MASK_ADD     = SNDRV_CTL_EVENT_MASK_ADD,
+    ALSACTL_ELEM_EVENT_MASK_TLV     = SNDRV_CTL_EVENT_MASK_TLV,
+    ALSACTL_ELEM_EVENT_MASK_REMOVE  = SNDRV_CTL_EVENT_MASK_TLV << 1,
+} ALSACtlElemEventMask;
 
 #endif

--- a/src/ctl/alsactl.map
+++ b/src/ctl/alsactl.map
@@ -4,7 +4,7 @@ ALSA_GOBJECT_0_0_0 {
     "alsactl_elem_iface_type_get_type";
     "alsactl_elem_access_flag_get_type";
     "alsactl_event_type_get_type";
-    "alsactl_event_mask_flag_get_type";
+    "alsactl_elem_event_mask_get_type";
 
     "alsactl_get_card_id_list";
     "alsactl_get_card_sysname";

--- a/src/ctl/card.c
+++ b/src/ctl/card.c
@@ -108,7 +108,7 @@ static void alsactl_card_class_init(ALSACtlCardClass *klass)
      * ALSACtlCard::handle-elem-event:
      * @self: A #ALSACtlCard.
      * @elem_id: (transfer none): A #ALSACtlElemId.
-     * @events: A set of #ALSACtlEventMaskFlag.
+     * @events: A set of #ALSACtlElemEventMask.
      *
      * When event occurs for any element, this signal is emit.
      */
@@ -120,7 +120,7 @@ static void alsactl_card_class_init(ALSACtlCardClass *klass)
                      NULL, NULL,
                      alsactl_sigs_marshal_VOID__BOXED_FLAGS,
                      G_TYPE_NONE, 2, ALSACTL_TYPE_ELEM_ID,
-                     ALSACTL_TYPE_EVENT_MASK_FLAG);
+                     ALSACTL_TYPE_ELEM_EVENT_MASK);
 
     /**
      * ALSACtlCard::handle-disconnection:
@@ -775,12 +775,12 @@ static void handle_elem_event(CtlCardSource *src, struct snd_ctl_event *ev)
         ALSACtlElemId *elem_id = (ALSACtlElemId *)entry->data;
 
         if (ev->data.elem.id.numid == elem_id->numid) {
-            ALSACtlEventMaskFlag mask;
+            ALSACtlElemEventMask mask;
 
             if (ev->data.elem.mask != SNDRV_CTL_EVENT_MASK_REMOVE)
                 mask = ev->data.elem.mask;
             else
-                mask = ALSACTL_EVENT_MASK_FLAG_REMOVE;
+                mask = ALSACTL_ELEM_EVENT_MASK_REMOVE;
 
             g_signal_emit(self,
                           ctl_card_sigs[CTL_CARD_SIG_HANDLE_ELEM_EVENT], 0,

--- a/src/ctl/card.h
+++ b/src/ctl/card.h
@@ -53,12 +53,12 @@ struct _ALSACtlCardClass {
      * ALSACtlCardClass::handle_elem_event:
      * @self: A #ALSACtlCard.
      * @elem_id: (transfer none): A #ALSACtlElemId.
-     * @events: A set of #ALSACtlEventMaskFlag.
+     * @events: A set of #ALSACtlElemEventMask.
      *
      * When event occurs for any element, this signal is emit.
      */
     void (*handle_elem_event)(ALSACtlCard *self, const ALSACtlElemId *elem_id,
-                              ALSACtlEventMaskFlag events);
+                              ALSACtlElemEventMask events);
 
     /**
      * ALSACtlCardClass::handle_disconnection:

--- a/tests/alsactl-enums
+++ b/tests/alsactl-enums
@@ -43,7 +43,7 @@ event_types = (
     'ELEM',
 )
 
-event_mask_flags = (
+elem_event_mask_flags = (
     'VALUE',
     'INFO',
     'ADD',
@@ -57,7 +57,7 @@ types = {
     ALSACtl.ElemAccessFlag: elem_access_flags,
     ALSACtl.ElemAccessFlag: elem_access_flags,
     ALSACtl.EventType:      event_types,
-    ALSACtl.EventMaskFlag:  event_mask_flags,
+    ALSACtl.ElemEventMask:  elem_event_mask_flags,
 }
 
 for obj, types in types.items():


### PR DESCRIPTION
This patchset incldues two changes:

 * rename element event flag with suitable name
 * simplify event dispatching