### PR TITLE
alsa-gobject: GSource optimization

### DIFF
--- a/src/ctl/card.c
+++ b/src/ctl/card.c
@@ -161,11 +161,13 @@ ALSACtlCard *alsactl_card_new()
  * alsactl_card_open:
  * @self: A #ALSACtlCard.
  * @card_id: The numerical ID of sound card.
+ * @open_flag: The flag of open(2) system call. O_RDONLY is forced to fulfil internally.
  * @error: A #GError.
  *
  * Open ALSA control character device for the sound card.
  */
-void alsactl_card_open(ALSACtlCard *self, guint card_id, GError **error)
+void alsactl_card_open(ALSACtlCard *self, guint card_id, gint open_flag,
+                       GError **error)
 {
     ALSACtlCardPrivate *priv;
     char *devnode;
@@ -177,7 +179,8 @@ void alsactl_card_open(ALSACtlCard *self, guint card_id, GError **error)
     if (*error != NULL)
         return;
 
-    priv->fd = open(devnode, O_RDONLY | O_NONBLOCK);
+    open_flag |= O_RDONLY;
+    priv->fd = open(devnode, open_flag);
     if (priv->fd < 0) {
         generate_error(error, errno);
         g_free(devnode);

--- a/src/ctl/card.c
+++ b/src/ctl/card.c
@@ -778,14 +778,6 @@ static void handle_elem_event(CtlCardSource *src, struct snd_ctl_event *ev)
                   elem_id, mask);
 }
 
-static gboolean ctl_card_prepare_src(GSource *src, gint *timeout)
-{
-    *timeout = 500;
-
-    // This source is not ready, let's poll(2).
-    return FALSE;
-}
-
 static gboolean ctl_card_check_src(GSource *gsrc)
 {
     CtlCardSource *src = (CtlCardSource *)gsrc;
@@ -868,7 +860,6 @@ void alsactl_card_create_source(ALSACtlCard *self, GSource **gsrc,
                                 GError **error)
 {
     static GSourceFuncs funcs = {
-            .prepare        = ctl_card_prepare_src,
             .check          = ctl_card_check_src,
             .dispatch       = ctl_card_dispatch_src,
             .finalize       = ctl_card_finalize_src,

--- a/src/ctl/card.h
+++ b/src/ctl/card.h
@@ -76,7 +76,8 @@ GType alsactl_card_get_type() G_GNUC_CONST;
 
 ALSACtlCard *alsactl_card_new();
 
-void alsactl_card_open(ALSACtlCard *self, guint card_id, GError **error);
+void alsactl_card_open(ALSACtlCard *self, guint card_id, gint open_flag,
+                       GError **error);
 
 void alsactl_card_get_info(ALSACtlCard *self, ALSACtlCardInfo **card_info,
                            GError **error);

--- a/src/timer/user-instance.c
+++ b/src/timer/user-instance.c
@@ -316,14 +316,6 @@ static void handle_timestamp_events(TimerUserInstanceSource *src, int len)
     }
 }
 
-static gboolean timer_user_instance_prepare_src(GSource *src, gint *timeout)
-{
-    *timeout = 500;
-
-    // This source is not ready, let's poll(2).
-    return FALSE;
-}
-
 static gboolean timer_user_instance_check_src(GSource *gsrc)
 {
     TimerUserInstanceSource *src = (TimerUserInstanceSource *)gsrc;
@@ -395,7 +387,6 @@ void alsatimer_user_instance_create_source(ALSATimerUserInstance *self,
                                          GSource **gsrc, GError **error)
 {
     static GSourceFuncs funcs = {
-            .prepare        = timer_user_instance_prepare_src,
             .check          = timer_user_instance_check_src,
             .dispatch       = timer_user_instance_dispatch_src,
             .finalize       = timer_user_instance_finalize_src,

--- a/src/timer/user-instance.c
+++ b/src/timer/user-instance.c
@@ -96,11 +96,13 @@ static void alsatimer_user_instance_init(ALSATimerUserInstance *self)
 /**
  * alsatimer_user_instance_open:
  * @self: A #ALSATimerUserInstance.
+ * @open_flag: The flag of open(2) system call. O_RDONLY is forced to fulfil internally.
  * @error: A #GError.
  *
  * Open ALSA Timer character device to allocate queue.
  */
-void alsatimer_user_instance_open(ALSATimerUserInstance *self, GError **error)
+void alsatimer_user_instance_open(ALSATimerUserInstance *self, gint open_flag,
+                                  GError **error)
 {
     ALSATimerUserInstancePrivate *priv;
     char *devnode;
@@ -112,7 +114,8 @@ void alsatimer_user_instance_open(ALSATimerUserInstance *self, GError **error)
     if (*error != NULL)
         return;
 
-    priv->fd = open(devnode, O_RDONLY);
+    open_flag |= O_RDONLY;
+    priv->fd = open(devnode, open_flag);
     g_free(devnode);
     if (priv->fd < 0) {
         generate_error(error, errno);

--- a/src/timer/user-instance.h
+++ b/src/timer/user-instance.h
@@ -74,7 +74,8 @@ GType alsatimer_user_instance_get_type() G_GNUC_CONST;
 
 ALSATimerUserInstance *alsatimer_user_instance_new();
 
-void alsatimer_user_instance_open(ALSATimerUserInstance *self, GError **error);
+void alsatimer_user_instance_open(ALSATimerUserInstance *self, gint open_flag,
+                                  GError **error);
 
 void alsatimer_user_instance_attach(ALSATimerUserInstance *self,
                                     ALSATimerDeviceId *device_id,


### PR DESCRIPTION
As long as using the created Gsource with GMainContext, the call of poll(2)
system call with infinite timeout surely returns when quit() method is
called for the context. All of GMainContext implements GWakeup with eventfd
and the call of quit() emits event via the file descriptor of eventfd. This
brings wakeup from blocking when poll(2) is called with inifinite timeout.

In current implementation of alsactl/alsatimer, open(2) is called with O_NONBLOCK
and GSource includes explicit timeout to avoid the infinite blocking. However,
they are not necessarily required for GMainContext.

This patchset obsoletes these points and adds options as the alternatives.