### PR TITLE
alsa-gobject: timer: add global method to retrieve current source of timestamp

### DIFF
--- a/src/timer/alsatimer.map
+++ b/src/timer/alsatimer.map
@@ -13,6 +13,7 @@ ALSA_GOBJECT_0_0_0 {
     "alsatimer_get_device_id_list";
     "alsatimer_get_device_info";
     "alsatimer_get_device_status";
+    "alsatimer_get_tstamp_source";
 
     "alsatimer_device_id_get_type";
     "alsatimer_device_id_new";

--- a/src/timer/query.h
+++ b/src/timer/query.h
@@ -32,6 +32,8 @@ void alsatimer_set_device_params(ALSATimerDeviceId *device_id,
                                  const ALSATimerDeviceParams *device_params,
                                  GError **error);
 
+void alsatimer_get_tstamp_source(int *clock_id, GError **error);
+
 G_END_DECLS
 
 #endif


### PR DESCRIPTION
ALSA snd_timer kernel module has a parameter for source of timestamping. Applications cannot refer to the parameter via UAPI of Linux kernel, however it's possible via sysfs.

This patch adds an API to refer to the parameter.