### PR TITLE
alsa-gobject: timer/seq: use const qualifier to self argument for getter API

### DIFF
--- a/src/seq/event-data-connect.c
+++ b/src/seq/event-data-connect.c
@@ -25,7 +25,7 @@ G_DEFINE_BOXED_TYPE(ALSASeqEventDataConnect, alsaseq_event_data_connect, seq_eve
  *
  * Get the source of connection event.
  */
-void alsaseq_event_data_connect_get_src(ALSASeqEventDataConnect *self,
+void alsaseq_event_data_connect_get_src(const ALSASeqEventDataConnect *self,
                                         const ALSASeqAddr **src)
 {
     *src = &self->sender;
@@ -51,7 +51,7 @@ void alsaseq_event_data_connect_set_src(ALSASeqEventDataConnect *self,
  *
  * Get the destination of connection event.
  */
-void alsaseq_event_data_connect_get_dst(ALSASeqEventDataConnect *self,
+void alsaseq_event_data_connect_get_dst(const ALSASeqEventDataConnect *self,
                                         const ALSASeqAddr **dst)
 {
     *dst = &self->dest;

--- a/src/seq/event-data-connect.h
+++ b/src/seq/event-data-connect.h
@@ -17,12 +17,12 @@ typedef struct snd_seq_connect ALSASeqEventDataConnect;
 
 GType alsaseq_event_data_connect_get_type() G_GNUC_CONST;
 
-void alsaseq_event_data_connect_get_src(ALSASeqEventDataConnect *self,
+void alsaseq_event_data_connect_get_src(const ALSASeqEventDataConnect *self,
                                         const ALSASeqAddr **src);
 void alsaseq_event_data_connect_set_src(ALSASeqEventDataConnect *self,
                                         const ALSASeqAddr *src);
 
-void alsaseq_event_data_connect_get_dst(ALSASeqEventDataConnect *self,
+void alsaseq_event_data_connect_get_dst(const ALSASeqEventDataConnect *self,
                                         const ALSASeqAddr **dst);
 void alsaseq_event_data_connect_set_dst(ALSASeqEventDataConnect *self,
                                         const ALSASeqAddr *dst);

--- a/src/seq/event-data-ctl.c
+++ b/src/seq/event-data-ctl.c
@@ -25,7 +25,7 @@ G_DEFINE_BOXED_TYPE(ALSASeqEventDataCtl, alsaseq_event_data_ctl, seq_event_data_
  *
  * Get the value of channel for the control event.
  */
-void alsaseq_event_data_ctl_get_channel(ALSASeqEventDataCtl *self,
+void alsaseq_event_data_ctl_get_channel(const ALSASeqEventDataCtl *self,
                                         guint8 *channel)
 {
     *channel = self->channel;
@@ -51,7 +51,8 @@ void alsaseq_event_data_ctl_set_channel(ALSASeqEventDataCtl *self,
  *
  * Get the parameter for the control event.
  */
-void alsaseq_event_data_ctl_get_param(ALSASeqEventDataCtl *self, guint *param)
+void alsaseq_event_data_ctl_get_param(const ALSASeqEventDataCtl *self,
+                                      guint *param)
 {
     *param = self->param;
 }
@@ -75,7 +76,8 @@ void alsaseq_event_data_ctl_set_param(ALSASeqEventDataCtl *self, guint param)
  *
  * Get the value for the control event.
  */
-void alsaseq_event_data_ctl_get_value(ALSASeqEventDataCtl *self, gint *value)
+void alsaseq_event_data_ctl_get_value(const ALSASeqEventDataCtl *self,
+                                      gint *value)
 {
     *value = self->param;
 }

--- a/src/seq/event-data-ctl.h
+++ b/src/seq/event-data-ctl.h
@@ -17,15 +17,17 @@ typedef struct snd_seq_ev_ctrl ALSASeqEventDataCtl;
 
 GType alsaseq_event_data_ctl_get_type() G_GNUC_CONST;
 
-void alsaseq_event_data_ctl_get_channel(ALSASeqEventDataCtl *self,
+void alsaseq_event_data_ctl_get_channel(const ALSASeqEventDataCtl *self,
                                         guint8 *channel);
 void alsaseq_event_data_ctl_set_channel(ALSASeqEventDataCtl *self,
                                         guint8 channel);
 
-void alsaseq_event_data_ctl_get_param(ALSASeqEventDataCtl *self, guint *param);
+void alsaseq_event_data_ctl_get_param(const ALSASeqEventDataCtl *self,
+                                      guint *param);
 void alsaseq_event_data_ctl_set_param(ALSASeqEventDataCtl *self, guint param);
 
-void alsaseq_event_data_ctl_get_value(ALSASeqEventDataCtl *self, gint *value);
+void alsaseq_event_data_ctl_get_value(const ALSASeqEventDataCtl *self,
+                                      gint *value);
 void alsaseq_event_data_ctl_set_value(ALSASeqEventDataCtl *self, gint value);
 
 G_END_DECLS

--- a/src/seq/event-data-note.c
+++ b/src/seq/event-data-note.c
@@ -25,7 +25,7 @@ G_DEFINE_BOXED_TYPE(ALSASeqEventDataNote, alsaseq_event_data_note, seq_event_dat
  *
  * Get the value of channel in the note event.
  */
-void alsaseq_event_data_note_get_channel(ALSASeqEventDataNote *self,
+void alsaseq_event_data_note_get_channel(const ALSASeqEventDataNote *self,
                                          guint8 *channel)
 {
     *channel = self->channel;
@@ -51,7 +51,8 @@ void alsaseq_event_data_note_set_channel(ALSASeqEventDataNote *self,
  *
  * Get the value of note in the note event.
  */
-void alsaseq_event_data_note_get_note(ALSASeqEventDataNote *self, guint8 *note)
+void alsaseq_event_data_note_get_note(const ALSASeqEventDataNote *self,
+                                      guint8 *note)
 {
     *note = self->note;
 }
@@ -75,7 +76,7 @@ void alsaseq_event_data_note_set_note(ALSASeqEventDataNote *self, guint8 note)
  *
  * Get the value of velocity in the note event.
  */
-void alsaseq_event_data_note_get_velocity(ALSASeqEventDataNote *self,
+void alsaseq_event_data_note_get_velocity(const ALSASeqEventDataNote *self,
                                           guint8 *velocity)
 {
     *velocity = self->velocity;
@@ -101,7 +102,7 @@ void alsaseq_event_data_note_set_velocity(ALSASeqEventDataNote *self,
  *
  * Get the value of off-velocity in the note event.
  */
-void alsaseq_event_data_note_get_off_velocity(ALSASeqEventDataNote *self,
+void alsaseq_event_data_note_get_off_velocity(const ALSASeqEventDataNote *self,
                                               guint8 *off_velocity)
 {
     *off_velocity = self->off_velocity;
@@ -127,7 +128,7 @@ void alsaseq_event_data_note_set_off_velocity(ALSASeqEventDataNote *self,
  *
  * Get the value of duration in the note event.
  */
-void alsaseq_event_data_note_get_duration(ALSASeqEventDataNote *self,
+void alsaseq_event_data_note_get_duration(const ALSASeqEventDataNote *self,
                                           guint8 *duration)
 {
     *duration = self->duration;

--- a/src/seq/event-data-note.h
+++ b/src/seq/event-data-note.h
@@ -15,25 +15,26 @@ typedef struct snd_seq_ev_note ALSASeqEventDataNote;
 
 GType alsaseq_event_data_note_get_type() G_GNUC_CONST;
 
-void alsaseq_event_data_note_get_channel(ALSASeqEventDataNote *self,
+void alsaseq_event_data_note_get_channel(const ALSASeqEventDataNote *self,
                                          guint8 *channel);
 void alsaseq_event_data_note_set_channel(ALSASeqEventDataNote *self,
                                          guint8 channel);
 
-void alsaseq_event_data_note_get_note(ALSASeqEventDataNote *self, guint8 *note);
+void alsaseq_event_data_note_get_note(const ALSASeqEventDataNote *self,
+                                      guint8 *note);
 void alsaseq_event_data_note_set_note(ALSASeqEventDataNote *self, guint8 note);
 
-void alsaseq_event_data_note_get_velocity(ALSASeqEventDataNote *self,
+void alsaseq_event_data_note_get_velocity(const ALSASeqEventDataNote *self,
                                           guint8 *velocity);
 void alsaseq_event_data_note_set_velocity(ALSASeqEventDataNote *self,
                                           guint8 velocity);
 
-void alsaseq_event_data_note_get_off_velocity(ALSASeqEventDataNote *self,
+void alsaseq_event_data_note_get_off_velocity(const ALSASeqEventDataNote *self,
                                               guint8 *off_velocity);
 void alsaseq_event_data_note_set_off_velocity(ALSASeqEventDataNote *self,
                                               guint8 off_velocity);
 
-void alsaseq_event_data_note_get_duration(ALSASeqEventDataNote *self,
+void alsaseq_event_data_note_get_duration(const ALSASeqEventDataNote *self,
                                           guint8 *duration);
 void alsaseq_event_data_note_set_duration(ALSASeqEventDataNote *self,
                                           guint8 duration);

--- a/src/seq/event-data-queue.c
+++ b/src/seq/event-data-queue.c
@@ -26,7 +26,7 @@ G_DEFINE_BOXED_TYPE(ALSASeqEventDataQueue, alsaseq_event_data_queue, seq_event_d
  *
  * Get the numerical ID of queue for the event.
  */
-void alsaseq_event_data_queue_get_queue_id(ALSASeqEventDataQueue *self,
+void alsaseq_event_data_queue_get_queue_id(const ALSASeqEventDataQueue *self,
                                            guint8 *queue_id)
 {
     *queue_id = self->queue;
@@ -52,7 +52,7 @@ void alsaseq_event_data_queue_set_queue_id(ALSASeqEventDataQueue *self,
  *
  * Get the value as param of the queue event.
  */
-void alsaseq_event_data_queue_get_value_param(ALSASeqEventDataQueue *self,
+void alsaseq_event_data_queue_get_value_param(const ALSASeqEventDataQueue *self,
                                               gint *value)
 {
     *value = self->param.value;
@@ -78,7 +78,7 @@ void alsaseq_event_data_queue_set_value_param(ALSASeqEventDataQueue *self,
  *
  * Get the timestamp as param of the queue event.
  */
-void alsaseq_event_data_queue_get_tstamp_param(ALSASeqEventDataQueue *self,
+void alsaseq_event_data_queue_get_tstamp_param(const ALSASeqEventDataQueue *self,
                                                const ALSASeqTstamp **tstamp)
 {
     *tstamp = &self->param.time;
@@ -104,7 +104,7 @@ void alsaseq_event_data_queue_set_tstamp_param(ALSASeqEventDataQueue *self,
  *
  * Get the position as param of the queue event.
  */
-void alsaseq_event_data_queue_get_position_param(ALSASeqEventDataQueue *self,
+void alsaseq_event_data_queue_get_position_param(const ALSASeqEventDataQueue *self,
                                                  guint *position)
 {
     *position = self->param.position;
@@ -132,7 +132,7 @@ void alsaseq_event_data_queue_set_position_param(ALSASeqEventDataQueue *self,
  * Refer to numerator and denominator of fraction for skew as the parameter of
  * queue event.
  */
-void alsaseq_event_data_queue_get_skew_param(ALSASeqEventDataQueue *self,
+void alsaseq_event_data_queue_get_skew_param(const ALSASeqEventDataQueue *self,
                                              const guint *skew[2])
 {
     // MEMO: I wish 32-bit storage size is aligned to 32 bit offset in all of
@@ -164,7 +164,7 @@ void alsaseq_event_data_queue_set_skew_param(ALSASeqEventDataQueue *self,
  *
  * Refer to two quadlets as the parameter of queue event.
  */
-void alsaseq_event_data_queue_get_quadlet_param(ALSASeqEventDataQueue *self,
+void alsaseq_event_data_queue_get_quadlet_param(const ALSASeqEventDataQueue *self,
                                                 const guint32 *quadlets[2])
 {
     *quadlets = self->param.d32;
@@ -192,7 +192,7 @@ void alsaseq_event_data_queue_set_quadlet_param(ALSASeqEventDataQueue *self,
  *
  * Refer to eight bytes as the parameter of queue event.
  */
-void alsaseq_event_data_queue_get_byte_param(ALSASeqEventDataQueue *self,
+void alsaseq_event_data_queue_get_byte_param(const ALSASeqEventDataQueue *self,
                                              const guint8 *bytes[8])
 {
     *bytes = self->param.d8;

--- a/src/seq/event-data-queue.h
+++ b/src/seq/event-data-queue.h
@@ -17,37 +17,37 @@ typedef struct snd_seq_ev_queue_control ALSASeqEventDataQueue;
 
 GType alsaseq_event_data_queue_get_type() G_GNUC_CONST;
 
-void alsaseq_event_data_queue_get_queue_id(ALSASeqEventDataQueue *self,
+void alsaseq_event_data_queue_get_queue_id(const ALSASeqEventDataQueue *self,
                                            guint8 *queue_id);
 void alsaseq_event_data_queue_set_queue_id(ALSASeqEventDataQueue *self,
                                            guint8 queue_id);
 
-void alsaseq_event_data_queue_get_value_param(ALSASeqEventDataQueue *self,
+void alsaseq_event_data_queue_get_value_param(const ALSASeqEventDataQueue *self,
                                               gint *value);
 void alsaseq_event_data_queue_set_value_param(ALSASeqEventDataQueue *self,
                                               gint value);
 
-void alsaseq_event_data_queue_get_tstamp_param(ALSASeqEventDataQueue *self,
+void alsaseq_event_data_queue_get_tstamp_param(const ALSASeqEventDataQueue *self,
                                                const ALSASeqTstamp **tstamp);
 void alsaseq_event_data_queue_set_tstamp_param(ALSASeqEventDataQueue *self,
                                                const ALSASeqTstamp *tstamp);
 
-void alsaseq_event_data_queue_get_position_param(ALSASeqEventDataQueue *self,
+void alsaseq_event_data_queue_get_position_param(const ALSASeqEventDataQueue *self,
                                                  guint *position);
 void alsaseq_event_data_queue_set_position_param(ALSASeqEventDataQueue *self,
                                                  guint position);
 
-void alsaseq_event_data_queue_get_skew_param(ALSASeqEventDataQueue *self,
+void alsaseq_event_data_queue_get_skew_param(const ALSASeqEventDataQueue *self,
                                              const guint *skew[2]);
 void alsaseq_event_data_queue_set_skew_param(ALSASeqEventDataQueue *self,
                                              const guint skew[2]);
 
-void alsaseq_event_data_queue_get_quadlet_param(ALSASeqEventDataQueue *self,
+void alsaseq_event_data_queue_get_quadlet_param(const ALSASeqEventDataQueue *self,
                                                 const guint32 *quadlets[2]);
 void alsaseq_event_data_queue_set_quadlet_param(ALSASeqEventDataQueue *self,
                                                 const guint32 quadlets[2]);
 
-void alsaseq_event_data_queue_get_byte_param(ALSASeqEventDataQueue *self,
+void alsaseq_event_data_queue_get_byte_param(const ALSASeqEventDataQueue *self,
                                              const guint8 *bytes[8]);
 void alsaseq_event_data_queue_set_byte_param(ALSASeqEventDataQueue *self,
                                              const guint8 bytes[8]);

--- a/src/seq/event-data-result.c
+++ b/src/seq/event-data-result.c
@@ -25,7 +25,7 @@ G_DEFINE_BOXED_TYPE(ALSASeqEventDataResult, alsaseq_event_data_result, seq_event
  *
  * Get the type of event in which the data results.
  */
-void alsaseq_event_data_result_get_event(ALSASeqEventDataResult *self,
+void alsaseq_event_data_result_get_event(const ALSASeqEventDataResult *self,
                                          ALSASeqEventType *event_type)
 {
     *event_type = (ALSASeqEventType)self->event;
@@ -51,7 +51,7 @@ void alsaseq_event_data_result_set_event(ALSASeqEventDataResult *self,
  *
  * Get the status of event.
  */
-void alsaseq_event_data_result_get_result(ALSASeqEventDataResult *self,
+void alsaseq_event_data_result_get_result(const ALSASeqEventDataResult *self,
                                           gint *result)
 {
     *result = self->result;

--- a/src/seq/event-data-result.h
+++ b/src/seq/event-data-result.h
@@ -17,12 +17,12 @@ typedef struct snd_seq_result ALSASeqEventDataResult;
 
 GType alsaseq_event_data_result_get_type() G_GNUC_CONST;
 
-void alsaseq_event_data_result_get_event(ALSASeqEventDataResult *self,
+void alsaseq_event_data_result_get_event(const ALSASeqEventDataResult *self,
                                          ALSASeqEventType *event_type);
 void alsaseq_event_data_result_set_event(ALSASeqEventDataResult *self,
                                          ALSASeqEventType event_type);
 
-void alsaseq_event_data_result_get_result(ALSASeqEventDataResult *self,
+void alsaseq_event_data_result_get_result(const ALSASeqEventDataResult *self,
                                           gint *result);
 void alsaseq_event_data_result_set_result(ALSASeqEventDataResult *self,
                                           gint result);

--- a/src/seq/queue-timer-data-alsa.c
+++ b/src/seq/queue-timer-data-alsa.c
@@ -25,7 +25,7 @@ G_DEFINE_BOXED_TYPE(ALSASeqQueueTimerDataAlsa, alsaseq_queue_timer_data_alsa, se
  *
  * Refer to the device ID of timer which drives the queue.
  */
-void alsaseq_queue_timer_data_alsa_get_device_id(ALSASeqQueueTimerDataAlsa *self,
+void alsaseq_queue_timer_data_alsa_get_device_id(const ALSASeqQueueTimerDataAlsa *self,
                                         const ALSATimerDeviceId **device_id)
 {
     *device_id = (ALSATimerDeviceId *)&self->device_id;
@@ -51,7 +51,7 @@ void alsaseq_queue_timer_data_alsa_set_device_id(ALSASeqQueueTimerDataAlsa *self
  *
  * Get the resolution of timer which drives the queue.
  */
-void alsaseq_queue_timer_data_alsa_get_resolution(ALSASeqQueueTimerDataAlsa *self,
+void alsaseq_queue_timer_data_alsa_get_resolution(const ALSASeqQueueTimerDataAlsa *self,
                                                   guint *resolution)
 {
     *resolution = self->resolution;

--- a/src/seq/queue-timer-data-alsa.h
+++ b/src/seq/queue-timer-data-alsa.h
@@ -20,12 +20,12 @@ typedef struct {
 
 GType alsaseq_queue_timer_data_alsa_get_type() G_GNUC_CONST;
 
-void alsaseq_queue_timer_data_alsa_get_device_id(ALSASeqQueueTimerDataAlsa *self,
+void alsaseq_queue_timer_data_alsa_get_device_id(const ALSASeqQueueTimerDataAlsa *self,
                                         const ALSATimerDeviceId **device_id);
 void alsaseq_queue_timer_data_alsa_set_device_id(ALSASeqQueueTimerDataAlsa *self,
                                         const ALSATimerDeviceId *device_id);
 
-void alsaseq_queue_timer_data_alsa_get_resolution(ALSASeqQueueTimerDataAlsa *self,
+void alsaseq_queue_timer_data_alsa_get_resolution(const ALSASeqQueueTimerDataAlsa *self,
                                                   guint *resolution);
 void alsaseq_queue_timer_data_alsa_set_resolution(ALSASeqQueueTimerDataAlsa *self,
                                                   guint resolution);

--- a/src/seq/tstamp.c
+++ b/src/seq/tstamp.c
@@ -25,7 +25,7 @@ G_DEFINE_BOXED_TYPE(ALSASeqTstamp, alsaseq_tstamp, seq_tstamp_copy, g_free)
  *
  * Get time as MIDI ticks.
  */
-void alsaseq_tstamp_get_tick_time(ALSASeqTstamp *self, guint32 *tick_time)
+void alsaseq_tstamp_get_tick_time(const ALSASeqTstamp *self, guint32 *tick_time)
 {
     *tick_time = self->tick;
 }
@@ -50,7 +50,8 @@ void alsaseq_tstamp_set_tick_time(ALSASeqTstamp *self, const guint32 tick_time)
  *
  * Refer to the time as wall-clock time.
  */
-void alsaseq_tstamp_get_real_time(ALSASeqTstamp *self, const guint32 *real_time[2])
+void alsaseq_tstamp_get_real_time(const ALSASeqTstamp *self,
+                                  const guint32 *real_time[2])
 {
     // MEMO: I wish 32-bit storage size is aligned to 32 bit offset in all of
     // supported ABIs.

--- a/src/seq/tstamp.h
+++ b/src/seq/tstamp.h
@@ -15,10 +15,11 @@ typedef union snd_seq_timestamp ALSASeqTstamp;
 
 GType alsaseq_tstamp_get_type() G_GNUC_CONST;
 
-void alsaseq_tstamp_get_tick_time(ALSASeqTstamp *self, guint32 *tick_time);
+void alsaseq_tstamp_get_tick_time(const ALSASeqTstamp *self, guint32 *tick_time);
 void alsaseq_tstamp_set_tick_time(ALSASeqTstamp *self, const guint32 tick_time);
 
-void alsaseq_tstamp_get_real_time(ALSASeqTstamp *self, const guint32 *real_time[2]);
+void alsaseq_tstamp_get_real_time(const ALSASeqTstamp *self,
+                                  const guint32 *real_time[2]);
 void alsaseq_tstamp_set_real_time(ALSASeqTstamp *self, const guint32 real_time[2]);
 
 G_END_DECLS

--- a/src/timer/event-data-tick.c
+++ b/src/timer/event-data-tick.c
@@ -27,7 +27,7 @@ G_DEFINE_BOXED_TYPE(ALSATimerEventDataTick, alsatimer_event_data_tick, timer_eve
  *
  * Get the resolution of tick event.
  */
-void alsatimer_event_data_tick_get_resolution(ALSATimerEventDataTick *self,
+void alsatimer_event_data_tick_get_resolution(const ALSATimerEventDataTick *self,
                                               guint *resolution)
 {
     *resolution = self->resolution;
@@ -40,7 +40,7 @@ void alsatimer_event_data_tick_get_resolution(ALSATimerEventDataTick *self,
  *
  * Get the tick count since the last event.
  */
-void alsatimer_event_data_tick_get_ticks(ALSATimerEventDataTick *self,
+void alsatimer_event_data_tick_get_ticks(const ALSATimerEventDataTick *self,
                                          guint *ticks)
 {
     *ticks = self->ticks;

--- a/src/timer/event-data-tick.h
+++ b/src/timer/event-data-tick.h
@@ -15,10 +15,10 @@ typedef struct snd_timer_read ALSATimerEventDataTick;
 
 GType alsatimer_event_data_tick_get_type() G_GNUC_CONST;
 
-void alsatimer_event_data_tick_get_resolution(ALSATimerEventDataTick *self,
+void alsatimer_event_data_tick_get_resolution(const ALSATimerEventDataTick *self,
                                               guint *resolution);
 
-void alsatimer_event_data_tick_get_ticks(ALSATimerEventDataTick *self,
+void alsatimer_event_data_tick_get_ticks(const ALSATimerEventDataTick *self,
                                          guint *ticks);
 
 G_END_DECLS

--- a/src/timer/event-data-tstamp.c
+++ b/src/timer/event-data-tstamp.c
@@ -27,7 +27,7 @@ G_DEFINE_BOXED_TYPE(ALSATimerEventDataTstamp, alsatimer_event_data_tstamp, timer
  *
  * Get the kind of event for the timestamp event.
  */
-void alsatimer_event_data_tstamp_get_event(ALSATimerEventDataTstamp *self,
+void alsatimer_event_data_tstamp_get_event(const ALSATimerEventDataTstamp *self,
                                            ALSATimerEventType *event)
 {
     *event = (ALSATimerEventType)self->event;
@@ -42,7 +42,7 @@ void alsatimer_event_data_tstamp_get_event(ALSATimerEventDataTstamp *self,
  *
  * Get the seconds and nanoseconds part for the timestamp event.
  */
-void alsatimer_event_data_tstamp_get_tstamp(ALSATimerEventDataTstamp *self,
+void alsatimer_event_data_tstamp_get_tstamp(const ALSATimerEventDataTstamp *self,
                                             gint64 *const tstamp[2])
 {
     (*tstamp)[0] = (gint64)self->tstamp.tv_sec;
@@ -56,7 +56,7 @@ void alsatimer_event_data_tstamp_get_tstamp(ALSATimerEventDataTstamp *self,
  *
  * Get the value depending on the type of timestamp event.
  */
-void alsatimer_event_data_tstamp_get_val(ALSATimerEventDataTstamp *self,
+void alsatimer_event_data_tstamp_get_val(const ALSATimerEventDataTstamp *self,
                                          guint *val)
 {
     *val = self->val;

--- a/src/timer/event-data-tstamp.h
+++ b/src/timer/event-data-tstamp.h
@@ -17,13 +17,13 @@ typedef struct snd_timer_tread ALSATimerEventDataTstamp;
 
 GType alsatimer_event_data_tstamp_get_type() G_GNUC_CONST;
 
-void alsatimer_event_data_tstamp_get_event(ALSATimerEventDataTstamp *self,
+void alsatimer_event_data_tstamp_get_event(const ALSATimerEventDataTstamp *self,
                                            ALSATimerEventType *event);
 
-void alsatimer_event_data_tstamp_get_tstamp(ALSATimerEventDataTstamp *self,
+void alsatimer_event_data_tstamp_get_tstamp(const ALSATimerEventDataTstamp *self,
                                             gint64 *const tstamp[2]);
 
-void alsatimer_event_data_tstamp_get_val(ALSATimerEventDataTstamp *self,
+void alsatimer_event_data_tstamp_get_val(const ALSATimerEventDataTstamp *self,
                                          guint *val);
 
 G_END_DECLS


### PR DESCRIPTION
In ALSATimer and ALSASeq, some methods have prototype such that self argument don't have const qualifier even if it's getter method.

This patchset adds const qualifier to the methods.