### PR TITLE
alsa-gobject: seq: misc fixes (take 2)

### DIFF
--- a/src/seq/meson.build
+++ b/src/seq/meson.build
@@ -144,6 +144,7 @@ gnome.generate_gir(library,
   includes: [
     'GLib-2.0',
     'GObject-2.0',
+    alsatimer_gir[0],
   ],
   install: true,
 )

--- a/src/seq/query.c
+++ b/src/seq/query.c
@@ -575,6 +575,7 @@ void alsaseq_get_queue_id_list(guint **entries, gsize *entry_count,
         return;
     }
 
+    index = 0;
     for (i = 0; i < maximum_count; ++i) {
         struct snd_seq_queue_info info;
 

--- a/src/timer/meson.build
+++ b/src/timer/meson.build
@@ -114,7 +114,7 @@ pkg.generate(library,
 )
 
 # Generate metadata for gobject introspection.
-gnome.generate_gir(library,
+alsatimer_gir = gnome.generate_gir(library,
   sources: sources + headers,
   nsversion: '0.0',
   namespace: namespace,

--- a/tests/alsaseq-queue-timer
+++ b/tests/alsaseq-queue-timer
@@ -9,8 +9,11 @@ import gi
 gi.require_version('ALSASeq', '0.0')
 from gi.repository import ALSASeq
 
-target = ALSASeq.QueueTimerAlsa()
-props = ()
+target = ALSASeq.QueueTimer
+props = (
+    'queue-id',
+    'type',
+)
 methods = ()
 signals = ()
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -56,13 +56,16 @@ tests = {
   ],
 }
 
+dir_paths = []
 foreach path, scripts: tests
-  objdir = join_paths(meson.build_root(), 'src', path)
+  dir_paths += join_paths(meson.build_root(), 'src', path)
+endforeach
 
-  env = environment()
-  env.append('LD_LIBRARY_PATH', objdir, separator : ':')
-  env.append('GI_TYPELIB_PATH', objdir, separator : ':')
+env = environment()
+env.append('LD_LIBRARY_PATH', ':'.join(dir_paths), separator : ':')
+env.append('GI_TYPELIB_PATH', ':'.join(dir_paths), separator : ':')
 
+foreach path, scripts: tests
   foreach script: scripts
     prog = find_program(script)
     test(script, prog,


### PR DESCRIPTION
This patchset includes misc fixes for ALSASeq.

Especially the execution of g-ir-scanner to generate ALSASeq-0.0 becomes to expect ALSATimer-0.0 is available. Although it is expected, it results in Python 3 gir loader (PyGObject) loading ALSATimer-0.0 before loading ALSASeq-0.0. Any test for ALSASeq-0.0 is going to fail because ALSATimer-0.0 is not available before installing. To solve the issue, the patchset includes the patch to change test procedure to arrange environment variables.