### PR TITLE
alsa-gobject: timer: user_instance: add API to choose the type of event to read

### DIFF
--- a/src/ctl/elem-info.c
+++ b/src/ctl/elem-info.c
@@ -177,7 +177,7 @@ ALSACtlElemInfo *alsactl_elem_info_new(ALSACtlElemType elem_type, GError **error
         return NULL;
     }
 
-    return g_object_new(ALSACTL_TYPE_ELEM_INFO, "type", elem_type);
+    return g_object_new(ALSACTL_TYPE_ELEM_INFO, "type", elem_type, NULL);
 }
 
 /**

--- a/src/timer/alsatimer.map
+++ b/src/timer/alsatimer.map
@@ -32,6 +32,7 @@ ALSA_GOBJECT_0_0_0 {
     "alsatimer_user_instance_get_type";
     "alsatimer_user_instance_new";
     "alsatimer_user_instance_open";
+    "alsatimer_user_instance_choose_event_data_type";
     "alsatimer_user_instance_attach";
     "alsatimer_user_instance_attach_as_slave";
     "alsatimer_user_instance_get_info";

--- a/src/timer/user-instance.h
+++ b/src/timer/user-instance.h
@@ -77,15 +77,17 @@ ALSATimerUserInstance *alsatimer_user_instance_new();
 void alsatimer_user_instance_open(ALSATimerUserInstance *self, gint open_flag,
                                   GError **error);
 
+void alsatimer_user_instance_choose_event_data_type(ALSATimerUserInstance *self,
+                                        ALSATimerEventDataType event_data_type,
+                                        GError **error);
+
 void alsatimer_user_instance_attach(ALSATimerUserInstance *self,
                                     ALSATimerDeviceId *device_id,
-                                    ALSATimerEventDataType event_data_type,
                                     GError **error);
 
 void alsatimer_user_instance_attach_as_slave(ALSATimerUserInstance *self,
                                         ALSATimerSlaveClass slave_class,
                                         int slave_id,
-                                        ALSATimerEventDataType event_data_type,
                                         GError **error);
 
 void alsatimer_user_instance_get_info(ALSATimerUserInstance *self,

--- a/tests/alsatimer-user-instance
+++ b/tests/alsatimer-user-instance
@@ -14,6 +14,7 @@ props = ()
 methods = (
     'new',
     'open',
+    'choose_event_data_type',
     'attach',
     'attach_as_slave',
     'get_info',


### PR DESCRIPTION
Currently ALSATimer.UserInstance has any attach API to decide the type of
event to read. In design of ALSA Timer core, the attach API has two
functionality; to attach or to detach with error for absent timer device.
Current implementation has inconvenient for the functionality due to
execution to choose the type of event in advance. The execution fails
when the instance is already attached.

This commit adds a new API to choose the type of event and split the
call from any attach API.