### PR TITLE
alsa-gobject: fix annotations for constructors

### DIFF
--- a/src/ctl/elem-id.c
+++ b/src/ctl/elem-id.c
@@ -14,7 +14,7 @@ G_DEFINE_BOXED_TYPE(ALSACtlElemId, alsactl_elem_id, ctl_elem_id_copy, g_free);
  *
  * Allocates and return an instance of ALSACtlElemId by the numerical ID.
  *
- * Returns: (transfer full): A #ALSACtlElemId.
+ * Returns: A #ALSACtlElemId.
  */
 ALSACtlElemId *alsactl_elem_id_new_by_numid(guint numid)
 {

--- a/src/ctl/elem-info-bool.c
+++ b/src/ctl/elem-info-bool.c
@@ -75,7 +75,7 @@ static void alsactl_elem_info_bool_init(ALSACtlElemInfoBool *self)
  *
  * Allocate and return an instance of ALSACtlElemInfoBool.
  *
- * Returns: (transfer full): A #ALSACtlElemInfoBool.
+ * Returns: A #ALSACtlElemInfoBool.
  */
 ALSACtlElemInfoBool *alsactl_elem_info_bool_new()
 {

--- a/src/ctl/elem-info-bytes.c
+++ b/src/ctl/elem-info-bytes.c
@@ -75,7 +75,7 @@ static void alsactl_elem_info_bytes_init(ALSACtlElemInfoBytes *self)
  *
  * Allocate and return an instance of ALSACtlElemInfoBytes.
  *
- * Returns: (transfer full): A #ALSACtlElemInfoBytes.
+ * Returns: A #ALSACtlElemInfoBytes.
  */
 ALSACtlElemInfoBytes *alsactl_elem_info_bytes_new()
 {

--- a/src/ctl/elem-info-enum.c
+++ b/src/ctl/elem-info-enum.c
@@ -110,7 +110,7 @@ static void alsactl_elem_info_enum_init(ALSACtlElemInfoEnum *self)
  *
  * Allocate and return an instance of ALSACtlElemInfoEnum.
  *
- * Returns: (transfer full): A #ALSACtlElemInfoEnum.
+ * Returns: A #ALSACtlElemInfoEnum.
  */
 ALSACtlElemInfoEnum *alsactl_elem_info_enum_new()
 {

--- a/src/ctl/elem-info-iec60958.c
+++ b/src/ctl/elem-info-iec60958.c
@@ -18,7 +18,7 @@ static void alsactl_elem_info_iec60958_init(ALSACtlElemInfoIec60958 *self)
  *
  * Allocate and return an instance of ALSACtlElemInfoIec60958.
  *
- * Returns: (transfer full): A #ALSACtlElemInfoIec60958.
+ * Returns: A #ALSACtlElemInfoIec60958.
  */
 ALSACtlElemInfoIec60958 *alsactl_elem_info_iec60958_new()
 {

--- a/src/ctl/elem-info-int.c
+++ b/src/ctl/elem-info-int.c
@@ -112,7 +112,7 @@ static void alsactl_elem_info_int_init(ALSACtlElemInfoInt *self)
 }
 
 /**
- * alsactl_elem_info_int:
+ * alsactl_elem_info_int_new:
  *
  * Allocate and return an instance of ALSACtlElemInfoInt.
  *

--- a/src/ctl/elem-info-int.c
+++ b/src/ctl/elem-info-int.c
@@ -116,7 +116,7 @@ static void alsactl_elem_info_int_init(ALSACtlElemInfoInt *self)
  *
  * Allocate and return an instance of ALSACtlElemInfoInt.
  *
- * Returns: (transfer full): A #ALSACtlElemInfoInt.
+ * Returns: A #ALSACtlElemInfoInt.
  */
 ALSACtlElemInfoInt *alsactl_elem_info_int_new()
 {

--- a/src/seq/addr.c
+++ b/src/seq/addr.c
@@ -15,7 +15,7 @@ G_DEFINE_BOXED_TYPE(ALSASeqAddr, alsaseq_addr, seq_addr_copy, g_free)
  *
  * Allocate and return an instance of ALSASeqAddr.
  *
- * Returns: (transfer full): A #ALSASeqAddr.
+ * Returns: A #ALSASeqAddr.
  */
 ALSASeqAddr *alsaseq_addr_new(guint8 client_id, guint8 port_id)
 {

--- a/src/seq/event-fixed.c
+++ b/src/seq/event-fixed.c
@@ -189,7 +189,7 @@ static void alsaseq_event_fixed_init(ALSASeqEventFixed *self)
  *
  * Allocate and returns an instance of #ALSASeqEventFixed class.
  *
- * Returns: (transfer full): A #ALSASeqEventFixed.
+ * Returns: A #ALSASeqEventFixed.
  */
 ALSASeqEventFixed *alsaseq_event_fixed_new(ALSASeqEventType event_type,
                                            GError **error)

--- a/src/seq/event-variable.c
+++ b/src/seq/event-variable.c
@@ -43,7 +43,7 @@ static void alsaseq_event_variable_init(ALSASeqEventVariable *self)
  *
  * Allocate and return an instance of #ALSASeqEventVariable class.
  *
- * Returns: (transfer full): A #ALSASeqEventVariable.
+ * Returns: A #ALSASeqEventVariable.
  */
 ALSASeqEventVariable *alsaseq_event_variable_new(ALSASeqEventType event_type,
                                                  GError **error)

--- a/src/seq/subscribe-data.c
+++ b/src/seq/subscribe-data.c
@@ -124,7 +124,7 @@ static void alsaseq_subscribe_data_init(ALSASeqSubscribeData *self)
  *
  * Allocates and returns the instance of ALSASeqSubscribeData class.
  *
- * Returns: (transfer full): A #ALSASeqSubscribeData.
+ * Returns: A #ALSASeqSubscribeData.
  */
 ALSASeqSubscribeData *alsaseq_subscribe_data_new()
 {

--- a/src/timer/device-id.c
+++ b/src/timer/device-id.c
@@ -17,7 +17,7 @@ G_DEFINE_BOXED_TYPE(ALSATimerDeviceId, alsatimer_device_id, timer_device_id_copy
  *
  * Allocate and return an instance of ALSATimerDeviceId.
  *
- * Returns: (transfer full): A #ALSATimerDeviceId.
+ * Returns: A #ALSATimerDeviceId.
  */
 ALSATimerDeviceId *alsatimer_device_id_new(ALSATimerClass class,
                                            gint card_id, gint device_id,


### PR DESCRIPTION
Some constructor functions have redundant or invalid annotations.