### PR TITLE
alsa-gobject: seq/timer: use (inout) annotation for API to retrieve status

### DIFF
--- a/src/seq/query.c
+++ b/src/seq/query.c
@@ -727,7 +727,7 @@ void alsaseq_get_queue_info_by_name(const gchar *name,
  * alsaseq_get_queue_status:
  * @queue_id: The numerical ID of queue, except for entries in
  *            ALSASeqSpecificQueueId.
- * @queue_status: (out): The current status of queue.
+ * @queue_status: (inout): The current status of queue.
  * @error: A #GError.
  *
  * Get current status of queue.
@@ -736,7 +736,8 @@ void alsaseq_get_queue_info_by_name(const gchar *name,
  * with SNDRV_SEQ_IOCTL_GET_QUEUE_STATUS command for ALSA sequencer character
  * device.
  */
-void alsaseq_get_queue_status(guint queue_id, ALSASeqQueueStatus **queue_status,
+void alsaseq_get_queue_status(guint queue_id,
+                              ALSASeqQueueStatus *const *queue_status,
                               GError **error)
 {
     struct snd_seq_queue_status *status;
@@ -754,16 +755,12 @@ void alsaseq_get_queue_status(guint queue_id, ALSASeqQueueStatus **queue_status,
         return;
     }
 
-    *queue_status = g_object_new(ALSASEQ_TYPE_QUEUE_STATUS, NULL);
+    g_return_if_fail(ALSASEQ_IS_QUEUE_STATUS(*queue_status));
     seq_queue_status_refer_private(*queue_status, &status);
 
     status->queue = (int)queue_id;
-    if (ioctl(fd, SNDRV_SEQ_IOCTL_GET_QUEUE_STATUS, status) < 0) {
+    if (ioctl(fd, SNDRV_SEQ_IOCTL_GET_QUEUE_STATUS, status) < 0)
         generate_error(error, errno);
-        close(fd);
-        g_object_unref(*queue_status);
-        return;
-    }
 
     close(fd);
 }

--- a/src/seq/query.h
+++ b/src/seq/query.h
@@ -49,7 +49,8 @@ void alsaseq_get_queue_info_by_name(const gchar *name,
                                     ALSASeqQueueInfo **queue_info,
                                     GError **error);
 
-void alsaseq_get_queue_status(guint queue_id, ALSASeqQueueStatus **queue_status,
+void alsaseq_get_queue_status(guint queue_id,
+                              ALSASeqQueueStatus *const *queue_status,
                               GError **error);
 
 G_END_DECLS

--- a/src/timer/query.c
+++ b/src/timer/query.c
@@ -220,7 +220,7 @@ void alsatimer_get_device_info(ALSATimerDeviceId *device_id,
 /**
  * alsatimer_get_device_status:
  * @device_id: A #ALSATimerDeviceId to identify the timer device.
- * @device_status: (out): The status of timer device.
+ * @device_status: (inout): The status of timer device.
  * @error: A #GError.
  *
  * Get the status of timer device.
@@ -229,7 +229,7 @@ void alsatimer_get_device_info(ALSATimerDeviceId *device_id,
  * with SNDRV_TIMER_IOCTL_GSTATUS command for ALSA timer character device.
  */
 void alsatimer_get_device_status(ALSATimerDeviceId *device_id,
-                                 ALSATimerDeviceStatus **device_status,
+                                 ALSATimerDeviceStatus *const *device_status,
                                  GError **error)
 {
     char *devnode;
@@ -237,6 +237,7 @@ void alsatimer_get_device_status(ALSATimerDeviceId *device_id,
     int fd;
 
     g_return_if_fail(device_id != NULL);
+    g_return_if_fail(ALSATIMER_IS_DEVICE_STATUS(*device_status));
 
     alsatimer_get_devnode(&devnode, error);
     if (*error != NULL)
@@ -249,7 +250,6 @@ void alsatimer_get_device_status(ALSATimerDeviceId *device_id,
         return;
     }
 
-    *device_status = g_object_new(ALSATIMER_TYPE_DEVICE_STATUS, NULL);
     timer_device_status_refer_private(*device_status, &status);
 
     status->tid = *device_id;

--- a/src/timer/query.h
+++ b/src/timer/query.h
@@ -25,7 +25,7 @@ void alsatimer_get_device_info(ALSATimerDeviceId *device_id,
                                GError **error);
 
 void alsatimer_get_device_status(ALSATimerDeviceId *device_id,
-                                 ALSATimerDeviceStatus **device_status,
+                                 ALSATimerDeviceStatus *const *device_status,
                                  GError **error);
 
 void alsatimer_set_device_params(ALSATimerDeviceId *device_id,

--- a/src/timer/user-instance.c
+++ b/src/timer/user-instance.c
@@ -301,7 +301,7 @@ void alsatimer_user_instance_set_params(ALSATimerUserInstance *self,
 /**
  * alsatimer_user_instance_get_status:
  * @self: A #ALSATimerUserInstance.
- * @instance_status: (out): A #ALSATimerInstanceStatus.
+ * @instance_status: (inout): A #ALSATimerInstanceStatus.
  * @error: A #GError.
  *
  * Get the latest status of instance.
@@ -310,8 +310,8 @@ void alsatimer_user_instance_set_params(ALSATimerUserInstance *self,
  * SNDRV_TIMER_IOCTL_STATUS command for ALSA timer character device.
  */
 void alsatimer_user_instance_get_status(ALSATimerUserInstance *self,
-                                    ALSATimerInstanceStatus **instance_status,
-                                    GError **error)
+                                ALSATimerInstanceStatus *const *instance_status,
+                                GError **error)
 {
     ALSATimerUserInstancePrivate *priv;
     struct snd_timer_status *status;
@@ -319,13 +319,11 @@ void alsatimer_user_instance_get_status(ALSATimerUserInstance *self,
     g_return_if_fail(ALSATIMER_IS_USER_INSTANCE(self));
     priv = alsatimer_user_instance_get_instance_private(self);
 
-    *instance_status = g_object_new(ALSATIMER_TYPE_INSTANCE_STATUS, NULL);
+    g_return_if_fail(ALSATIMER_IS_INSTANCE_STATUS(*instance_status));
     timer_instance_status_refer_private(*instance_status, &status);
 
-    if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_STATUS, status) < 0) {
+    if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_STATUS, status) < 0)
         generate_error(error, errno);
-        g_object_unref(*instance_status);
-    }
 }
 
 static gboolean timer_user_instance_check_src(GSource *gsrc)

--- a/src/timer/user-instance.h
+++ b/src/timer/user-instance.h
@@ -99,8 +99,8 @@ void alsatimer_user_instance_set_params(ALSATimerUserInstance *self,
                                 GError **error);
 
 void alsatimer_user_instance_get_status(ALSATimerUserInstance *self,
-                                    ALSATimerInstanceStatus **instance_status,
-                                    GError **error);
+                                ALSATimerInstanceStatus *const *instance_status,
+                                GError **error);
 
 void alsatimer_user_instance_create_source(ALSATimerUserInstance *self,
                                          GSource **gsrc, GError **error);


### PR DESCRIPTION
It's probable to retrieve status for something several times in runtime, and it's convenient for the runtime to use pre-allocated instance for the status.