### PR TITLE
alsa-gobject: seq: tstamp: use wrapper structure instead of union

### DIFF
--- a/src/seq/event-data-queue.c
+++ b/src/seq/event-data-queue.c
@@ -70,7 +70,9 @@ void alsaseq_event_data_queue_set_value_param(ALSASeqEventDataQueue *self,
 void alsaseq_event_data_queue_get_tstamp_param(ALSASeqEventDataQueue *self,
                                                const ALSASeqTstamp **tstamp)
 {
-    *tstamp = &self->param.time;
+    // MEMO: I wish the structure has no padding in its head in all of supported
+    // ABIs.
+    *tstamp = (const ALSASeqTstamp *)&self->param.time;
 }
 
 /**
@@ -83,7 +85,7 @@ void alsaseq_event_data_queue_get_tstamp_param(ALSASeqEventDataQueue *self,
 void alsaseq_event_data_queue_set_tstamp_param(ALSASeqEventDataQueue *self,
                                                const ALSASeqTstamp *tstamp)
 {
-    self->param.time = *tstamp;
+    self->param.time = tstamp->tstamp;
 }
 
 /**

--- a/src/seq/event-fixed.c
+++ b/src/seq/event-fixed.c
@@ -72,7 +72,7 @@ static void seq_event_fixed_set_property(GObject *obj, guint id,
     {
         ALSASeqTstamp *data = g_value_get_boxed(val);
         if (data != NULL)
-            ev->data.time = *data;
+            ev->data.time = data->tstamp;
         break;
     }
     default:
@@ -108,7 +108,9 @@ static void seq_event_fixed_get_property(GObject *obj, guint id, GValue *val,
         g_value_set_static_boxed(val, &ev->data.connect);
         break;
     case SEQ_EVENT_FIXED_PROP_TSTAMP_DATA:
-        g_value_set_static_boxed(val, &ev->data.time);
+        // MEMO: I wish the structure has no padding in its head in all of
+	// supported ABIs.
+        g_value_set_static_boxed(val, (ALSASeqTstamp *)&ev->data.time);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(obj, id, spec);

--- a/src/seq/event.c
+++ b/src/seq/event.c
@@ -60,7 +60,7 @@ static void seq_event_set_property(GObject *obj, guint id, const GValue *val,
     {
         ALSASeqTstamp *tstamp = g_value_get_boxed(val);
         if (tstamp != NULL)
-            ev->time = *tstamp;
+            ev->time = tstamp->tstamp;
         break;
     }
     case SEQ_EVENT_PROP_SRC_ADDR:
@@ -129,7 +129,9 @@ static void seq_event_get_property(GObject *obj, guint id, GValue *val,
         g_value_set_uchar(val, ev->queue);
         break;
     case SEQ_EVENT_PROP_TSTAMP:
-        g_value_set_static_boxed(val, &ev->time);
+        // MEMO: I wish the structure has no padding in its head in all of
+	// supported ABIs.
+        g_value_set_static_boxed(val, (ALSASeqTstamp *)&ev->time);
         break;
     case SEQ_EVENT_PROP_SRC_ADDR:
         g_value_set_static_boxed(val, &ev->source);

--- a/src/seq/queue-status.c
+++ b/src/seq/queue-status.c
@@ -101,7 +101,7 @@ void alsaseq_queue_status_get_tick_time(ALSASeqQueueStatus *self,
  * Get time as wall-clock time.
  */
 void alsaseq_queue_status_get_real_time(ALSASeqQueueStatus *self,
-                                        const guint32 **real_time)
+                                        const guint32 *real_time[2])
 {
     ALSASeqQueueStatusPrivate *priv;
 

--- a/src/seq/queue-status.h
+++ b/src/seq/queue-status.h
@@ -49,7 +49,7 @@ void alsaseq_queue_status_get_tick_time(ALSASeqQueueStatus *self,
                                         guint *tick_time);
 
 void alsaseq_queue_status_get_real_time(ALSASeqQueueStatus *self,
-                                        const guint32 **real_time);
+                                        const guint32 *real_time[2]);
 
 G_END_DECLS
 

--- a/src/seq/tstamp.c
+++ b/src/seq/tstamp.c
@@ -35,29 +35,29 @@ void alsaseq_tstamp_set_tick_time(ALSASeqTstamp *self, const guint32 tick_time)
 /**
  * alsaseq_tstamp_get_real_time:
  * @self: A #ALSASeqTstamp.
- * @tstamp: (array fixed-size=2)(out)(transfer none): The array with two
- *          elements for sec part and nsec part of real time.
+ * @real_time: (array fixed-size=2)(out)(transfer none): The array with two
+ *             elements for sec part and nsec part of real time.
  *
  * Refer to the time as wall-clock time.
  */
-void alsaseq_tstamp_get_real_time(ALSASeqTstamp *self, const guint32 **tstamp)
+void alsaseq_tstamp_get_real_time(ALSASeqTstamp *self, guint32 *real_time[2])
 {
     // MEMO: I wish 32-bit storage size is aligned to 32 bit offset in all of
     // supported ABIs.
-    *tstamp = (guint32 *)&self->tstamp.time;
+    *real_time = (guint32 *)&self->tstamp.time;
 }
 
 
 /**
  * alsaseq_tstamp_set_real_time:
  * @self: A #ALSASeqTstamp.
- * @tstamp: (array fixed-size=2)(transfer none): The array with two elements for
- *          sec part and nsec part of real time.
+ * @real_time: (array fixed-size=2)(transfer none): The array with two elements
+ *             for sec part and nsec part of real time.
  *
  * Copy the time as wall-clock time.
  */
