### PR TITLE
alsa-gobject: seq: fix port creation API

### DIFF
--- a/src/rawmidi/substream-status.c
+++ b/src/rawmidi/substream-status.c
@@ -34,10 +34,10 @@ static void rawmidi_substream_status_get_property(GObject *obj, guint id,
 
     switch (id) {
     case RAWMIDI_SUBSTREAM_STATUS_PROP_AVAIL:
-        g_value_set_long(val, priv->status.avail);
+        g_value_set_uint64(val, priv->status.avail);
         break;
     case RAWMIDI_SUBSTREAM_STATUS_PROP_XRUN:
-        g_value_set_long(val, priv->status.xruns);
+        g_value_set_uint64(val, priv->status.xruns);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(obj, id, spec);
@@ -52,18 +52,18 @@ static void alsarawmidi_substream_status_class_init(ALSARawmidiSubstreamStatusCl
     gobject_class->get_property = rawmidi_substream_status_get_property;
 
     rawmidi_substream_status_props[RAWMIDI_SUBSTREAM_STATUS_PROP_AVAIL] =
-        g_param_spec_ulong("avail", "avail",
-               "The size of available space in intermediate buffer.",
-                          0, G_MAXULONG,
-                          0,
-                          G_PARAM_READABLE);
+        g_param_spec_uint64("avail", "avail",
+                            "The size of available space in intermediate buffer.",
+                            0, G_MAXUINT64,
+                            0,
+                            G_PARAM_READABLE);
 
     rawmidi_substream_status_props[RAWMIDI_SUBSTREAM_STATUS_PROP_XRUN] =
-        g_param_spec_ulong("xruns", "xruns",
-               "The count of XRUNs since the last query of status.",
-                           0, G_MAXULONG,
-                           0,
-                           G_PARAM_READABLE);
+        g_param_spec_uint64("xruns", "xruns",
+                            "The count of XRUNs since the last query of status.",
+                            0, G_MAXUINT64,
+                            0,
+                            G_PARAM_READABLE);
 
     g_object_class_install_properties(gobject_class,
                                       RAWMIDI_SUBSTREAM_STATUS_PROP_COUNT,

--- a/src/seq/alsaseq.map
+++ b/src/seq/alsaseq.map
@@ -45,6 +45,7 @@ ALSA_GOBJECT_0_0_0 {
     "alsaseq_user_client_set_info";
     "alsaseq_user_client_get_info";
     "alsaseq_user_client_create_port";
+    "alsaseq_user_client_create_port_at";
     "alsaseq_user_client_update_port";
     "alsaseq_user_client_delete_port";
     "alsaseq_user_client_set_pool";

--- a/src/seq/client-info.c
+++ b/src/seq/client-info.c
@@ -177,11 +177,11 @@ static void alsaseq_client_info_class_init(ALSASeqClientInfoClass *klass)
                          G_PARAM_READWRITE);
 
     seq_client_info_props[SEQ_CLIENT_INFO_PROP_PROCESS_ID] =
-        g_param_spec_long("process-id", "process-id",
-                          "The process ID for user client, otherwise -1.",
-                          G_MINLONG, G_MAXLONG,
-                          -1,
-                          G_PARAM_READABLE);
+        g_param_spec_int64("process-id", "process-id",
+                           "The process ID for user client, otherwise -1.",
+                           G_MININT64, G_MAXINT64,
+                           -1,
+                           G_PARAM_READABLE);
 
     g_object_class_install_properties(gobject_class,
                                       SEQ_CLIENT_INFO_PROP_COUNT,

--- a/src/seq/port-info.c
+++ b/src/seq/port-info.c
@@ -234,10 +234,8 @@ static void alsaseq_port_info_class_init(ALSASeqPortInfoClass *klass)
     seq_port_info_props[SEQ_PORT_INFO_PROP_TIME_QUEUE] =
         g_param_spec_uchar("queue-id", "queue-id",
                            "The numerical ID of queue to update timestamp "
-                           "when timestamp-overwrite property is set to "
-                           "ALSASeq.PortTstampOverwrite.TICK or "
-                           "ALSASeq.PortTstampOverwrite.REAL. One of "
-                           "ALSASeqSpecificQueueId is available as well.",
+                           "when timestamp-overwrite property is set to True. "
+                           "One of ALSASeqSpecificQueueId is available as well.",
                            0, G_MAXUINT8,
                            0,
                            G_PARAM_READWRITE);

--- a/src/seq/user-client.c
+++ b/src/seq/user-client.c
@@ -601,7 +601,7 @@ void alsaseq_user_client_operate_subscription(ALSASeqUserClient *self,
 /**
  * alsaseq_user_client_create_queue:
  * @self: A #ALSASeqUserClient.
- * @queue_info: The information of queue to add.
+ * @queue_info: (inout): The information of queue to add.
  * @error: A #GError.
  *
  * Create a new queue owned by the client. The content of information is updated
@@ -611,16 +611,17 @@ void alsaseq_user_client_operate_subscription(ALSASeqUserClient *self,
  * SNDRV_SEQ_IOCTL_CREATE_QUEUE command for ALSA sequencer character device.
  */
 void alsaseq_user_client_create_queue(ALSASeqUserClient *self,
-                                ALSASeqQueueInfo *queue_info, GError **error)
+                                      ALSASeqQueueInfo *const *queue_info,
+				      GError **error)
 {
     ALSASeqUserClientPrivate *priv;
     struct snd_seq_queue_info *info;
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
-    g_return_if_fail(ALSASEQ_IS_QUEUE_INFO(queue_info));
+    g_return_if_fail(ALSASEQ_IS_QUEUE_INFO(*queue_info));
     priv = alsaseq_user_client_get_instance_private(self);
 
-    seq_queue_info_refer_private(queue_info, &info);
+    seq_queue_info_refer_private(*queue_info, &info);
 
     if (ioctl(priv->fd, SNDRV_SEQ_IOCTL_CREATE_QUEUE, info) < 0)
         generate_error(error, errno);

--- a/src/seq/user-client.c
+++ b/src/seq/user-client.c
@@ -271,6 +271,35 @@ void alsaseq_user_client_create_port(ALSASeqUserClient *self,
 }
 
 /**
+ * alsaseq_user_client_create_port_at:
+ * @self: A #ALSASeqUserClient.
+ * @port_info: (inout): A #ALSASeqPortInfo.
+ * @port_id: The numerical ID of port to create.
+ * @error: A #GError.
+ *
+ * Create a port into the client with the given numerical port ID.
+ *
+ * The call of function executes ioctl(2) system call with
+ * SNDRV_SEQ_IOCTL_CREATE_PORT command for ALSA sequencer character device.
+ */
+void alsaseq_user_client_create_port_at(ALSASeqUserClient *self,
+                                        ALSASeqPortInfo *const *port_info,
+                                        guint8 port_id, GError **error)
+{
+    struct snd_seq_port_info *info;
+
+    g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
+    g_return_if_fail(ALSASEQ_IS_PORT_INFO(*port_info));
+
+    seq_port_info_refer_private(*port_info, &info);
+
+    info->addr.port = port_id;
+    info->flags |= SNDRV_SEQ_PORT_FLG_GIVEN_PORT;
+
+    alsaseq_user_client_create_port(self, *port_info, NULL, error);
+}
+
+/**
  * alsaseq_user_client_update_port:
  * @self: A #ALSASeqUserClient.
  * @port_info: A #ALSASeqPortInfo.

--- a/src/seq/user-client.c
+++ b/src/seq/user-client.c
@@ -239,8 +239,7 @@ void alsaseq_user_client_get_info(ALSASeqUserClient *self,
 /**
  * alsaseq_user_client_create_port:
  * @self: A #ALSASeqUserClient.
- * @port_info: A #ALSASeqPortInfo.
- * @port_id: (nullable): The numerical ID of port if specified.
+ * @port_info: (inout): A #ALSASeqPortInfo.
  * @error: A #GError.
  *
  * Create a port into the client.
@@ -249,23 +248,19 @@ void alsaseq_user_client_get_info(ALSASeqUserClient *self,
  * SNDRV_SEQ_IOCTL_CREATE_PORT command for ALSA sequencer character device.
  */
 void alsaseq_user_client_create_port(ALSASeqUserClient *self,
-                                     ALSASeqPortInfo *port_info,
-                                     const guint8 *port_id, GError **error)
+                                     ALSASeqPortInfo *const *port_info,
+                                     GError **error)
 {
     ALSASeqUserClientPrivate *priv;
     struct snd_seq_port_info *info;
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
-    g_return_if_fail(ALSASEQ_IS_PORT_INFO(port_info));
+    g_return_if_fail(ALSASEQ_IS_PORT_INFO(*port_info));
     priv = alsaseq_user_client_get_instance_private(self);
 
-    seq_port_info_refer_private(port_info, &info);
+    seq_port_info_refer_private(*port_info, &info);
 
     info->addr.client = priv->client_id;
-    if (port_id != NULL) {
-        info->addr.port = *port_id;
-        info->flags |= SNDRV_SEQ_PORT_FLG_GIVEN_PORT;
-    }
     if (ioctl(priv->fd, SNDRV_SEQ_IOCTL_CREATE_PORT, info) < 0)
         generate_error(error, errno);
 }
@@ -296,7 +291,7 @@ void alsaseq_user_client_create_port_at(ALSASeqUserClient *self,
     info->addr.port = port_id;
     info->flags |= SNDRV_SEQ_PORT_FLG_GIVEN_PORT;
 
-    alsaseq_user_client_create_port(self, *port_info, NULL, error);
+    alsaseq_user_client_create_port(self, port_info, error);
 }
 
 /**

--- a/src/seq/user-client.h
+++ b/src/seq/user-client.h
@@ -84,6 +84,9 @@ void alsaseq_user_client_get_info(ALSASeqUserClient *self,
 void alsaseq_user_client_create_port(ALSASeqUserClient *self,
                                      ALSASeqPortInfo *port_info,
                                      const guint8 *port_id, GError **error);
+void alsaseq_user_client_create_port_at(ALSASeqUserClient *self,
+                                        ALSASeqPortInfo *const *port_info,
+                                        guint8 port_id, GError **error);
 
 void alsaseq_user_client_update_port(ALSASeqUserClient *self,
                                      ALSASeqPortInfo *port_info,

--- a/src/seq/user-client.h
+++ b/src/seq/user-client.h
@@ -82,8 +82,8 @@ void alsaseq_user_client_get_info(ALSASeqUserClient *self,
                                   GError **error);
 
 void alsaseq_user_client_create_port(ALSASeqUserClient *self,
-                                     ALSASeqPortInfo *port_info,
-                                     const guint8 *port_id, GError **error);
+                                     ALSASeqPortInfo *const *port_info,
+                                     GError **error);
 void alsaseq_user_client_create_port_at(ALSASeqUserClient *self,
                                         ALSASeqPortInfo *const *port_info,
                                         guint8 port_id, GError **error);

--- a/src/seq/user-client.h
+++ b/src/seq/user-client.h
@@ -116,7 +116,8 @@ void alsaseq_user_client_operate_subscription(ALSASeqUserClient *self,
                                               GError **error);
 
 void alsaseq_user_client_create_queue(ALSASeqUserClient *self,
-                                ALSASeqQueueInfo *queue_info, GError **error);
+                                      ALSASeqQueueInfo *const *queue_info,
+                                      GError **error);
 void alsaseq_user_client_delete_queue(ALSASeqUserClient *self,
                                       guint queue_id, GError **error);
 void alsaseq_user_client_update_queue(ALSASeqUserClient *self,

--- a/tests/alsaseq-user-client
+++ b/tests/alsaseq-user-client
@@ -19,6 +19,7 @@ methods = (
     'set_info',
     'get_info',
     'create_port',
+    'create_port_at',
     'update_port',
     'delete_port',
     'set_pool',


### PR DESCRIPTION
ALSASeq.UserClient.create_port() has nullable argument for the numerical ID of port to use SNDRV_SEQ_PORT_FLG_GIVEN_PORT flag properly. However, the nullable is not inconvenient for PyGObject and causes SIGSEGV.

This patchset adds an alternative API, ALSASeq.UserClient.create_port_at() for the flag, then ALSASeq.UserClient.create_port() hs no argument for explicit port ID.

Additionally, this patchset includes some fixes for the other parts.