### PR TITLE
alsa-gobject: hwdep/timer/rawmidi: fulfill documentation for ALSAHwdep/ALSATimer/ALSARawmidi

### DIFF
--- a/doc/reference/ctl/alsactl-docs.xml
+++ b/doc/reference/ctl/alsactl-docs.xml
@@ -15,10 +15,10 @@
     <chapter id="introduction">
         <title>Introduction</title>
         <para>This library is designed for applications to manipulate ALSA
-        control character device and operate functionality on sound card
-        abstracted as element. Event dispatching is based on GLib's GMainContext
-        and GMainLoop with created GSource.
-        </para>
+        control character device and operate control functionality abstracted
+        as card and element. ALSACtlCard represent the card. It holds file
+        descriptor and creates GSource for event dispatching by GLib's
+        GMainContext/GMainLoop.</para>
     </chapter>
 
     <chapter id="alsactl-enumerations">

--- a/doc/reference/hwdep/alsahwdep-docs.xml
+++ b/doc/reference/hwdep/alsahwdep-docs.xml
@@ -12,6 +12,16 @@
     </releaseinfo>
     </bookinfo>
 
+    <chapter id="introduction">
+        <title></title>
+        <param>This library is designed for applications to manipulate ALSA
+        hwdep character device and retrieve common information of hardware
+        dependent functionality abstracted as hwdep device. As the design
+        concept means; hardware dependent, this library has no further
+        functionality. Each applications should implement it by their own.
+        </param>
+    </chapter>
+
     <chapter id="alsahwdep-enumerations">
         <title>ALSAHwdep enumerations</title>
         <xi:include href="xml/alsahwdep-enum-types.xml"/>

--- a/doc/reference/rawmidi/alsarawmidi-docs.xml
+++ b/doc/reference/rawmidi/alsarawmidi-docs.xml
@@ -12,6 +12,15 @@
     </releaseinfo>
     </bookinfo>
 
+    <chapter id="introduction">
+        <title>Introduction</title>
+        <para>This library is designed for applications to manipulate ALSA
+        Rawmidi character device and operate rawmidi functionality abstracted
+        as a pair of streams and substream. ALSARawmidiStreamPair represents
+        the pair of streams. It holds file descriptor and creates GSource for
+        event dispathing by GLib's GMainContext/GMainLoop.</para>
+    </chapter>
+
     <chapter id="alsarawmidi-enumerations">
         <title>ALSARawmidi enumerations</title>
         <xi:include href="xml/alsarawmidi-enum-types.xml"/>

--- a/doc/reference/timer/alsatimer-docs.xml
+++ b/doc/reference/timer/alsatimer-docs.xml
@@ -12,6 +12,15 @@
     </releaseinfo>
     </bookinfo>
 
+    <chapter id="introduction">
+        <title>Introduction</title>
+        <para>This library is designed for applications to manipulate ALSA
+        timer character device and operate timer functionality abstracted
+        as timer device and user instance. ALSATimerUserInstance represents
+        the user instance. It holds file descriptor and creates GSource for
+        event dispatching by GLib's GMainContext/GMainLoop.</para>
+    </chapter>
+
     <chapter id="alsatimer-enumerations">
         <title>ALSATimer enumerations</title>
         <xi:include href="xml/alsatimer-enum-types.xml"/>

--- a/src/ctl/card-info.c
+++ b/src/ctl/card-info.c
@@ -8,8 +8,10 @@
  *                     sound card
  *
  * A #ALSACtlCardInfo is a GObject-derived object to represent information of
- * sound card. A call of alsactl_card_get_info() returns an instance of the
+ * sound card. The call of alsactl_card_get_info() returns an instance of the
  * object.
