### PR TITLE
seq: user_client: use constant qualifier for read-only parameter

### DIFF
--- a/src/seq/user-client.c
+++ b/src/seq/user-client.c
@@ -218,7 +218,7 @@ void alsaseq_user_client_get_info(ALSASeqUserClient *self,
  */
 void alsaseq_user_client_create_port(ALSASeqUserClient *self,
                                      ALSASeqPortInfo *port_info,
-                                     guint8 *port_id, GError **error)
+                                     const guint8 *port_id, GError **error)
 {
     ALSASeqUserClientPrivate *priv;
     struct snd_seq_port_info *info;

--- a/src/seq/user-client.h
+++ b/src/seq/user-client.h
@@ -81,7 +81,7 @@ void alsaseq_user_client_get_info(ALSASeqUserClient *self,
 
 void alsaseq_user_client_create_port(ALSASeqUserClient *self,
                                      ALSASeqPortInfo *port_info,
-                                     guint8 *port_id, GError **error);
+                                     const guint8 *port_id, GError **error);
 
 void alsaseq_user_client_update_port(ALSASeqUserClient *self,
                                      ALSASeqPortInfo *port_info,


### PR DESCRIPTION
The 'port_id' parameters of 'alsaseq_user_client_create_port()' is
a pointer to storage of unsigned char type, due to optional parameter
in g-i interface. It's read-only if having value and it's better to
have const qualifier.