-void alsaseq_tstamp_set_real_time(ALSASeqTstamp *self, const guint32 tstamp[2])
+void alsaseq_tstamp_set_real_time(ALSASeqTstamp *self, const guint32 real_time[2])
 {
-    self->tstamp.time.tv_sec = tstamp[0];
-    self->tstamp.time.tv_nsec = tstamp[1];
+    self->tstamp.time.tv_sec = real_time[0];
+    self->tstamp.time.tv_nsec = real_time[1];
 }

--- a/src/seq/tstamp.c
+++ b/src/seq/tstamp.c
@@ -17,7 +17,7 @@ G_DEFINE_BOXED_TYPE(ALSASeqTstamp, alsaseq_tstamp, seq_tstamp_copy, g_free)
  */
 void alsaseq_tstamp_get_tick_time(ALSASeqTstamp *self, guint32 *tick_time)
 {
-    *tick_time = self->tick;
+    *tick_time = self->tstamp.tick;
 }
 
 /**
@@ -29,7 +29,7 @@ void alsaseq_tstamp_get_tick_time(ALSASeqTstamp *self, guint32 *tick_time)
  */
 void alsaseq_tstamp_set_tick_time(ALSASeqTstamp *self, const guint32 tick_time)
 {
-    self->tick = tick_time;
+    self->tstamp.tick = tick_time;
 }
 
 /**
@@ -44,7 +44,7 @@ void alsaseq_tstamp_get_real_time(ALSASeqTstamp *self, const guint32 **tstamp)
 {
     // MEMO: I wish 32-bit storage size is aligned to 32 bit offset in all of
     // supported ABIs.
-    *tstamp = (guint32 *)&self->time;
+    *tstamp = (guint32 *)&self->tstamp.time;
 }
 
 
@@ -58,6 +58,6 @@ void alsaseq_tstamp_get_real_time(ALSASeqTstamp *self, const guint32 **tstamp)
  */
 void alsaseq_tstamp_set_real_time(ALSASeqTstamp *self, const guint32 tstamp[2])
 {
-    self->time.tv_sec = tstamp[0];
-    self->time.tv_nsec = tstamp[1];
+    self->tstamp.time.tv_sec = tstamp[0];
+    self->tstamp.time.tv_nsec = tstamp[1];
 }

--- a/src/seq/tstamp.h
+++ b/src/seq/tstamp.h
@@ -14,7 +14,7 @@ G_BEGIN_DECLS
 // The usage of union is inconvenient to some programming languages which has
 // no support to handle it. Let's use wrapper structure.
 typedef struct {
-    union snd_seq_timestamp time;
+    union snd_seq_timestamp tstamp;
 } ALSASeqTstamp;
 
 GType alsaseq_tstamp_get_type() G_GNUC_CONST;
@@ -22,8 +22,8 @@ GType alsaseq_tstamp_get_type() G_GNUC_CONST;
 void alsaseq_tstamp_get_tick_time(ALSASeqTstamp *self, guint32 *tick_time);
 void alsaseq_tstamp_set_tick_time(ALSASeqTstamp *self, const guint32 tick_time);
 
-void alsaseq_tstamp_get_real_time(ALSASeqTstamp *self, const guint32 **tstamp);
-void alsaseq_tstamp_set_real_time(ALSASeqTstamp *self, const guint32 tstamp[2]);
+void alsaseq_tstamp_get_real_time(ALSASeqTstamp *self, guint32 *real_time[2]);
+void alsaseq_tstamp_set_real_time(ALSASeqTstamp *self, const guint32 real_time[2]);
 
 G_END_DECLS
 

--- a/src/seq/tstamp.h
+++ b/src/seq/tstamp.h
@@ -11,7 +11,11 @@ G_BEGIN_DECLS
 
 #define ALSASEQ_TYPE_TSTAMP   (alsaseq_tstamp_get_type())
 
-typedef union snd_seq_timestamp ALSASeqTstamp;
+// The usage of union is inconvenient to some programming languages which has
+// no support to handle it. Let's use wrapper structure.
+typedef struct {
+    union snd_seq_timestamp time;
+} ALSASeqTstamp;
 
 GType alsaseq_tstamp_get_type() G_GNUC_CONST;
 


### PR DESCRIPTION
In UAPI for ALSA Sequencer, snd_seq_timestamp is union with
snd_seq_tick_time_t and struct snd_seq_real_time types. The
libalsaseq has GLib Boxed object for the union, named as
ALSASeqTstamp.

```
$ cat build/src/seq/ALSASeq-0.0.gir
    ...
    <union name="Tstamp"
           c:type="ALSASeqTstamp"
           glib:type-name="ALSASeqTstamp"
           glib:get-type="alsaseq_tstamp_get_type"
           c:symbol-prefix="tstamp">
      <source-position filename="../src/seq/tstamp.h" line="14"/>
      ...
    </union>
    ...
```

Although this is valid in a view of GObject
Introspection, it's not necessarily convenient to language
bindings because some programming language doesn't support
union type. In this case, the type is not available.

This commit adds an alternative structure to wrap the union.
As a result, ALSASeqTstamp is GLib Boxed object for the
wrapper structure.

```
$ cat build/src/seq/ALSASeq-0.0.gir
    ...
    <record name="Tstamp"
            c:type="ALSASeqTstamp"
            glib:type-name="ALSASeqTstamp"
            glib:get-type="alsaseq_tstamp_get_type"
            c:symbol-prefix="tstamp">
      <source-position filename="../src/seq/tstamp.h" line="18"/>
      <field name="tstamp" writable="1">
        <type name="gpointer" c:type="snd_seq_timestamp"/>
      </field>
      ...
    </record>
    ...
```