### PR TITLE
alsa-gobject: ctl: fix wrong operation for values in enumerated type of element

### DIFF
--- a/src/ctl/elem-value.c
+++ b/src/ctl/elem-value.c
@@ -190,9 +190,9 @@ void alsactl_elem_value_set_enum(ALSACtlElemValue *self,
     priv = alsactl_elem_value_get_instance_private(self);
     value = &priv->value;
 
-    value_count = MIN(value_count, G_N_ELEMENTS(value->value.integer.value));
+    value_count = MIN(value_count, G_N_ELEMENTS(value->value.enumerated.item));
     for (i = 0; i < value_count; ++i)
-        value->value.integer.value[i] = (long)values[i];
+        value->value.enumerated.item[i] = (unsigned int)values[i];
 }
 
 /**
@@ -215,9 +215,9 @@ void alsactl_elem_value_get_enum(ALSACtlElemValue *self,
     priv = alsactl_elem_value_get_instance_private(self);
     value = &priv->value;
 
-    *value_count = MIN(*value_count, G_N_ELEMENTS(value->value.integer.value));
+    *value_count = MIN(*value_count, G_N_ELEMENTS(value->value.enumerated.item));
     for (i = 0; i < *value_count; ++i)
-        (*values)[i] = (guint32)value->value.integer.value[i];
+        (*values)[i] = (guint32)value->value.enumerated.item[i];
 }
 
 /**


### PR DESCRIPTION
The 'snd_ctl_elem_value' structure includes union member for values.
Although it includes 'enumerated' member for values in enumerated type
of element, current implementation of alsactl library uses 'integer'
member to pick up the values. As a result, in any 64 bit System V ABI,
the library fails to get/set values for the enumerated type of
element. This commit fixes the bug.

Signed-off-by: Takashi Sakamoto <o-takashi@sakamocchi.jp>