### PR TITLE
alsa-gobject: normalize function signatures

### DIFF
--- a/src/seq/alsaseq.map
+++ b/src/seq/alsaseq.map
@@ -116,6 +116,8 @@ ALSA_GOBJECT_0_0_0 {
     "alsaseq_event_data_queue_set_skew_param";
     "alsaseq_event_data_queue_get_quadlet_param";
     "alsaseq_event_data_queue_set_quadlet_param";
+    "alsaseq_event_data_queue_get_byte_param";
+    "alsaseq_event_data_queue_set_byte_param";
 
     "alsaseq_event_data_connect_get_type";
     "alsaseq_event_data_connect_get_src";

--- a/src/seq/event-data-connect.c
+++ b/src/seq/event-data-connect.c
@@ -11,14 +11,14 @@ G_DEFINE_BOXED_TYPE(ALSASeqEventDataConnect, alsaseq_event_data_connect, seq_eve
 /**
  * alsaseq_event_data_connect_get_src:
  * @self: A #ALSASeqEventDataConnect.
+ * @src: (out)(transfer none): The source of connection event.
  *
  * Get the source of connection event.
- *
- * Returns: (transfer none): The source of connection event.
  */
-const ALSASeqAddr *alsaseq_event_data_connect_get_src(ALSASeqEventDataConnect *self)
+void alsaseq_event_data_connect_get_src(ALSASeqEventDataConnect *self,
+                                        const ALSASeqAddr **src)
 {
-    return &self->sender;
+    *src = &self->sender;
 }
 
 /**
@@ -37,14 +37,14 @@ void alsaseq_event_data_connect_set_src(ALSASeqEventDataConnect *self,
 /**
  * alsaseq_event_data_connect_get_dst:
  * @self: A #ALSASeqEventDataConnect.
+ * @dst: (out)(transfer none): The destination of connection event.
  *
- * Get the source of connection event.
- *
- * Returns: (transfer none): The source of connection event.
+ * Get the destination of connection event.
  */
-const ALSASeqAddr *alsaseq_event_data_connect_get_dst(ALSASeqEventDataConnect *self)
+void alsaseq_event_data_connect_get_dst(ALSASeqEventDataConnect *self,
+                                        const ALSASeqAddr **dst)
 {
-    return &self->dest;
+    *dst = &self->dest;
 }
 
 /**

--- a/src/seq/event-data-connect.h
+++ b/src/seq/event-data-connect.h
@@ -17,11 +17,13 @@ typedef struct snd_seq_connect ALSASeqEventDataConnect;
 
 GType alsaseq_event_data_connect_get_type() G_GNUC_CONST;
 
-const ALSASeqAddr *alsaseq_event_data_connect_get_src(ALSASeqEventDataConnect *self);
+void alsaseq_event_data_connect_get_src(ALSASeqEventDataConnect *self,
+                                        const ALSASeqAddr **src);
 void alsaseq_event_data_connect_set_src(ALSASeqEventDataConnect *self,
                                         const ALSASeqAddr *src);
 
-const ALSASeqAddr *alsaseq_event_data_connect_get_dst(ALSASeqEventDataConnect *self);
+void alsaseq_event_data_connect_get_dst(ALSASeqEventDataConnect *self,
+                                        const ALSASeqAddr **dst);
 void alsaseq_event_data_connect_set_dst(ALSASeqEventDataConnect *self,
                                         const ALSASeqAddr *dst);
 

--- a/src/seq/event-data-ctl.c
+++ b/src/seq/event-data-ctl.c
@@ -11,14 +11,14 @@ G_DEFINE_BOXED_TYPE(ALSASeqEventDataCtl, alsaseq_event_data_ctl, seq_event_data_
 /**
  * alsaseq_event_data_ctl_get_channel:
  * @self: A #ALSASeqEventDataCtl.
+ * @channel: (out): The value of channel for the control event.
  *
  * Get the value of channel for the control event.
- *
- * Returns: the value of channel for the control event.
  */
-guint8 alsaseq_event_data_ctl_get_channel(ALSASeqEventDataCtl *self)
+void alsaseq_event_data_ctl_get_channel(ALSASeqEventDataCtl *self,
+                                        guint8 *channel)
 {
-    return self->channel;
+    *channel = self->channel;
 }
 
 /**
@@ -37,14 +37,13 @@ void alsaseq_event_data_ctl_set_channel(ALSASeqEventDataCtl *self,
 /**
  * alsaseq_event_data_ctl_get_param:
  * @self: A #ALSASeqEventDataCtl.
+ * @param: (out): The parameter for the control event.
  *
  * Get the parameter for the control event.
- *
- * Returns: the parameter for the control event.
  */
-guint alsaseq_event_data_ctl_get_param(ALSASeqEventDataCtl *self)
+void alsaseq_event_data_ctl_get_param(ALSASeqEventDataCtl *self, guint *param)
 {
-    return self->param;
+    *param = self->param;
 }
 
 /**
@@ -62,14 +61,13 @@ void alsaseq_event_data_ctl_set_param(ALSASeqEventDataCtl *self, guint param)
 /**
  * alsaseq_event_data_ctl_get_value:
  * @self: A #ALSASeqEventDataCtl.
+ * @value: (out): The value for the control event.
  *
  * Get the value for the control event.
- *
- * Returns: the value for the control event.
  */
-gint alsaseq_event_data_ctl_get_value(ALSASeqEventDataCtl *self)
+void alsaseq_event_data_ctl_get_value(ALSASeqEventDataCtl *self, gint *value)
 {
-    return self->param;
+    *value = self->param;
 }
 
 /**

--- a/src/seq/event-data-ctl.h
+++ b/src/seq/event-data-ctl.h
@@ -17,14 +17,15 @@ typedef struct snd_seq_ev_ctrl ALSASeqEventDataCtl;
 
 GType alsaseq_event_data_ctl_get_type() G_GNUC_CONST;
 
-guint8 alsaseq_event_data_ctl_get_channel(ALSASeqEventDataCtl *self);
+void alsaseq_event_data_ctl_get_channel(ALSASeqEventDataCtl *self,
+                                        guint8 *channel);
 void alsaseq_event_data_ctl_set_channel(ALSASeqEventDataCtl *self,
                                         guint8 channel);
 
-guint alsaseq_event_data_ctl_get_param(ALSASeqEventDataCtl *self);
+void alsaseq_event_data_ctl_get_param(ALSASeqEventDataCtl *self, guint *param);
 void alsaseq_event_data_ctl_set_param(ALSASeqEventDataCtl *self, guint param);
 
-gint alsaseq_event_data_ctl_get_value(ALSASeqEventDataCtl *self);
+void alsaseq_event_data_ctl_get_value(ALSASeqEventDataCtl *self, gint *value);
 void alsaseq_event_data_ctl_set_value(ALSASeqEventDataCtl *self, gint value);
 
 G_END_DECLS

--- a/src/seq/event-data-note.c
+++ b/src/seq/event-data-note.c
@@ -11,14 +11,14 @@ G_DEFINE_BOXED_TYPE(ALSASeqEventDataNote, alsaseq_event_data_note, seq_event_dat
 /**
  * alsaseq_event_data_note_get_channel:
  * @self: A #ALSASeqEventDataNote.
+ * @channel: (out): The value of channel in the note event.
  *
  * Get the value of channel in the note event.
- *
- * Returns: the value of channel in the note event.
  */
-guint8 alsaseq_event_data_note_get_channel(ALSASeqEventDataNote *self)
+void alsaseq_event_data_note_get_channel(ALSASeqEventDataNote *self,
+                                         guint8 *channel)
 {
-    return self->channel;
+    *channel = self->channel;
 }
 
 /**
@@ -37,14 +37,13 @@ void alsaseq_event_data_note_set_channel(ALSASeqEventDataNote *self,
 /**
  * alsaseq_event_data_note_get_note:
  * @self: A #ALSASeqEventDataNote.
+ * @note: (out): The value of note in the note event.
  *
  * Get the value of note in the note event.
- *
- * Returns: the value of note in the note event.
  */
-guint8 alsaseq_event_data_note_get_note(ALSASeqEventDataNote *self)
+void alsaseq_event_data_note_get_note(ALSASeqEventDataNote *self, guint8 *note)
 {
-    return self->note;
+    *note = self->note;
 }
 
 /**
@@ -62,14 +61,14 @@ void alsaseq_event_data_note_set_note(ALSASeqEventDataNote *self, guint8 note)
 /**
  * alsaseq_event_data_note_get_velocity:
  * @self: A #ALSASeqEventDataNote.
+ * @velocity: (out): The value of velocity in the note event.
  *
  * Get the value of velocity in the note event.
- *
- * Returns: the value of velocity in the note event.
  */
-guint8 alsaseq_event_data_note_get_velocity(ALSASeqEventDataNote *self)
+void alsaseq_event_data_note_get_velocity(ALSASeqEventDataNote *self,
+                                          guint8 *velocity)
 {
-    return self->velocity;
+    *velocity = self->velocity;
 }
 
 /**
@@ -88,14 +87,14 @@ void alsaseq_event_data_note_set_velocity(ALSASeqEventDataNote *self,
 /**
  * alsaseq_event_data_note_get_off_velocity:
  * @self: A #ALSASeqEventDataNote.
+ * @off_velocity: (out): The value of off-velocity in the note event.
  *
  * Get the value of off-velocity in the note event.
- *
- * Returns: the value of off-velocity in the note event.
  */
-guint8 alsaseq_event_data_note_get_off_velocity(ALSASeqEventDataNote *self)
+void alsaseq_event_data_note_get_off_velocity(ALSASeqEventDataNote *self,
+                                              guint8 *off_velocity)
 {
-    return self->off_velocity;
+    *off_velocity = self->off_velocity;
 }
 
 /**
@@ -114,14 +113,14 @@ void alsaseq_event_data_note_set_off_velocity(ALSASeqEventDataNote *self,
 /**
  * alsaseq_event_data_note_get_duration:
  * @self: A #ALSASeqEventDataNote.
+ * @duration: (out): The value of duratino in the note event.
  *
  * Get the value of duration in the note event.
- *
- * Returns: the value of duratino in the note event.
  */
-guint8 alsaseq_event_data_note_get_duration(ALSASeqEventDataNote *self)
+void alsaseq_event_data_note_get_duration(ALSASeqEventDataNote *self,
+                                          guint8 *duration)
 {
-    return self->duration;
+    *duration = self->duration;
 }
 
 /**

--- a/src/seq/event-data-note.h
+++ b/src/seq/event-data-note.h
@@ -15,22 +15,26 @@ typedef struct snd_seq_ev_note ALSASeqEventDataNote;
 
 GType alsaseq_event_data_note_get_type() G_GNUC_CONST;
 
-guint8 alsaseq_event_data_note_get_channel(ALSASeqEventDataNote *self);
+void alsaseq_event_data_note_get_channel(ALSASeqEventDataNote *self,
+                                         guint8 *channel);
 void alsaseq_event_data_note_set_channel(ALSASeqEventDataNote *self,
                                          guint8 channel);
 
-guint8 alsaseq_event_data_note_get_note(ALSASeqEventDataNote *self);
+void alsaseq_event_data_note_get_note(ALSASeqEventDataNote *self, guint8 *note);
 void alsaseq_event_data_note_set_note(ALSASeqEventDataNote *self, guint8 note);
 
-guint8 alsaseq_event_data_note_get_velocity(ALSASeqEventDataNote *self);
+void alsaseq_event_data_note_get_velocity(ALSASeqEventDataNote *self,
+                                          guint8 *velocity);
 void alsaseq_event_data_note_set_velocity(ALSASeqEventDataNote *self,
                                           guint8 velocity);
 
-guint8 alsaseq_event_data_note_get_off_velocity(ALSASeqEventDataNote *self);
+void alsaseq_event_data_note_get_off_velocity(ALSASeqEventDataNote *self,
+                                              guint8 *off_velocity);
 void alsaseq_event_data_note_set_off_velocity(ALSASeqEventDataNote *self,
                                               guint8 off_velocity);
 
-guint8 alsaseq_event_data_note_get_duration(ALSASeqEventDataNote *self);
+void alsaseq_event_data_note_get_duration(ALSASeqEventDataNote *self,
+                                          guint8 *duration);
 void alsaseq_event_data_note_set_duration(ALSASeqEventDataNote *self,
                                           guint8 duration);
 

--- a/src/seq/event-data-queue.c
+++ b/src/seq/event-data-queue.c
@@ -11,14 +11,14 @@ G_DEFINE_BOXED_TYPE(ALSASeqEventDataQueue, alsaseq_event_data_queue, seq_event_d
 /**
  * alsaseq_event_data_queue_get_queue_id:
  * @self: A #ALSASeqEventDataQueue.
+ * @queue_id: (out): the numerical ID of queue for the event.
  *
  * Get the numerical ID of queue for the event.
- *
- * Returns: the numerical ID of queue for the event.
  */
-guint8 alsaseq_event_data_queue_get_queue_id(ALSASeqEventDataQueue *self)
+void alsaseq_event_data_queue_get_queue_id(ALSASeqEventDataQueue *self,
+                                           guint8 *queue_id)
 {
-    return self->queue;
+    *queue_id = self->queue;
 }
 
 /**
@@ -37,14 +37,14 @@ void alsaseq_event_data_queue_set_queue_id(ALSASeqEventDataQueue *self,
 /**
  * alsaseq_event_data_queue_get_value_param:
  * @self: A #ALSASeqEventDataQueue.
+ * @value: (out): The value as param of the queue event.
  *
  * Get the value as param of the queue event.
- *
- * Returns: the value as param of the queue event.
  */
-gint alsaseq_event_data_queue_get_value_param(ALSASeqEventDataQueue *self)
+void alsaseq_event_data_queue_get_value_param(ALSASeqEventDataQueue *self,
+                                              gint *value)
 {
-    return self->param.value;
+    *value = self->param.value;
 }
 
 /**
@@ -63,14 +63,14 @@ void alsaseq_event_data_queue_set_value_param(ALSASeqEventDataQueue *self,
 /**
  * alsaseq_event_data_queue_get_tstamp_param:
  * @self: A #ALSASeqEventDataQueue.
+ * @tstamp: (out)(transfer none): The timestamp as param of the queue event.
  *
  * Get the timestamp as param of the queue event.
- *
- * Returns: (transfer none): the timestamp as param of the queue event.
  */
-const ALSASeqTstamp *alsaseq_event_data_queue_get_tstamp_param(ALSASeqEventDataQueue *self)
+void alsaseq_event_data_queue_get_tstamp_param(ALSASeqEventDataQueue *self,
+                                               const ALSASeqTstamp **tstamp)
 {
-    return &self->param.time;
+    *tstamp = &self->param.time;
 }
 
 /**
@@ -89,14 +89,14 @@ void alsaseq_event_data_queue_set_tstamp_param(ALSASeqEventDataQueue *self,
 /**
  * alsaseq_event_data_queue_get_position_param:
  * @self: A #ALSASeqEventDataQueue.
+ * @position: (out): The position as param of the queue event.
  *
  * Get the position as param of the queue event.
- *
- * Returns: the position as param of the queue event.
  */
-guint alsaseq_event_data_queue_get_position_param(ALSASeqEventDataQueue *self)
+void alsaseq_event_data_queue_get_position_param(ALSASeqEventDataQueue *self,
+                                                 guint *position)
 {
-    return self->param.position;
+    *position = self->param.position;
 }
 
 /**
@@ -115,15 +115,17 @@ void alsaseq_event_data_queue_set_position_param(ALSASeqEventDataQueue *self,
 /**
  * alsaseq_event_data_queue_get_skew_param:
  * @self: A #ALSASeqEventDataQueue.
+ * @skew: (array fixed-size=2)(out)(transfer none): The skew as param of the
+ *        queue event. The first element is for 'value' and another is for 'base'.
  *
  * Get the skew as param of the queue event.
- *
- * Returns: (transfer none)(array fixed-size=2): the skew as param of the queue
- *          event. The first element is for 'value' and another is for 'base'.
  */
-const guint *alsaseq_event_data_queue_get_skew_param(ALSASeqEventDataQueue *self)
+void alsaseq_event_data_queue_get_skew_param(ALSASeqEventDataQueue *self,
+                                             const guint **skew)
 {
-    return (const guint *)&self->param.skew;
+    // MEMO: I wish 32-bit storage size is aligned to 32 bit offset in all of
+    // supported ABIs.
+    *skew = (const guint *)&self->param.skew;
 }
 
 /**
@@ -144,21 +146,21 @@ void alsaseq_event_data_queue_set_skew_param(ALSASeqEventDataQueue *self,
 /**
  * alsaseq_event_data_queue_get_quadlet_param:
  * @self: A #ALSASeqEventDataQueue.
+ * @quadlets: (array fixed-size=2)(out)(transfer none): Two quadlets as param of
+ *            the queue event.
  *
  * Get two quadlets as param of the queue event.
- *
- * Returns: (transfer none)(array fixed-size=2): two quadlets as param of the
- *          queue event.
  */
-const guint32 *alsaseq_event_data_queue_get_quadlet_param(ALSASeqEventDataQueue *self)
+void alsaseq_event_data_queue_get_quadlet_param(ALSASeqEventDataQueue *self,
+                                                const guint32 **quadlets)
 {
-    return self->param.d32;
+    *quadlets = self->param.d32;
 }
 
 /**
  * alsaseq_event_data_queue_set_quadlets_param:
  * @self: A #ALSASeqEventDataQueue.
- * @quadlets: (array fixed-size=2)(transfer none): two quadlets as param of the
+ * @quadlets: (array fixed-size=2)(transfer none): Two quadlets as param of the
  *            queue event.
  *
  * Set two quadlets as param of the queue event.
@@ -172,15 +174,15 @@ void alsaseq_event_data_queue_set_quadlet_param(ALSASeqEventDataQueue *self,
 /**
  * alsaseq_event_data_queue_get_byte_param:
  * @self: A #ALSASeqEventDataQueue.
+ * @bytes: (array fixed-size=8)(out)(transfer none): Eight bytes as param of the
+ *          queue event.
  *
  * Get eight bytes as param of the queue event.
- *
- * Returns: (transfer none)(array fixed-size=8): eight bytes as param of the
- *          queue event.
  */
-const guint8 *alsaseq_event_data_queue_get_byte_param(ALSASeqEventDataQueue *self)
+void alsaseq_event_data_queue_get_byte_param(ALSASeqEventDataQueue *self,
+                                             const guint8 **bytes)
 {
-    return self->param.d8;
+    *bytes = self->param.d8;
 }
 
 /**

--- a/src/seq/event-data-queue.c
+++ b/src/seq/event-data-queue.c
@@ -192,7 +192,7 @@ const guint8 *alsaseq_event_data_queue_get_byte_param(ALSASeqEventDataQueue *sel
  * Set eight quadlets as param of the queue event.
  */
 void alsaseq_event_data_queue_set_byte_param(ALSASeqEventDataQueue *self,
-                                             const guint32 bytes[8])
+                                             const guint8 bytes[8])
 {
     memcpy(self->param.d8, bytes, sizeof(self->param.d8));
 }

--- a/src/seq/event-data-queue.h
+++ b/src/seq/event-data-queue.h
@@ -43,7 +43,7 @@ void alsaseq_event_data_queue_set_quadlet_param(ALSASeqEventDataQueue *self,
 
 const guint8 *alsaseq_event_data_queue_get_byte_param(ALSASeqEventDataQueue *self);
 void alsaseq_event_data_queue_set_byte_param(ALSASeqEventDataQueue *self,
-                                             const guint32 bytes[8]);
+                                             const guint8 bytes[8]);
 
 G_END_DECLS
 

--- a/src/seq/event-data-queue.h
+++ b/src/seq/event-data-queue.h
@@ -17,31 +17,38 @@ typedef struct snd_seq_ev_queue_control ALSASeqEventDataQueue;
 
 GType alsaseq_event_data_queue_get_type() G_GNUC_CONST;
 
-guint8 alsaseq_event_data_queue_get_queue_id(ALSASeqEventDataQueue *self);
+void alsaseq_event_data_queue_get_queue_id(ALSASeqEventDataQueue *self,
+                                           guint8 *queue_id);
 void alsaseq_event_data_queue_set_queue_id(ALSASeqEventDataQueue *self,
                                            guint8 queue_id);
 
-gint alsaseq_event_data_queue_get_value_param(ALSASeqEventDataQueue *self);
+void alsaseq_event_data_queue_get_value_param(ALSASeqEventDataQueue *self,
+                                              gint *value);
 void alsaseq_event_data_queue_set_value_param(ALSASeqEventDataQueue *self,
                                               gint value);
 
-const ALSASeqTstamp *alsaseq_event_data_queue_get_tstamp_param(ALSASeqEventDataQueue *self);
+void alsaseq_event_data_queue_get_tstamp_param(ALSASeqEventDataQueue *self,
+                                               const ALSASeqTstamp **tstamp);
 void alsaseq_event_data_queue_set_tstamp_param(ALSASeqEventDataQueue *self,
                                                const ALSASeqTstamp *tstamp);
 
-guint alsaseq_event_data_queue_get_position_param(ALSASeqEventDataQueue *self);
+void alsaseq_event_data_queue_get_position_param(ALSASeqEventDataQueue *self,
+                                                 guint *position);
 void alsaseq_event_data_queue_set_position_param(ALSASeqEventDataQueue *self,
                                                  guint position);
 
-const guint *alsaseq_event_data_queue_get_skew_param(ALSASeqEventDataQueue *self);
+void alsaseq_event_data_queue_get_skew_param(ALSASeqEventDataQueue *self,
+                                             const guint **skew);
 void alsaseq_event_data_queue_set_skew_param(ALSASeqEventDataQueue *self,
                                              const guint skew[2]);
 
-const guint32 *alsaseq_event_data_queue_get_quadlet_param(ALSASeqEventDataQueue *self);
+void alsaseq_event_data_queue_get_quadlet_param(ALSASeqEventDataQueue *self,
+                                                const guint32 **quadlets);
 void alsaseq_event_data_queue_set_quadlet_param(ALSASeqEventDataQueue *self,
                                                 const guint32 quadlets[2]);
 
-const guint8 *alsaseq_event_data_queue_get_byte_param(ALSASeqEventDataQueue *self);
+void alsaseq_event_data_queue_get_byte_param(ALSASeqEventDataQueue *self,
+                                             const guint8 **bytes);
 void alsaseq_event_data_queue_set_byte_param(ALSASeqEventDataQueue *self,
                                              const guint8 bytes[8]);
 

--- a/src/seq/event-data-result.c
+++ b/src/seq/event-data-result.c
@@ -11,14 +11,14 @@ G_DEFINE_BOXED_TYPE(ALSASeqEventDataResult, alsaseq_event_data_result, seq_event
 /**
  * alsaseq_event_data_result_get_event:
  * @self: A #ALSASeqEventDataResult.
+ * @event_type: (out): The type of event in which the data results.
  *
  * Get the type of event in which the data results.
- *
- * Returns: The type of event in which the data results.
  */
-ALSASeqEventType alsaseq_event_data_result_get_event(ALSASeqEventDataResult *self)
+void alsaseq_event_data_result_get_event(ALSASeqEventDataResult *self,
+                                         ALSASeqEventType *event_type)
 {
-    return (ALSASeqEventType)self->event;
+    *event_type = (ALSASeqEventType)self->event;
 }
 
 /**
@@ -37,14 +37,14 @@ void alsaseq_event_data_result_set_event(ALSASeqEventDataResult *self,
 /**
  * alsaseq_event_data_result_get_result:
  * @self: A #ALSASeqEventDataResult.
+ * @result: (out): the status of the event.
  *
  * Get the status of event.
- *
- * Returns: the status of the event.
  */
-gint alsaseq_event_data_result_get_result(ALSASeqEventDataResult *self)
+void alsaseq_event_data_result_get_result(ALSASeqEventDataResult *self,
+                                          gint *result)
 {
-    return self->result;
+    *result = self->result;
 }
 
 /**

--- a/src/seq/event-data-result.h
+++ b/src/seq/event-data-result.h
@@ -17,13 +17,13 @@ typedef struct snd_seq_result ALSASeqEventDataResult;
 
 GType alsaseq_event_data_result_get_type() G_GNUC_CONST;
 
-ALSASeqEventType alsaseq_event_data_result_get_event(ALSASeqEventDataResult *self);
-
+void alsaseq_event_data_result_get_event(ALSASeqEventDataResult *self,
+                                         ALSASeqEventType *event_type);
 void alsaseq_event_data_result_set_event(ALSASeqEventDataResult *self,
                                          ALSASeqEventType event_type);
 
-gint alsaseq_event_data_result_get_result(ALSASeqEventDataResult *self);
-
+void alsaseq_event_data_result_get_result(ALSASeqEventDataResult *self,
+                                          gint *result);
 void alsaseq_event_data_result_set_result(ALSASeqEventDataResult *self,
                                           gint result);
 

--- a/src/seq/event-fixed.c
+++ b/src/seq/event-fixed.c
@@ -237,12 +237,12 @@ const guint8 *alsaseq_event_fixed_get_byte_data(ALSASeqEventFixed *self)
 /**
  * alsaseq_event_fixed_set_byte_data:
  * @self: A #ALSASeqEventFixed.
- * @data: (array fixed-size=12)(transfer none): The 12 byte data for the event.
+ * @bytes: (array fixed-size=12)(transfer none): The 12 byte data for the event.
  *
  * Copy the 12 byte data for the event.
  */
 void alsaseq_event_fixed_set_byte_data(ALSASeqEventFixed *self,
-                                       const guint8 data[12])
+                                       const guint8 bytes[12])
 {
     ALSASeqEvent *parent;
     struct snd_seq_event *ev;
@@ -251,7 +251,7 @@ void alsaseq_event_fixed_set_byte_data(ALSASeqEventFixed *self,
     parent = ALSASEQ_EVENT(self);
     seq_event_refer_private(parent, &ev);
 
-    memcpy(ev->data.raw8.d, data, sizeof(ev->data.raw8.d));
+    memcpy(ev->data.raw8.d, bytes, sizeof(ev->data.raw8.d));
 }
 
 /**
@@ -278,12 +278,13 @@ const guint32 *alsaseq_event_fixed_get_quadlet_data(ALSASeqEventFixed *self)
 /**
  * alsaseq_event_fixed_set_quadlet_data:
  * @self: A #ALSASeqEventFixed.
- * @data: (array fixed-size=3)(transfer none): The 3 quadlet data for the event.
+ * @quadlets: (array fixed-size=3)(transfer none): The 3 quadlet data for the
+ *            event.
  *
  * Copy the 3 quadlet data for the event.
  */
 void alsaseq_event_fixed_set_quadlet_data(ALSASeqEventFixed *self,
-                                          const guint32 data[3])
+                                          const guint32 quadlets[3])
 {
     ALSASeqEvent *parent;
     struct snd_seq_event *ev;
@@ -292,5 +293,5 @@ void alsaseq_event_fixed_set_quadlet_data(ALSASeqEventFixed *self,
     parent = ALSASEQ_EVENT(self);
     seq_event_refer_private(parent, &ev);
 
-    memcpy(ev->data.raw32.d, data, sizeof(ev->data.raw32.d));
+    memcpy(ev->data.raw32.d, quadlets, sizeof(ev->data.raw32.d));
 }

--- a/src/seq/event-fixed.c
+++ b/src/seq/event-fixed.c
@@ -216,22 +216,22 @@ ALSASeqEventFixed *alsaseq_event_fixed_new(ALSASeqEventType event_type,
 /**
  * alsaseq_event_fixed_get_byte_data:
  * @self: A #ALSASeqEventFixed.
+ * @bytes: (array fixed-size=12)(out)(transfer none): The 12 byte data for the
+ *         event. The lifetime of the object is the same as the event itself.
  *
  * Refer to the 12 byte data for the event.
- *
- * Returns: (array fixed-size=12)(transfer none): The 12 byte data for the
- *          event. The lifetime of the object is the same as the event itself.
  */
-const guint8 *alsaseq_event_fixed_get_byte_data(ALSASeqEventFixed *self)
+void alsaseq_event_fixed_get_byte_data(ALSASeqEventFixed *self,
+                                       const guint8 **bytes)
 {
     ALSASeqEvent *parent;
     struct snd_seq_event *ev;
 
-    g_return_val_if_fail(ALSASEQ_IS_EVENT_FIXED(self), NULL);
+    g_return_if_fail(ALSASEQ_IS_EVENT_FIXED(self));
     parent = ALSASEQ_EVENT(self);
     seq_event_refer_private(parent, &ev);
 
-    return ev->data.raw8.d;
+    *bytes = ev->data.raw8.d;
 }
 
 /**
@@ -257,22 +257,23 @@ void alsaseq_event_fixed_set_byte_data(ALSASeqEventFixed *self,
 /**
  * alsaseq_event_fixed_get_quadlet_data:
  * @self: A #ALSASeqEventFixed.
+ * @quadlets: (array fixed-size=3)(out)(transfer none): The 3 quadlet data for
+ *            the event. The lifetime of the object is the same as the event
+ *            itself.
  *
  * Get the 3 quadlet data for the event.
- *
- * Returns: (array fixed-size=3)(transfer none): The 3 quadlet data for the
- *          event. The lifetime of the object is the same as the event itself.
  */
-const guint32 *alsaseq_event_fixed_get_quadlet_data(ALSASeqEventFixed *self)
+void alsaseq_event_fixed_get_quadlet_data(ALSASeqEventFixed *self,
+                                          const guint32 **quadlets)
 {
     ALSASeqEvent *parent;
     struct snd_seq_event *ev;
 
-    g_return_val_if_fail(ALSASEQ_IS_EVENT_FIXED(self), NULL);
+    g_return_if_fail(ALSASEQ_IS_EVENT_FIXED(self));
     parent = ALSASEQ_EVENT(self);
     seq_event_refer_private(parent, &ev);
 
-    return ev->data.raw32.d;
+    *quadlets = ev->data.raw32.d;
 }
 
 /**

--- a/src/seq/event-fixed.h
+++ b/src/seq/event-fixed.h
@@ -54,11 +54,11 @@ ALSASeqEventFixed *alsaseq_event_fixed_new(ALSASeqEventType event_type,
 
 const guint8 *alsaseq_event_fixed_get_byte_data(ALSASeqEventFixed *self);
 void alsaseq_event_fixed_set_byte_data(ALSASeqEventFixed *self,
-                                       const guint8 data[12]);
+                                       const guint8 bytes[12]);
 
 const guint32 *alsaseq_event_fixed_get_quadlet_data(ALSASeqEventFixed *self);
 void alsaseq_event_fixed_set_quadlet_data(ALSASeqEventFixed *self,
-                                          const guint32 data[3]);
+                                          const guint32 quadlets[3]);
 
 G_END_DECLS
 

--- a/src/seq/event-fixed.h
+++ b/src/seq/event-fixed.h
@@ -52,11 +52,13 @@ GType alsaseq_event_fixed_get_type() G_GNUC_CONST;
 ALSASeqEventFixed *alsaseq_event_fixed_new(ALSASeqEventType event_type,
                                            GError **error);
 
-const guint8 *alsaseq_event_fixed_get_byte_data(ALSASeqEventFixed *self);
+void alsaseq_event_fixed_get_byte_data(ALSASeqEventFixed *self,
+                                       const guint8 **bytes);
 void alsaseq_event_fixed_set_byte_data(ALSASeqEventFixed *self,
                                        const guint8 bytes[12]);
 
-const guint32 *alsaseq_event_fixed_get_quadlet_data(ALSASeqEventFixed *self);
+void alsaseq_event_fixed_get_quadlet_data(ALSASeqEventFixed *self,
+                                          const guint32 **quadlets);
 void alsaseq_event_fixed_set_quadlet_data(ALSASeqEventFixed *self,
                                           const guint32 quadlets[3]);
 

--- a/src/seq/tstamp.c
+++ b/src/seq/tstamp.c
@@ -35,17 +35,16 @@ void alsaseq_tstamp_set_tick_time(ALSASeqTstamp *self, const guint32 tick_time)
 /**
  * alsaseq_tstamp_get_real_time:
  * @self: A #ALSASeqTstamp.
+ * @tstamp: (array fixed-size=2)(out)(transfer none): The array with two
+ *          elements for sec part and nsec part of real time.
  *
  * Refer to the time as wall-clock time.
- *
- * Returns: (array fixed-size=2)(transfer none): The array with two elements
- *          for sec part and nsec part of real time.
  */
-const guint32 *alsaseq_tstamp_get_real_time(ALSASeqTstamp *self)
+void alsaseq_tstamp_get_real_time(ALSASeqTstamp *self, const guint32 **tstamp)
 {
     // MEMO: I wish 32-bit storage size is aligned to 32 bit offset in all of
     // supported ABIs.
-    return (guint32 *)&self->time;
+    *tstamp = (guint32 *)&self->time;
 }
 
 

--- a/src/seq/tstamp.h
+++ b/src/seq/tstamp.h
@@ -18,7 +18,7 @@ GType alsaseq_tstamp_get_type() G_GNUC_CONST;
 void alsaseq_tstamp_get_tick_time(ALSASeqTstamp *self, guint32 *tick_time);
 void alsaseq_tstamp_set_tick_time(ALSASeqTstamp *self, const guint32 tick_time);
 
-const guint32 *alsaseq_tstamp_get_real_time(ALSASeqTstamp *self);
+void alsaseq_tstamp_get_real_time(ALSASeqTstamp *self, const guint32 **tstamp);
 void alsaseq_tstamp_set_real_time(ALSASeqTstamp *self, const guint32 tstamp[2]);
 
 G_END_DECLS


### PR DESCRIPTION
The alsa-gobject project has a loose convention to have functions returning nothing. This pull
request refine according to it as well as fixes for some bugs.
