### PR TITLE
alsa-gobject: add support for i386 build job to workflow of Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build test
 on: [push, pull_request]
 
 jobs:
-  build_in_fedora_on_docker:
+  build_in_fedora_for_amd64_on_docker:
     runs-on: ubuntu-latest
     container:
       image: fedora:32
@@ -36,7 +36,48 @@ jobs:
         cd build
         meson install
 
-  build_in_ubuntu_on_lxd:
+  build_in_ubuntu_for_i386_on_lxd:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install and initialize LXD
+      run: |
+        sudo snap install lxd
+        sudo lxd init --auto
+    - name: Launch container
+      run: |
+        sudo lxc launch ubuntu:19.10/i386 builder
+        sudo lxc exec builder -- bash -c 'while [ "$(systemctl is-system-running 2>/dev/null)" != "running" ] && [ "$(systemctl is-system-running 2>/dev/null)" != "degraded" ]; do :; done'
+    - name: Prepare build environment.
+      run: |
+        sudo lxc exec builder -- su ubuntu -c 'sudo apt-get update'
+        sudo lxc exec builder -- su ubuntu -c 'sudo apt-get -y full-upgrade'
+        sudo lxc exec builder -- su ubuntu -c 'sudo apt-get install -y git build-essential'
+        sudo lxc exec builder -- su ubuntu -c 'sudo apt-get install -y meson ninja-build libglib2.0-dev libudev-dev gobject-introspection libgirepository1.0-dev'
+        sudo lxc exec builder -- su ubuntu -c 'sudo apt-get install -y gtk-doc-tools python3-gi'
+    - name: Checkout repository.
+      uses: actions/checkout@v2
+    - name: Generate archive and expand it inner the container.
+      run: |
+        git archive --format=tar --prefix=dist/ HEAD | xz > archive.tar.xz
+        sudo lxc file push archive.tar.xz builder/home/ubuntu/
+        sudo lxc exec builder -- su ubuntu -c 'cd; tar xf archive.tar.xz'
+    - name: Initialization for build
+      run: |
+        sudo lxc exec builder -- su ubuntu -c 'cd; cd dist; meson --prefix=/home/ubuntu/install -Dgtk_doc=true -Dwarning_level=3 . build'
+    - name: Display configuration.
+      run: |
+        sudo lxc exec builder -- su ubuntu -c 'cd; cd dist/build; meson configure'
+    - name: Build library.
+      run: |
+        sudo lxc exec builder -- su ubuntu -c 'cd; cd dist/build; ninja'
+    - name: Test interfaces exposed by g-i.
+      run: |
+        sudo lxc exec builder -- su ubuntu -c 'cd; cd dist/build; meson test'
+    - name: Test install.
+      run: |
+        sudo lxc exec builder -- su ubuntu -c 'cd; cd dist/build; meson install'
+
+  build_in_ubuntu_for_amd64_on_lxd:
     runs-on: ubuntu-latest
     steps:
     - name: Install and initialize LXD


### PR DESCRIPTION
In lxd repository for Ubuntu Cloud Images[1], Ubuntu i386 container
is available for applications of Intel386 ABI.

This commit uses the container to test build for Intel386 ABI in
workflow of Github Actions.

I note that no official Fedora i386 container is in dockerhub
registry[2]. It's needed to find the way to build application for
Intel386 ABI on AMD64 architecture (perhaps multiarch) if we are
going to support it.

[1] https://cloud-images.ubuntu.com/releases/
[2] https://hub.docker.com/_/fedora

Signed-off-by: Takashi Sakamoto <o-takashi@sakamocchi.jp>