### PR TITLE
alsa-gobject: seq: some improvements and fixes

### DIFF
--- a/src/seq/addr.c
+++ b/src/seq/addr.c
@@ -50,3 +50,20 @@ void alsaseq_addr_get_port_id(const ALSASeqAddr *self, guint8 *port_id)
 {
     *port_id = self->port;
 }
+
+/**
+ * alsaseq_addr_equal:
+ * @self: A #ALSASeqAddr.
+ * @target: A #ALSASeqAddr to compare.
+ *
+ * Returns: whether the given object indicates the same element.
+ */
+gboolean alsaseq_addr_equal(const ALSASeqAddr *self, const ALSASeqAddr *target)
+{
+    const struct snd_seq_addr *lhs, *rhs;
+
+    lhs = (const struct snd_seq_addr *)self;
+    rhs = (const struct snd_seq_addr *)target;
+
+    return lhs->client == rhs->client && lhs->port == rhs->port;
+}

--- a/src/seq/addr.h
+++ b/src/seq/addr.h
@@ -21,6 +21,8 @@ void alsaseq_addr_get_client_id(const ALSASeqAddr *self, guint8 *client_id);
 
 void alsaseq_addr_get_port_id(const ALSASeqAddr *self, guint8 *port_id);
 
+gboolean alsaseq_addr_equal(const ALSASeqAddr *self, const ALSASeqAddr *target);
+
 G_END_DECLS
 
 #endif

