### PR TITLE
alsa-gobject: seq/timer: add constructure for status object

### DIFF
--- a/src/seq/alsaseq.map
+++ b/src/seq/alsaseq.map
@@ -137,6 +137,7 @@ ALSA_GOBJECT_0_0_0 {
     "alsaseq_queue_info_new";
 
     "alsaseq_queue_status_get_type";
+    "alsaseq_queue_status_new";
     "alsaseq_queue_status_get_tick_time";
     "alsaseq_queue_status_get_real_time";
 

--- a/src/seq/queue-status.c
+++ b/src/seq/queue-status.c
@@ -86,6 +86,18 @@ static void alsaseq_queue_status_init(ALSASeqQueueStatus *self)
 }
 
 /**
+ * alsaseq_queue_status_new:
+ *
+ * Allocate and returns an instance of #ALSASeqQueueStatus.
+ *
+ * Returns: A #ALSASeqQueueStatus.
+ */
+ALSASeqQueueStatus *alsaseq_queue_status_new()
+{
+    return g_object_new(ALSASEQ_TYPE_QUEUE_STATUS, NULL);
+}
+
+/**
  * alsaseq_queue_status_get_tick_time:
  * @self: A #ALSASeqQueueStatus.
  * @tick_time: (out): The number of MIDI ticks.

--- a/src/seq/queue-status.h
+++ b/src/seq/queue-status.h
@@ -45,6 +45,8 @@ struct _ALSASeqQueueStatusClass {
 
 GType alsaseq_queue_status_get_type() G_GNUC_CONST;
 
+ALSASeqQueueStatus *alsaseq_queue_status_new();
+
 void alsaseq_queue_status_get_tick_time(ALSASeqQueueStatus *self,
                                         guint *tick_time);
 

--- a/src/timer/alsatimer.map
+++ b/src/timer/alsatimer.map
@@ -25,6 +25,7 @@ ALSA_GOBJECT_0_0_0 {
     "alsatimer_device_info_get_type";
 
     "alsatimer_device_status_get_type";
+    "alsatimer_device_status_new";
 
     "alsatimer_device_params_get_type";
     "alsatimer_device_params_new";

--- a/src/timer/alsatimer.map
+++ b/src/timer/alsatimer.map
@@ -53,6 +53,7 @@ ALSA_GOBJECT_0_0_0 {
     "alsatimer_instance_params_get_event_filter";
 
     "alsatimer_instance_status_get_type";
+    "alsatimer_instance_status_new";
     "alsatimer_instance_status_get_tstamp";
 
     "alsatimer_event_data_tick_get_type";

--- a/src/timer/device-status.c
+++ b/src/timer/device-status.c
@@ -87,6 +87,18 @@ static void alsatimer_device_status_init(ALSATimerDeviceStatus *self)
     return;
 }
 
+/**
+ * alsatimer_device_status_new:
+ *
+ * Allocate and return an instance of #ALSATimerDeviceStatus.
+ *
+ * Returns: A #ALSATimerDeviceStatus.
+ */
+ALSATimerDeviceStatus *alsatimer_device_status_new()
+{
+    return g_object_new(ALSATIMER_TYPE_DEVICE_STATUS, NULL);
+}
+
 void timer_device_status_refer_private(ALSATimerDeviceStatus *self,
                                        struct snd_timer_gstatus **status)
 {

--- a/src/timer/device-status.h
+++ b/src/timer/device-status.h
@@ -45,6 +45,8 @@ struct _ALSATimerDeviceStatusClass {
 
 GType alsatimer_device_status_get_type() G_GNUC_CONST;
 
+ALSATimerDeviceStatus *alsatimer_device_status_new();
+
 G_END_DECLS
 
 #endif

--- a/src/timer/instance-status.c
+++ b/src/timer/instance-status.c
@@ -125,6 +125,18 @@ void alsatimer_instance_status_get_tstamp(ALSATimerInstanceStatus *self,
     *tstamp = (const gint64 *)&priv->tstamp;
 }
 
+/**
+ * alsatimer_instance_status_new:
+ *
+ * Allocate and return an instance of #ALSATimerInstanceStatus.
+ *
+ * Returns: A #ALSATimerInstanceStatus.
+ */
+ALSATimerInstanceStatus *alsatimer_instance_status_new()
+{
+    return g_object_new(ALSATIMER_TYPE_INSTANCE_STATUS, NULL);
+}
+
 void timer_instance_status_refer_private(ALSATimerInstanceStatus *self,
                                          struct snd_timer_status **status)
 {

--- a/src/timer/instance-status.h
+++ b/src/timer/instance-status.h
@@ -45,6 +45,8 @@ struct _ALSATimerInstanceStatusClass {
 
 GType alsatimer_instance_status_get_type() G_GNUC_CONST;
 
+ALSATimerInstanceStatus *alsatimer_instance_status_new();
+
 void alsatimer_instance_status_get_tstamp(ALSATimerInstanceStatus *self,
                                           const gint64 *tstamp[2]);
 

--- a/tests/alsaseq-queue-status
+++ b/tests/alsaseq-queue-status
@@ -16,6 +16,7 @@ props = (
     'running',
 )
 methods = (
+    'new',
     'get_tick_time',
     'get_real_time',
 )

--- a/tests/alsatimer-device-status
+++ b/tests/alsatimer-device-status
@@ -15,7 +15,9 @@ props = (
     'resolution-numerator',
     'resolution-denominator',
 )
-methods = ()
+methods = (
+    'new',
+)
 signals = ()
 
 if not test(target, props, methods, signals):

--- a/tests/alsatimer-device-status
+++ b/tests/alsatimer-device-status
@@ -10,7 +10,11 @@ gi.require_version('ALSATimer', '0.0')
 from gi.repository import ALSATimer
 
 target = ALSATimer.DeviceStatus()
-props = ()
+props = (
+    'resolution',
+    'resolution-numerator',
+    'resolution-denominator',
+)
 methods = ()
 signals = ()
 

--- a/tests/alsatimer-instance-status
+++ b/tests/alsatimer-instance-status
@@ -17,6 +17,7 @@ props = (
     'queue-size',
 )
 methods = (
+    'new',
     'get_tstamp',
 )
 signals = ()


### PR DESCRIPTION
In patchset at #38, I forgot to add constructors for issued status object because no function call returns the instance of object. This patchset adds the constructors.