### PR TITLE
alsa-gobject: seq: Revert "seq: tstamp: use wrapper structure instead of union"

### DIFF
--- a/src/seq/event-data-queue.c
+++ b/src/seq/event-data-queue.c
@@ -70,9 +70,7 @@ void alsaseq_event_data_queue_set_value_param(ALSASeqEventDataQueue *self,
 void alsaseq_event_data_queue_get_tstamp_param(ALSASeqEventDataQueue *self,
                                                const ALSASeqTstamp **tstamp)
 {
-    // MEMO: I wish the structure has no padding in its head in all of supported
-    // ABIs.
-    *tstamp = (const ALSASeqTstamp *)&self->param.time;
+    *tstamp = &self->param.time;
 }
 
 /**
@@ -85,7 +83,7 @@ void alsaseq_event_data_queue_get_tstamp_param(ALSASeqEventDataQueue *self,
 void alsaseq_event_data_queue_set_tstamp_param(ALSASeqEventDataQueue *self,
                                                const ALSASeqTstamp *tstamp)
 {
-    self->param.time = tstamp->tstamp;
+    self->param.time = *tstamp;
 }
 
 /**

--- a/src/seq/event-fixed.c
+++ b/src/seq/event-fixed.c
@@ -72,7 +72,7 @@ static void seq_event_fixed_set_property(GObject *obj, guint id,
     {
         ALSASeqTstamp *data = g_value_get_boxed(val);
         if (data != NULL)
-            ev->data.time = data->tstamp;
+            ev->data.time = *data;
         break;
     }
     default:
@@ -108,9 +108,7 @@ static void seq_event_fixed_get_property(GObject *obj, guint id, GValue *val,
         g_value_set_static_boxed(val, &ev->data.connect);
         break;
     case SEQ_EVENT_FIXED_PROP_TSTAMP_DATA:
-        // MEMO: I wish the structure has no padding in its head in all of
-	// supported ABIs.
-        g_value_set_static_boxed(val, (ALSASeqTstamp *)&ev->data.time);
+        g_value_set_static_boxed(val, &ev->data.time);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(obj, id, spec);

--- a/src/seq/event.c
+++ b/src/seq/event.c
@@ -60,7 +60,7 @@ static void seq_event_set_property(GObject *obj, guint id, const GValue *val,
     {
         ALSASeqTstamp *tstamp = g_value_get_boxed(val);
         if (tstamp != NULL)
-            ev->time = tstamp->tstamp;
+            ev->time = *tstamp;
         break;
     }
     case SEQ_EVENT_PROP_SRC_ADDR:
@@ -129,9 +129,7 @@ static void seq_event_get_property(GObject *obj, guint id, GValue *val,
         g_value_set_uchar(val, ev->queue);
         break;
     case SEQ_EVENT_PROP_TSTAMP:
-        // MEMO: I wish the structure has no padding in its head in all of
-	// supported ABIs.
-        g_value_set_static_boxed(val, (ALSASeqTstamp *)&ev->time);
+        g_value_set_static_boxed(val, &ev->time);
         break;
     case SEQ_EVENT_PROP_SRC_ADDR:
         g_value_set_static_boxed(val, &ev->source);

--- a/src/seq/tstamp.c
+++ b/src/seq/tstamp.c
@@ -17,7 +17,7 @@ G_DEFINE_BOXED_TYPE(ALSASeqTstamp, alsaseq_tstamp, seq_tstamp_copy, g_free)
  */
 void alsaseq_tstamp_get_tick_time(ALSASeqTstamp *self, guint32 *tick_time)
 {
-    *tick_time = self->tstamp.tick;
+    *tick_time = self->tick;
 }
 
 /**
@@ -29,7 +29,7 @@ void alsaseq_tstamp_get_tick_time(ALSASeqTstamp *self, guint32 *tick_time)
  */
 void alsaseq_tstamp_set_tick_time(ALSASeqTstamp *self, const guint32 tick_time)
 {
-    self->tstamp.tick = tick_time;
+    self->tick = tick_time;
 }
 
 /**
@@ -44,7 +44,7 @@ void alsaseq_tstamp_get_real_time(ALSASeqTstamp *self, const guint32 *real_time[
 {
     // MEMO: I wish 32-bit storage size is aligned to 32 bit offset in all of
     // supported ABIs.
-    *real_time = (guint32 *)&self->tstamp.time;
+    *real_time = (guint32 *)&self->time;
 }
 
 
@@ -58,6 +58,6 @@ void alsaseq_tstamp_get_real_time(ALSASeqTstamp *self, const guint32 *real_time[
  */
 void alsaseq_tstamp_set_real_time(ALSASeqTstamp *self, const guint32 real_time[2])
 {
-    self->tstamp.time.tv_sec = real_time[0];
-    self->tstamp.time.tv_nsec = real_time[1];
+    self->time.tv_sec = real_time[0];
+    self->time.tv_nsec = real_time[1];
 }

--- a/src/seq/tstamp.h
+++ b/src/seq/tstamp.h
@@ -11,11 +11,7 @@ G_BEGIN_DECLS
 
 #define ALSASEQ_TYPE_TSTAMP   (alsaseq_tstamp_get_type())
 
-// The usage of union is inconvenient to some programming languages which has
-// no support to handle it. Let's use wrapper structure.
-typedef struct {
-    union snd_seq_timestamp tstamp;
-} ALSASeqTstamp;
+typedef union snd_seq_timestamp ALSASeqTstamp;
 
 GType alsaseq_tstamp_get_type() G_GNUC_CONST;
 


### PR DESCRIPTION
This reverts commit 20fdc2d893ccba609cc786ebac733bf6914f9874.

In the above commit, union type structure is wrapped with care of
language bindings in which union-compatible feature is not expected.
However, it's responsible for language bindings to parse gir and
the care is not necessarily required in shared library side. In first
place, ALSASeq.Tstamp is boxed type object.

Signed-off-by: Takashi Sakamoto <o-takashi@sakamocchi.jp>