--- a/src/seq/alsaseq.map
+++ b/src/seq/alsaseq.map
@@ -66,6 +66,7 @@ ALSA_GOBJECT_0_0_0 {
     "alsaseq_addr_new";
     "alsaseq_addr_get_client_id";
     "alsaseq_addr_get_port_id";
+    "alsaseq_addr_equal";
 
     "alsaseq_port_info_get_type";
     "alsaseq_port_info_new";

--- a/src/seq/event-data-queue.c
+++ b/src/seq/event-data-queue.c
@@ -117,10 +117,11 @@ void alsaseq_event_data_queue_set_position_param(ALSASeqEventDataQueue *self,
 /**
  * alsaseq_event_data_queue_get_skew_param:
  * @self: A #ALSASeqEventDataQueue.
- * @skew: (array fixed-size=2)(out)(transfer none): The skew as param of the
- *        queue event. The first element is for 'value' and another is for 'base'.
+ * @skew: (array fixed-size=2)(out)(transfer none): The array with two elements
+ *        for numerator and denominator of fraction for skew.
  *
- * Get the skew as param of the queue event.
+ * Refer to numerator and denominator of fraction for skew as the parameter of
+ * queue event.
  */
 void alsaseq_event_data_queue_get_skew_param(ALSASeqEventDataQueue *self,
                                              const guint *skew[2])
@@ -133,10 +134,11 @@ void alsaseq_event_data_queue_get_skew_param(ALSASeqEventDataQueue *self,
 /**
  * alsaseq_event_data_queue_set_skew_param:
  * @self: A #ALSASeqEventDataQueue.
- * @skew: (array fixed-size=2)(transfer none): the skew as param of the queue
- *        event. The first element is for 'value' and another is for 'base'.
+ * @skew: (array fixed-size=2)(transfer none): The array with two elements for
+ *        numerator and denominator of fraction for skew.
  *
- * Set the skew as param of the queue event.
+ * Copy numerator and denominator of fraction for skew from the given buffer as
+ * the parameter of queue event.
  */
 void alsaseq_event_data_queue_set_skew_param(ALSASeqEventDataQueue *self,
                                              const guint skew[2])

--- a/src/seq/event-data-queue.c
+++ b/src/seq/event-data-queue.c
@@ -178,10 +178,10 @@ void alsaseq_event_data_queue_set_quadlet_param(ALSASeqEventDataQueue *self,
 /**
  * alsaseq_event_data_queue_get_byte_param:
  * @self: A #ALSASeqEventDataQueue.
- * @bytes: (array fixed-size=8)(out)(transfer none): Eight bytes as param of the
- *          queue event.
+ * @bytes: (array fixed-size=8)(out)(transfer none): The array with eight
+ *         elements for bytes parameter of the queue event.
  *
- * Get eight bytes as param of the queue event.
+ * Refer to eight bytes as the parameter of queue event.
  */
 void alsaseq_event_data_queue_get_byte_param(ALSASeqEventDataQueue *self,
                                              const guint8 *bytes[8])
@@ -192,10 +192,10 @@ void alsaseq_event_data_queue_get_byte_param(ALSASeqEventDataQueue *self,
 /**
  * alsaseq_event_data_queue_set_byte_param:
  * @self: A #ALSASeqEventDataQueue.
- * @bytes: (array fixed-size=8)(transfer none): eight bytes as param of the
- *        queue event.
+ * @bytes: (array fixed-size=8)(transfer none): The array with eight elements
+ *         for bytes parameter of the queue event.
  *
- * Set eight quadlets as param of the queue event.
+ * Copy eight bytes from the given buffer as the parameter of queue event.
  */
 void alsaseq_event_data_queue_set_byte_param(ALSASeqEventDataQueue *self,
                                              const guint8 bytes[8])

--- a/src/seq/event-data-queue.c
+++ b/src/seq/event-data-queue.c
@@ -182,7 +182,7 @@ void alsaseq_event_data_queue_set_quadlet_param(ALSASeqEventDataQueue *self,
  * Get eight bytes as param of the queue event.
  */
 void alsaseq_event_data_queue_get_byte_param(ALSASeqEventDataQueue *self,
-                                             const guint8 **bytes)
+                                             const guint8 *bytes[8])
 {
     *bytes = self->param.d8;
 }

--- a/src/seq/event-data-queue.c
+++ b/src/seq/event-data-queue.c
@@ -123,7 +123,7 @@ void alsaseq_event_data_queue_set_position_param(ALSASeqEventDataQueue *self,
  * Get the skew as param of the queue event.
  */
 void alsaseq_event_data_queue_get_skew_param(ALSASeqEventDataQueue *self,
-                                             const guint **skew)
+                                             const guint *skew[2])
 {
     // MEMO: I wish 32-bit storage size is aligned to 32 bit offset in all of
     // supported ABIs.

--- a/src/seq/event-data-queue.c
+++ b/src/seq/event-data-queue.c
@@ -160,7 +160,7 @@ void alsaseq_event_data_queue_get_quadlet_param(ALSASeqEventDataQueue *self,
 }
 
 /**
- * alsaseq_event_data_queue_set_quadlets_param:
+ * alsaseq_event_data_queue_set_quadlet_param:
  * @self: A #ALSASeqEventDataQueue.
  * @quadlets: (array fixed-size=2)(transfer none): Two quadlets as param of the
  *            queue event.

--- a/src/seq/event-data-queue.c
+++ b/src/seq/event-data-queue.c
@@ -150,10 +150,10 @@ void alsaseq_event_data_queue_set_skew_param(ALSASeqEventDataQueue *self,
 /**
  * alsaseq_event_data_queue_get_quadlet_param:
  * @self: A #ALSASeqEventDataQueue.
- * @quadlets: (array fixed-size=2)(out)(transfer none): Two quadlets as param of
- *            the queue event.
+ * @quadlets: (array fixed-size=2)(out)(transfer none): The array with two
+ *            elements for quadlets as the parameter of queue event.
  *
- * Get two quadlets as param of the queue event.
+ * Refer to two quadlets as the parameter of queue event.
  */
 void alsaseq_event_data_queue_get_quadlet_param(ALSASeqEventDataQueue *self,
                                                 const guint32 *quadlets[2])
@@ -164,10 +164,10 @@ void alsaseq_event_data_queue_get_quadlet_param(ALSASeqEventDataQueue *self,
 /**
  * alsaseq_event_data_queue_set_quadlet_param:
  * @self: A #ALSASeqEventDataQueue.
- * @quadlets: (array fixed-size=2)(transfer none): Two quadlets as param of the
- *            queue event.
+ * @quadlets: (array fixed-size=2)(transfer none): The array with two elements
+ *            for quadlets as the parameter of queue event.
  *
- * Set two quadlets as param of the queue event.
+ * Set two quadlets from the given buffer as the parameter of queue event.
  */
 void alsaseq_event_data_queue_set_quadlet_param(ALSASeqEventDataQueue *self,
                                                 const guint32 quadlets[2])

--- a/src/seq/event-data-queue.c
+++ b/src/seq/event-data-queue.c
@@ -154,7 +154,7 @@ void alsaseq_event_data_queue_set_skew_param(ALSASeqEventDataQueue *self,
  * Get two quadlets as param of the queue event.
  */
 void alsaseq_event_data_queue_get_quadlet_param(ALSASeqEventDataQueue *self,
-                                                const guint32 **quadlets)
+                                                const guint32 *quadlets[2])
 {
     *quadlets = self->param.d32;
 }

--- a/src/seq/event-data-queue.h
+++ b/src/seq/event-data-queue.h
@@ -43,7 +43,7 @@ void alsaseq_event_data_queue_set_skew_param(ALSASeqEventDataQueue *self,
                                              const guint skew[2]);
 
 void alsaseq_event_data_queue_get_quadlet_param(ALSASeqEventDataQueue *self,
-                                                const guint32 **quadlets);
+                                                const guint32 *quadlets[2]);
 void alsaseq_event_data_queue_set_quadlet_param(ALSASeqEventDataQueue *self,
                                                 const guint32 quadlets[2]);
 

--- a/src/seq/event-data-queue.h
+++ b/src/seq/event-data-queue.h
@@ -48,7 +48,7 @@ void alsaseq_event_data_queue_set_quadlet_param(ALSASeqEventDataQueue *self,
                                                 const guint32 quadlets[2]);
 
 void alsaseq_event_data_queue_get_byte_param(ALSASeqEventDataQueue *self,
-                                             const guint8 **bytes);
+                                             const guint8 *bytes[8]);
 void alsaseq_event_data_queue_set_byte_param(ALSASeqEventDataQueue *self,
                                              const guint8 bytes[8]);
 

--- a/src/seq/event-data-queue.h
+++ b/src/seq/event-data-queue.h
@@ -38,7 +38,7 @@ void alsaseq_event_data_queue_set_position_param(ALSASeqEventDataQueue *self,
                                                  guint position);
 
 void alsaseq_event_data_queue_get_skew_param(ALSASeqEventDataQueue *self,
-                                             const guint **skew);
+                                             const guint *skew[2]);
 void alsaseq_event_data_queue_set_skew_param(ALSASeqEventDataQueue *self,
                                              const guint skew[2]);
 

--- a/src/seq/event-fixed.c
+++ b/src/seq/event-fixed.c
@@ -260,11 +260,10 @@ void alsaseq_event_fixed_set_byte_data(ALSASeqEventFixed *self,
 /**
  * alsaseq_event_fixed_get_quadlet_data:
  * @self: A #ALSASeqEventFixed.
- * @quadlets: (array fixed-size=3)(out)(transfer none): The 3 quadlet data for
- *            the event. The lifetime of the object is the same as the event
- *            itself.
+ * @quadlets: (array fixed-size=3)(out)(transfer none): The array with three
+ *            elements for quadlets as the data of event.
  *
- * Get the 3 quadlet data for the event.
+ * Refer to three quadlet as the data of event.
  */
 void alsaseq_event_fixed_get_quadlet_data(ALSASeqEventFixed *self,
                                           const guint32 *quadlets[3])
@@ -282,10 +281,10 @@ void alsaseq_event_fixed_get_quadlet_data(ALSASeqEventFixed *self,
 /**
  * alsaseq_event_fixed_set_quadlet_data:
  * @self: A #ALSASeqEventFixed.
- * @quadlets: (array fixed-size=3)(transfer none): The 3 quadlet data for the
- *            event.
+ * @quadlets: (array fixed-size=3)(transfer none): The array with three elements
+ *            for quadlets for the data of event.
  *
- * Copy the 3 quadlet data for the event.
+ * Copy three quadlets from the given buffer as the data of event.
  */
 void alsaseq_event_fixed_set_quadlet_data(ALSASeqEventFixed *self,
                                           const guint32 quadlets[3])

--- a/src/seq/event-fixed.c
+++ b/src/seq/event-fixed.c
@@ -218,10 +218,10 @@ ALSASeqEventFixed *alsaseq_event_fixed_new(ALSASeqEventType event_type,
 /**
  * alsaseq_event_fixed_get_byte_data:
  * @self: A #ALSASeqEventFixed.
- * @bytes: (array fixed-size=12)(out)(transfer none): The 12 byte data for the
- *         event. The lifetime of the object is the same as the event itself.
+ * @bytes: (array fixed-size=12)(out)(transfer none): The array with twelve
+ *         elements for byte data of the event.
  *
- * Refer to the 12 byte data for the event.
+ * Refer to the twelve bytes as the data of event.
  */
 void alsaseq_event_fixed_get_byte_data(ALSASeqEventFixed *self,
                                        const guint8 *bytes[12])
@@ -239,9 +239,10 @@ void alsaseq_event_fixed_get_byte_data(ALSASeqEventFixed *self,
 /**
  * alsaseq_event_fixed_set_byte_data:
  * @self: A #ALSASeqEventFixed.
- * @bytes: (array fixed-size=12)(transfer none): The 12 byte data for the event.
+ * @bytes: (array fixed-size=12)(transfer none): The array with twelve elements
+ *         for byte data of the event.
  *
- * Copy the 12 byte data for the event.
+ * Copy the twelve bytes from the given buffer as the data of event.
  */
 void alsaseq_event_fixed_set_byte_data(ALSASeqEventFixed *self,
                                        const guint8 bytes[12])

--- a/src/seq/event-fixed.c
+++ b/src/seq/event-fixed.c
@@ -266,7 +266,7 @@ void alsaseq_event_fixed_set_byte_data(ALSASeqEventFixed *self,
  * Get the 3 quadlet data for the event.
  */
 void alsaseq_event_fixed_get_quadlet_data(ALSASeqEventFixed *self,
-                                          const guint32 **quadlets)
+                                          const guint32 *quadlets[3])
 {
     ALSASeqEvent *parent;
     struct snd_seq_event *ev;

--- a/src/seq/event-fixed.c
+++ b/src/seq/event-fixed.c
@@ -224,7 +224,7 @@ ALSASeqEventFixed *alsaseq_event_fixed_new(ALSASeqEventType event_type,
  * Refer to the 12 byte data for the event.
  */
 void alsaseq_event_fixed_get_byte_data(ALSASeqEventFixed *self,
-                                       const guint8 **bytes)
+                                       const guint8 *bytes[12])
 {
     ALSASeqEvent *parent;
     struct snd_seq_event *ev;

--- a/src/seq/event-fixed.h
+++ b/src/seq/event-fixed.h
@@ -53,7 +53,7 @@ ALSASeqEventFixed *alsaseq_event_fixed_new(ALSASeqEventType event_type,
                                            GError **error);
 
 void alsaseq_event_fixed_get_byte_data(ALSASeqEventFixed *self,
-                                       const guint8 **bytes);
+                                       const guint8 *bytes[12]);
 void alsaseq_event_fixed_set_byte_data(ALSASeqEventFixed *self,
                                        const guint8 bytes[12]);
 

--- a/src/seq/event-fixed.h
+++ b/src/seq/event-fixed.h
@@ -58,7 +58,7 @@ void alsaseq_event_fixed_set_byte_data(ALSASeqEventFixed *self,
                                        const guint8 bytes[12]);
 
 void alsaseq_event_fixed_get_quadlet_data(ALSASeqEventFixed *self,
-                                          const guint32 **quadlets);
+                                          const guint32 *quadlets[3]);
 void alsaseq_event_fixed_set_quadlet_data(ALSASeqEventFixed *self,
                                           const guint32 quadlets[3]);
 

--- a/src/seq/queue-tempo.c
+++ b/src/seq/queue-tempo.c
@@ -119,7 +119,7 @@ ALSASeqQueueTempo *alsaseq_queue_tempo_new()
  *
  * Refer to numerator and denominator of skew.
  */
-void alsaseq_queue_tempo_get_skew(ALSASeqQueueTempo *self, const guint32 **skew)
+void alsaseq_queue_tempo_get_skew(ALSASeqQueueTempo *self, const guint32 *skew[2])
 {
     ALSASeqQueueTempoPrivate *priv;
 

--- a/src/seq/queue-tempo.c
+++ b/src/seq/queue-tempo.c
@@ -117,7 +117,7 @@ ALSASeqQueueTempo *alsaseq_queue_tempo_new()
  * @skew: (array fixed-size=2)(out)(transfer none): The array with two elements
  *        for numerator and denominator of fraction for skew.
  *
- * Refer to numerator and denominator of skew.
+ * Refer to numerator and denominator of fraction for skew.
  */
 void alsaseq_queue_tempo_get_skew(ALSASeqQueueTempo *self, const guint32 *skew[2])
 {
@@ -138,7 +138,7 @@ void alsaseq_queue_tempo_get_skew(ALSASeqQueueTempo *self, const guint32 *skew[2
  * @skew: (array fixed-size=2)(transfer none): The array with two elements for
  *        numerator and denominator of fraction for skew.
  *
- * Copy numerator and denominator of skew.
+ * Copy numerator and denominator of fraction for skew.
  */
 void alsaseq_queue_tempo_set_skew(ALSASeqQueueTempo *self, const guint32 skew[2])
 {

--- a/src/seq/queue-tempo.h
+++ b/src/seq/queue-tempo.h
@@ -47,7 +47,7 @@ GType alsaseq_queue_tempo_get_type() G_GNUC_CONST;
 
 ALSASeqQueueTempo *alsaseq_queue_tempo_new();
 
-void alsaseq_queue_tempo_get_skew(ALSASeqQueueTempo *self, const guint32 **skew);
+void alsaseq_queue_tempo_get_skew(ALSASeqQueueTempo *self, const guint32 *skew[2]);
 void alsaseq_queue_tempo_set_skew(ALSASeqQueueTempo *self, const guint32 skew[2]);
 
 G_END_DECLS

--- a/src/seq/tstamp.c
+++ b/src/seq/tstamp.c
@@ -40,7 +40,7 @@ void alsaseq_tstamp_set_tick_time(ALSASeqTstamp *self, const guint32 tick_time)
  *
  * Refer to the time as wall-clock time.
  */
-void alsaseq_tstamp_get_real_time(ALSASeqTstamp *self, guint32 *real_time[2])
+void alsaseq_tstamp_get_real_time(ALSASeqTstamp *self, const guint32 *real_time[2])
 {
     // MEMO: I wish 32-bit storage size is aligned to 32 bit offset in all of
     // supported ABIs.

--- a/src/seq/tstamp.h
+++ b/src/seq/tstamp.h
@@ -22,7 +22,7 @@ GType alsaseq_tstamp_get_type() G_GNUC_CONST;
 void alsaseq_tstamp_get_tick_time(ALSASeqTstamp *self, guint32 *tick_time);
 void alsaseq_tstamp_set_tick_time(ALSASeqTstamp *self, const guint32 tick_time);
 
-void alsaseq_tstamp_get_real_time(ALSASeqTstamp *self, guint32 *real_time[2]);
+void alsaseq_tstamp_get_real_time(ALSASeqTstamp *self, const guint32 *real_time[2]);
 void alsaseq_tstamp_set_real_time(ALSASeqTstamp *self, const guint32 real_time[2]);
 
 G_END_DECLS

--- a/src/seq/user-client.c
+++ b/src/seq/user-client.c
@@ -88,7 +88,7 @@ static void alsaseq_user_client_class_init(ALSASeqUserClientClass *klass)
     /**
      * ALSASeqUserClient::handle-event:
      * @self: A #ALSASeqUserClient.
-     * @event: (transfer none): A #ALSASeqEvent or derived objects.
+     * @event: (transfer none): An object derived from #ALSASeqEvent.
      *
      * When event occurs, this signal is emit with an object for the event.
      */

--- a/src/seq/user-client.h
+++ b/src/seq/user-client.h
@@ -58,7 +58,7 @@ struct _ALSASeqUserClientClass {
     /**
      * ALSASeqUserClientClass::handle_event:
      * @self: A #ALSASeqUserClient.
-     * @event: (transfer none): A #ALSASeqEvent or derived objects.
+     * @event: (transfer none): An object derived from #ALSASeqEvent.
      *
      * When event occurs, this signal is emit with an object for the event.
      */


### PR DESCRIPTION
In UAPI of ALSA Sequencer, some members in structures are defined as
fixed-sized array. For accessor methods to the members, this patchset
adds changes so that function annotations have 'not a variable length
array type' in their prototype.

In some cases, it's convenient to compare two instance of ALSASeq.Addr.
This patchset adds a new API, 'ALSASeq.Addr.equal()' for this purpose.

Finally, this patchset also adds some improvements and fixes.