+ *
+ * The object wraps 'struct snd_ctl_card_info' in UAPI of Linux sound subsystem.
  */
 struct _ALSACtlCardInfoPrivate {
     struct snd_ctl_card_info info;

--- a/src/ctl/card.c
+++ b/src/ctl/card.c
@@ -25,6 +25,8 @@
  * A #ALSACtlCard is a GObject-derived object to represent sound card.
  * Applications use the instance of object to manipulate functionalities on
  * sound card.
+ * After the call of alsactl_card_open() for the numerical ID of sound card,
+ * the object maintains file descriptor till object destruction.
  */
 struct _ALSACtlCardPrivate {
     int fd;

--- a/src/ctl/elem-id.c
+++ b/src/ctl/elem-id.c
@@ -6,10 +6,12 @@
  * @Title: ALSACtlElemId
  * @Short_description: A boxed object to represent the identifier of element.
  *
- * A #ALSACtlElemId is an boxed object to represent the identifier of element.
+ * A #ALSACtlElemId is a boxed object to represent the identifier of element.
  * It points to a element by two ways; by the numerical ID, or by the
  * combination of the type of interface, the numerical ID of device, the
  * numerical ID of subdevice, the name, and the index.
+ *
+ * The object wraps 'struct snd_ctl_elem_id' in UAPI of Linux sound subsystem.
  */
 ALSACtlElemId *ctl_elem_id_copy(const ALSACtlElemId *self)
 {

--- a/src/ctl/elem-info.c
+++ b/src/ctl/elem-info.c
@@ -9,6 +9,8 @@
  *
  * A #ALSACtlElemInfo is an abstract object to represent the common information
  * of any type of element.
+ *
+ * The object wraps 'struct snd_ctl_elem_info' in UAPI of Linux sound subsystem.
  */
 struct _ALSACtlElemInfoPrivate {
     struct snd_ctl_elem_info info;

--- a/src/ctl/elem-value.c
+++ b/src/ctl/elem-value.c
@@ -10,8 +10,10 @@
  * A #ALSACtlElemValue is boxed object to represent the container of values for
  * any type of element. The arrays of values for each type of element shares the
  * same storage, thus it's important for applications to distinguish the type of
- * element in advance of accesing the array. The object is used for the call of
+ * element in advance of accessing the array. The object is used for the call of
  * alsactl_card_write_elem_value() and alsactl_card_read_elem_value().
+ *
+ * The object wraps 'struct snd_ctl_elem_value' in UAPI of Linux sound subsystem.
  */
 struct _ALSACtlElemValuePrivate {
     struct snd_ctl_elem_value value;

--- a/src/ctl/query.c
+++ b/src/ctl/query.c
@@ -15,7 +15,8 @@
 /**
  * SECTION: query
  * @Title: Global functions in ALSACtl
- * @Short_description: Global functions in ALSACtl
+ * @Short_description: Global functions available without holding any file
+ *                     descriptor
  */
 
 // For error handling.

--- a/src/hwdep/device-info.c
+++ b/src/hwdep/device-info.c
@@ -1,6 +1,18 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "privates.h"
 
+/**
+ * SECTION: device-info
+ * @Title: ALSAHwdepDeviceInfo
+ * @Short_description: A GObject-derived object to represent information of
+ *                     ALSA hwdep device.
+ *
+ * A #ALSAHwdepDeviceInfo is a GObject-derived object to represent information
+ * of ALSA hwdep device. The call of alsahwdep_get_device_info() returns an
+ * instance of the object.
+ *
+ * The object wraps 'struct snd_hwdep_info' in UAPI of Linux sound subsystem.
+ */
 struct _ALSAHwdepDeviceInfoPrivate {
     struct snd_hwdep_info info;
 };

--- a/src/hwdep/query.c
+++ b/src/hwdep/query.c
@@ -12,6 +12,13 @@
 
 #include <libudev.h>
 
+/**
+ * SECTION: query
+ * @Title: Global functions in ALSAHwdep
+ * @Short_description: Global functions available without holding any file
+ *                     descriptor
+ */
+
 // For error handling.
 G_DEFINE_QUARK("alsahwdep-error", alsahwdep_error)
 

--- a/src/rawmidi/query.c
+++ b/src/rawmidi/query.c
@@ -12,6 +12,13 @@
 
 #include <libudev.h>
 
+/**
+ * SECTION: query
+ * @Title: Global functions in ALSARawmidi
+ * @Short_description: Global functions available without holding any file
+ *                     descriptor
+ */
+
 // For error reporting.
 G_DEFINE_QUARK("alsarawmidi-error", alsarawmidi_error)
 

--- a/src/rawmidi/stream-pair.c
+++ b/src/rawmidi/stream-pair.c
@@ -11,6 +11,29 @@
 #include <unistd.h>
 #include <sys/ioctl.h>
 
+/**
+ * SECTION: stream-pair
+ * @Title: ALSARawmidiStreamPair
+ * @Short_description: A GObject-derived object to represent a pair of Rawmidi
+ *                     stream.
+ *
+ * A #ALSARawmidiStreamPair is a GObject-derived object to represent a pair
+ * of Rawmidi stream to which substreams are attached. The substream is pointed
+ * by the combination of the numerical ID of device, subdevice, and direction.
+ * When the call of alsarawmidi_stream_pair_open() with the combination,
+ * corresponding substreams are attached to the object. Then the object maintains
+ * file descriptor till object destruction. The call of
+ * alsarawmidi_stream_pair_create_source() returns the instance of GSource. Once
+ * attached to the GSource, GMainContext/GMainLoop is available as event
+ * dispatcher. The 'handle-messages' GObject signal is emit in the event
+ * dispatcher to notify the intermediate buffer of capture substream has
+ * available messages. The call of alsarawmidi_stream_pair_read_from_substream()
+ * fills the given buffer with the available messages. The call of
+ * alsarawmidi_stream_pair_write_to_substream() write messages in the given
+ * buffer into the intermediate buffer of playback substream. The call of
+ * alsarawmidi_stream_pair_get_substream_status() is available to check the
+ * space in the intermediate buffer according to direction argument.
+ */
 struct _ALSARawmidiStreamPairPrivate {
     int fd;
     char *devnode;

--- a/src/rawmidi/substream-info.c
+++ b/src/rawmidi/substream-info.c
@@ -1,6 +1,19 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "privates.h"
 
+/**
+ * SECTION: substream-info
+ * @Title: ALSARawmidiSubstreamInfo
+ * @Short_description: A GObject-derived object to represent information of
+ *                     substream
+ *
+ * A #ALSARawmidiSubstreamInfo is a GObject-derived object to represent
+ * information of substream attached to the pair of streams. The call of
+ * alsarawmidi_stream_pair_get_substream_info() or
+ * alsarawmidi_get_substream_info() return the instance of object.
+ *
+ * The object wraps 'struct snd_rawmidi_info' in UAPI of Linux sound subsystem.
+ */
 struct _ALSARawmidiSubstreamInfoPrivate {
     struct snd_rawmidi_info info;
 };

--- a/src/rawmidi/substream-params.c
+++ b/src/rawmidi/substream-params.c
@@ -3,6 +3,19 @@
 
 #include <unistd.h>
 
+/**
+ * SECTION: substream-params
+ * @Title: ALSARawmidiSubstreamParams
+ * @Short_description: A GObject-derived object to represent parameters of
+ *                     substream.
+ *
+ * A #ALSARawmidiSubstreamParams is a GObject-derived object to represent
+ * parameters of substream attached to the pair of streams. The call of
+ * alsarawmidi_stream_pair_set_substream_params() requires the instance of
+ * object.
+ *
+ * The object wraps 'struct snd_rawmidi_params' in UAPI of Linux sound subsystem.
+ */
 struct _ALSARawmidiSubstreamParamsPrivate {
     struct snd_rawmidi_params params;
 };

--- a/src/rawmidi/substream-status.c
+++ b/src/rawmidi/substream-status.c
@@ -1,6 +1,18 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "privates.h"
 
+/**
+ * SECTION: substream-status
+ * @Title: ALSARawmidiSubstreamStatus
+ * @Short_description: A GObject-derived object to represent status of substream
+ *
+ * A #ALSARawmidiSubstreamStatus is a GObject-derived object to represent status
+ * of substream attached to the pair of stream. The call of
+ * alsarawmidi_stream_pair_get_substream_status() returns the instance of
+ * object.
+ *
+ * The object wraps 'struct snd_rawmidi_status' in UAPI of Linux sound subsystem.
+ */
 struct _ALSARawmidiSubstreamStatusPrivate {
     struct snd_rawmidi_status status;
 };

--- a/src/timer/device-id.c
+++ b/src/timer/device-id.c
@@ -1,6 +1,19 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "device-id.h"
 
+/**
+ * SECTION: device-id
+ * @Title: ALSATimerDeviceId
+ * @Short_description: A boxed object to represent the identifier of timer
+ *                     device.
+ *
+ * A #ALSATimerDeviceId is a boxed object to represent the identifier of timer
+ * device. The identifier mainly consists of the class of timer device. The
+ * other members; the numerical ID of card, device, and subdevice are optional
+ * according to the class of timer device.
+ *
+ * The object wraps 'struct snd_timer_id' in UAPI of Linux sound subsystem.
+ */
 ALSATimerDeviceId *timer_device_id_copy(const ALSATimerDeviceId *self)
 {
     return g_memdup(self, sizeof(*self));

--- a/src/timer/device-info.c
+++ b/src/timer/device-info.c
@@ -1,6 +1,18 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "privates.h"
 
+/**
+ * SECTION: device-info
+ * @Title: ALSATimerDeviceInfo
+ * @Short_description: A GObject-derived object to represent information of
+ *                     timer device.
+ *
+ * A #ALSATimerDeviceInfo is a GObject-derived object to represent information
+ * of timer device. The call of alsatimer_get_device_info() returns an instance
+ * of the object according to the identifier of timer device.
+ *
+ * The object wraps 'struct snd_timer_ginfo' in UAPI of Linux sound subsystem.
+ */
 struct _ALSATimerDeviceInfoPrivate {
     struct snd_timer_ginfo info;
 };

--- a/src/timer/device-params.c
+++ b/src/timer/device-params.c
@@ -1,6 +1,18 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "privates.h"
 
+/**
+ * SECTION: device-params
+ * @Title: ALSATimerDeviceParams
+ * @Short_description: A GObject-derived object to represent parameter of timer
+ *                     device.
+ *
+ * A #ALSATimerDeviceParams is a GObject-derived object to represent parameter
+ * of timer device. The call of alsatimer_set_device_params() requires the
+ * instance of object.
+ *
+ * The object wraps 'struct snd_timer_gparams' in UAPI of Linux sound subsystem.
+ */
 struct _ALSATimerDeviceParamsPrivate {
     struct snd_timer_gparams params;
 };

--- a/src/timer/device-status.c
+++ b/src/timer/device-status.c
@@ -1,6 +1,18 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "privates.h"
 
+/**
+ * SECTION: device-status
+ * @Title: ALSATimerDeviceStatus
+ * @Short_description: A GObject-derived object to represent status of timer
+ *                     device.
+ *
+ * A #ALSATimerDeviceStatus is a GObject-derived object to represent status of
+ * timer device. The call of alsatimer_get_device_status() returns the instance
+ * of object.
+ *
+ * The object wraps 'struct snd_timer_gstatus' in UAPI of Linux sound subsystem.
+ */
 struct _ALSATimerDeviceStatusPrivate {
     struct snd_timer_gstatus status;
 };

--- a/src/timer/event-data-tick.c
+++ b/src/timer/event-data-tick.c
@@ -2,6 +2,19 @@
 #include "event-data-tick.h"
 #include "privates.h"
 
+/**
+ * SECTION: event-data-tick
+ * @Title: ALSATimerEventDataTick
+ * @Short_description: A GObject-derived object to represent event of timer with
+ *                     tick count
+ *
+ * A #ALSATimerEventDataTick is a GObject-derived object to represent event of
+ * timer with tick count. The instance of object is passed to handler for
+ * 'handle-event' GObject signal in ALSATimerUserInstance when it's available.
+ * The object inherits properties of #ALSATimerEventData.
+ *
+ * The object wraps 'struct snd_timer_read' in UAPI of Linux sound subsystem.
+ */
 struct _ALSATimerEventDataTickPrivate {
     struct snd_timer_read event;
 };

--- a/src/timer/event-data-timestamp.c
+++ b/src/timer/event-data-timestamp.c
@@ -2,6 +2,21 @@
 #include "event-data-timestamp.h"
 #include "privates.h"
 
+/**
+ * SECTION: event-data-timestamp
+ * @Title: ALSATimerEventDataTimestamp
+ * @Short_description: A GObject-derived object to represent event of timer with
+ *                     timestamp
+ *
+ * A #ALSATimerEventDataTimestamp is a GObject-derived object to represent
+ * event of timer with timestamp. The instance of object is passed to handler for
+ * 'handle-event' GObject signal in ALSATimerUserInstance when it's available.
+ * The source of timestamp is decided by 'timer_tstamp_monotonic' option of
+ * 'snd-timer' kernel module. The object inherits properties of
+ * #ALSATimerEventData.
+ *
+ * The object wraps 'struct snd_timer_read' in UAPI of Linux sound subsystem.
+ */
 struct _ALSATimerEventDataTimestampPrivate {
     struct snd_timer_tread event;
 };

--- a/src/timer/event-data.c
+++ b/src/timer/event-data.c
@@ -1,6 +1,15 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "event-data.h"
 
+/**
+ * SECTION: event-data
+ * @Title: ALSATimerEventData
+ * @Short_description: A GObject-derived abstract object to represent common
+ *                     data of event
+ *
+ * A #ALSATimerEventData is a GObject-derived abstract object to represent
+ * common data of event.
+ */
 struct _ALSATimerEventDataPrivate {
     ALSATimerEventDataType type;
 };

--- a/src/timer/instance-info.c
+++ b/src/timer/instance-info.c
@@ -1,6 +1,18 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "privates.h"
 
+/**
+ * SECTION: instance-info
+ * @Title: ALSATimerInstanceInfo
+ * @Short_description: A GObject-derived object to represent information of
+ *                     user instance
+ *
+ * A #ALSATimerInstanceInfo is a GObject-derived object to represent information
+ * of user instance attached to any timer device or the other instance as slave.
+ * The call of alsatimer_user_instance_get_info() returns the instance of object.
+ *
+ * The object wraps 'struct snd_timer_info' in UAPI of Linux sound subsystem.
+ */
 struct _ALSATimerInstanceInfoPrivate {
     struct snd_timer_info info;
 };

--- a/src/timer/instance-params.c
+++ b/src/timer/instance-params.c
@@ -6,6 +6,19 @@
 
 #include <errno.h>
 
+/**
+ * SECTION: instance-params
+ * @Title: ALSATimerInstanceParams
+ * @Short_description: A GObject-derived object to represent parameters of user
+ *                     instance
+ *
+ * A #ALSATimerInstanceParams is a GObject-derived object to represent
+ * parameters of user instance attached to any timer device or the other
+ * instance as slave. The call of alsatimer_user_instance_set_params() requires
+ * the instance of object.
+ *
+ * The object wraps 'struct snd_timer_params' in UAPI of Linux sound subsystem.
+ */
 struct _ALSATimerInstanceParamsPrivate{
     struct snd_timer_params params;
 };

--- a/src/timer/instance-status.c
+++ b/src/timer/instance-status.c
@@ -3,6 +3,19 @@
 
 #include <sound/asound.h>
 
+/**
+ * SECTION: instance-status
+ * @Title: ALSATimerInstanceStatus
+ * @Short_description: A GObject-derived object to represent status of user
+ *                     instance
+ *
+ * A #ALSATimerInstanceStatus is a GObject-derived object to represent status
+ * of user instance attached to any timer device or the other instance as slave.
+ * The call of alsatimer_user_instance_get_status() returns the instance of
+ * object.
+ *
+ * The object wraps 'struct snd_timer_status' in UAPI of Linux sound subsystem.
+ */
 struct _ALSATimerInstanceStatusPrivate {
     struct snd_timer_status status;
 };

--- a/src/timer/query.c
+++ b/src/timer/query.c
@@ -17,6 +17,13 @@
 
 #define TIMER_SYSNAME_TEMPLATE  "timer"
 
+/**
+ * SECTION: query
+ * @Title: Global functions in ALSATimer
+ * @Short_description: Global functions available without holding any
+ *                     file descriptor
+ */
+
 // For error handling.
 G_DEFINE_QUARK("alsatimer-error", alsatimer_error)
 

--- a/src/timer/user-instance.c
+++ b/src/timer/user-instance.c
@@ -10,6 +10,19 @@
 #include <sys/ioctl.h>
 #include <errno.h>
 
+/**
+ * SECTION: user-instance
+ * @Title: ALSATimerUserInstance
+ * @Short_description: A GObject-derived object to represent user instance
+ *
+ * A #ALSATimerUserInstance is a GObject-derived object to represent information
+ * of user instance attached to any timer device or the other instance as slave.
+ * After calling alsatimer_user_instance_open(), the object maintains file
+ * descriptor till object destruction. After calling
+ * alsatimer_user_instance_attach() or alsatimer_user_instance_attach_as_slave(),
+ * the user instance is attached to any timer device or the other instance as
+ * slave.
+ */
 struct _ALSATimerUserInstancePrivate {
     int fd;
     ALSATimerEventDataType event_data_type;


### PR DESCRIPTION
This patchset fulfills documentation for ALSAHwdep/ALSATimer/ALSARawmidi, except for ALSASeq, including some documentation improvements for ALSACtl.