### PR TITLE
alsa-gobject: doc: hwdep: fix missing content of introduction element

### DIFF
--- a/doc/reference/hwdep/alsahwdep-docs.xml
+++ b/doc/reference/hwdep/alsahwdep-docs.xml
@@ -13,7 +13,7 @@
     </bookinfo>
 
     <chapter id="introduction">
-        <title></title>
+        <title>Introduction</title>
         <param>This library is designed for applications to manipulate ALSA
         hwdep character device and retrieve common information of hardware
         dependent functionality abstracted as hwdep device. As the design


### PR DESCRIPTION
A commit eb03ec0340b ("hwdep: fulfill documentation for ALSAHwdep") fulfilled documentation for ALSAHwDep but the content of introduction element is missing.

This patch fixes it.