### PR TITLE
alsa-gobject: seq: use guint8 for the numerical ID of client/port/queue

### DIFF
--- a/src/seq/client-info.c
+++ b/src/seq/client-info.c
@@ -44,7 +44,7 @@ static void seq_client_info_set_property(GObject *obj, guint id,
 
     switch (id) {
     case SEQ_CLIENT_INFO_PROP_CLIENT_ID:
-        priv->info.client = g_value_get_int(val);
+        priv->info.client = (int)g_value_get_uchar(val);
         break;
     case SEQ_CLIENT_INFO_PROP_CLIENT_TYPE:
         priv->info.type = (snd_seq_client_type_t)g_value_get_enum(val);
@@ -79,7 +79,7 @@ static void seq_client_info_get_property(GObject *obj, guint id, GValue *val,
 
     switch (id) {
     case SEQ_CLIENT_INFO_PROP_CLIENT_ID:
-        g_value_set_int(val, priv->info.client);
+        g_value_set_uchar(val, (guint8)priv->info.client);
         break;
     case SEQ_CLIENT_INFO_PROP_CLIENT_TYPE:
         g_value_set_enum(val, (ALSASeqClientType)priv->info.type);
@@ -121,13 +121,13 @@ static void alsaseq_client_info_class_init(ALSASeqClientInfoClass *klass)
     gobject_class->get_property = seq_client_info_get_property;
 
     seq_client_info_props[SEQ_CLIENT_INFO_PROP_CLIENT_ID] =
-        g_param_spec_int("client-id", "client-id",
-                         "The numerical ID of client. One of "
-                         "ALSASeqSpecificClientId is available as well as "
-                         "any numerical value.",
-                         0, G_MAXINT,
-                         0,
-                         G_PARAM_READWRITE);
+        g_param_spec_uchar("client-id", "client-id",
+                           "The numerical ID of client. One of "
+                           "ALSASeqSpecificClientId is available as well as "
+                           "any numerical value.",
+                           0, G_MAXUINT8,
+                           0,
+                           G_PARAM_READWRITE);
 
     seq_client_info_props[SEQ_CLIENT_INFO_PROP_CLIENT_TYPE] =
         g_param_spec_enum("type", "type",

--- a/src/seq/client-pool.c
+++ b/src/seq/client-pool.c
@@ -69,7 +69,7 @@ static void seq_client_pool_get_property(GObject *obj, guint id, GValue *val,
 
     switch (id) {
     case SEQ_CLIENT_POOL_PROP_CLIENT_ID:
-        g_value_set_int(val, priv->pool.client);
+        g_value_set_uchar(val, (guint8)priv->pool.client);
         break;
     case SEQ_CLIENT_POOL_PROP_OUTPUT_POOL:
         g_value_set_int(val, priv->pool.output_pool);
@@ -100,13 +100,13 @@ static void alsaseq_client_pool_class_init(ALSASeqClientPoolClass *klass)
     gobject_class->get_property = seq_client_pool_get_property;
 
     seq_client_pool_props[SEQ_CLIENT_POOL_PROP_CLIENT_ID] =
-        g_param_spec_int("client-id", "client-id",
-                         "The numerical ID of client. One of "
-                         "ALSASeqSpecificClientId is available as well as "
-                         "any numerical value.",
-                         0, G_MAXINT,
-                         0,
-                         G_PARAM_READABLE);
+        g_param_spec_uchar("client-id", "client-id",
+                           "The numerical ID of client. One of "
+                           "ALSASeqSpecificClientId is available as well as "
+                           "any numerical value.",
+                           0, G_MAXUINT8,
+                           0,
+                           G_PARAM_READABLE);
 
     seq_client_pool_props[SEQ_CLIENT_POOL_PROP_OUTPUT_POOL] =
         g_param_spec_int("output-pool", "output-pool",

--- a/src/seq/query.c
+++ b/src/seq/query.c
@@ -259,7 +259,7 @@ void alsaseq_get_client_id_list(guint **entries, gsize *entry_count,
  * with SNDRV_SEQ_IOCTL_GET_CLIENT_INFO command for ALSA sequencer character
  * device.
  */
-void alsaseq_get_client_info(guint client_id, ALSASeqClientInfo **client_info,
+void alsaseq_get_client_info(guint8 client_id, ALSASeqClientInfo **client_info,
                              GError **error)
 {
     char *devnode;
@@ -309,7 +309,7 @@ void alsaseq_get_client_info(guint client_id, ALSASeqClientInfo **client_info,
  * with SNDRV_SEQ_IOCTL_GET_CLIENT_INFO and SNDRV_SEQ_IOCTL_QUERY_NEXT_PORT
  * commands for ALSA sequencer character device.
  */
-void alsaseq_get_port_id_list(guint client_id, guint **entries,
+void alsaseq_get_port_id_list(guint8 client_id, guint **entries,
                               gsize *entry_count, GError **error)
 {
     char *devnode;
@@ -385,7 +385,7 @@ void alsaseq_get_port_id_list(guint client_id, guint **entries,
  * with SNDRV_SEQ_IOCTL_GET_PORT_INFO command for ALSA sequencer character
  * device.
  */
-void alsaseq_get_port_info(guint client_id, guint port_id,
+void alsaseq_get_port_info(guint8 client_id, guint port_id,
                            ALSASeqPortInfo **port_info, GError **error)
 {
     char *devnode;
@@ -433,7 +433,7 @@ void alsaseq_get_port_info(guint client_id, guint port_id,
  * with SNDRV_SEQ_IOCTL_GET_CLIENT_POOL command for ALSA sequencer character
  * device.
  */
-void alsaseq_get_client_pool(gint client_id, ALSASeqClientPool **client_pool,
+void alsaseq_get_client_pool(guint8 client_id, ALSASeqClientPool **client_pool,
                              GError **error)
 {
     char *devnode;

--- a/src/seq/query.c
+++ b/src/seq/query.c
@@ -646,7 +646,7 @@ void alsaseq_get_queue_id_list(guint **entries, gsize *entry_count,
  * with SNDRV_SEQ_IOCTL_GET_QUEUE_INFO command for ALSA sequencer character
  * device.
  */
-void alsaseq_get_queue_info_by_id(guint queue_id, ALSASeqQueueInfo **queue_info,
+void alsaseq_get_queue_info_by_id(guint8 queue_id, ALSASeqQueueInfo **queue_info,
                                   GError **error)
 {
     struct snd_seq_queue_info *info;
@@ -736,7 +736,7 @@ void alsaseq_get_queue_info_by_name(const gchar *name,
  * with SNDRV_SEQ_IOCTL_GET_QUEUE_STATUS command for ALSA sequencer character
  * device.
  */
-void alsaseq_get_queue_status(guint queue_id,
+void alsaseq_get_queue_status(guint8 queue_id,
                               ALSASeqQueueStatus *const *queue_status,
                               GError **error)
 {

--- a/src/seq/query.c
+++ b/src/seq/query.c
@@ -309,13 +309,13 @@ void alsaseq_get_client_info(guint8 client_id, ALSASeqClientInfo **client_info,
  * with SNDRV_SEQ_IOCTL_GET_CLIENT_INFO and SNDRV_SEQ_IOCTL_QUERY_NEXT_PORT
  * commands for ALSA sequencer character device.
  */
-void alsaseq_get_port_id_list(guint8 client_id, guint **entries,
+void alsaseq_get_port_id_list(guint8 client_id, guint8 **entries,
                               gsize *entry_count, GError **error)
 {
     char *devnode;
     struct snd_seq_client_info client_info = {0};
     unsigned int count;
-    guint *list;
+    guint8 *list;
     unsigned int index;
     struct snd_seq_port_info port_info = {0};
     int fd;
@@ -385,7 +385,7 @@ void alsaseq_get_port_id_list(guint8 client_id, guint **entries,
  * with SNDRV_SEQ_IOCTL_GET_PORT_INFO command for ALSA sequencer character
  * device.
  */
-void alsaseq_get_port_info(guint8 client_id, guint port_id,
+void alsaseq_get_port_info(guint8 client_id, guint8 port_id,
                            ALSASeqPortInfo **port_info, GError **error)
 {
     char *devnode;

--- a/src/seq/query.h
+++ b/src/seq/query.h
@@ -27,10 +27,10 @@ void alsaseq_get_client_id_list(guint **entries, gsize *entry_count,
 void alsaseq_get_client_info(guint8 client_id, ALSASeqClientInfo **client_info,
 			     GError **error);
 
-void alsaseq_get_port_id_list(guint8 client_id, guint **entries,
+void alsaseq_get_port_id_list(guint8 client_id, guint8 **entries,
                               gsize *entry_count, GError **error);
 
-void alsaseq_get_port_info(guint8 client_id, guint port_id,
+void alsaseq_get_port_info(guint8 client_id, guint8 port_id,
                            ALSASeqPortInfo **port_info, GError **error);
 
 void alsaseq_get_client_pool(guint8 client_id, ALSASeqClientPool **client_pool,

--- a/src/seq/query.h
+++ b/src/seq/query.h
@@ -43,13 +43,13 @@ void alsaseq_get_subscription_list(const ALSASeqAddr *addr,
 void alsaseq_get_queue_id_list(guint **entries, gsize *entry_count,
                                GError **error);
 
-void alsaseq_get_queue_info_by_id(guint queue_id, ALSASeqQueueInfo **queue_info,
+void alsaseq_get_queue_info_by_id(guint8 queue_id, ALSASeqQueueInfo **queue_info,
                                   GError **error);
 void alsaseq_get_queue_info_by_name(const gchar *name,
                                     ALSASeqQueueInfo **queue_info,
                                     GError **error);
 
-void alsaseq_get_queue_status(guint queue_id,
+void alsaseq_get_queue_status(guint8 queue_id,
                               ALSASeqQueueStatus *const *queue_status,
                               GError **error);
 

--- a/src/seq/query.h
+++ b/src/seq/query.h
@@ -24,16 +24,16 @@ void alsaseq_get_system_info(ALSASeqSystemInfo **system_info, GError **error);
 void alsaseq_get_client_id_list(guint **entries, gsize *entry_count,
                                 GError **error);
 
-void alsaseq_get_client_info(guint client_id, ALSASeqClientInfo **client_info,
+void alsaseq_get_client_info(guint8 client_id, ALSASeqClientInfo **client_info,
 			     GError **error);
 
-void alsaseq_get_port_id_list(guint client_id, guint **entries,
+void alsaseq_get_port_id_list(guint8 client_id, guint **entries,
                               gsize *entry_count, GError **error);
 
-void alsaseq_get_port_info(guint client_id, guint port_id,
+void alsaseq_get_port_info(guint8 client_id, guint port_id,
                            ALSASeqPortInfo **port_info, GError **error);
 
-void alsaseq_get_client_pool(gint client_id, ALSASeqClientPool **client_pool,
+void alsaseq_get_client_pool(guint8 client_id, ALSASeqClientPool **client_pool,
                              GError **error);
 
 void alsaseq_get_subscription_list(const ALSASeqAddr *addr,

--- a/src/seq/queue-info.c
+++ b/src/seq/queue-info.c
@@ -41,7 +41,7 @@ static void seq_queue_info_set_property(GObject *obj, guint id,
         priv->info.queue = (int)g_value_get_uchar(val);
         break;
     case SEQ_QUEUE_INFO_PROP_CLIENT_ID:
-        priv->info.owner = g_value_get_int(val);
+        priv->info.owner = (int)g_value_get_uchar(val);
         break;
     case SEQ_QUEUE_INFO_PROP_LOCKED:
         priv->info.locked = g_value_get_boolean(val);
@@ -67,7 +67,7 @@ static void seq_queue_info_get_property(GObject *obj, guint id, GValue *val,
         g_value_set_uchar(val, (guint8)priv->info.queue);
         break;
     case SEQ_QUEUE_INFO_PROP_CLIENT_ID:
-        g_value_set_int(val, priv->info.owner);
+        g_value_set_uchar(val, (guint8)priv->info.owner);
         break;
     case SEQ_QUEUE_INFO_PROP_LOCKED:
         g_value_set_boolean(val, priv->info.locked);
@@ -97,12 +97,12 @@ static void alsaseq_queue_info_class_init(ALSASeqQueueInfoClass *klass)
                            G_PARAM_READWRITE);
 
     seq_queue_info_props[SEQ_QUEUE_INFO_PROP_CLIENT_ID] =
-        g_param_spec_int("client-id", "client-id",
-                         "The numerical ID of client which owns the queue, "
-                         "except for one of ALSASeqSpecificClientId.",
-                         G_MININT, G_MAXINT,
-                         -1,
-                         G_PARAM_READWRITE);
+        g_param_spec_uchar("client-id", "client-id",
+                           "The numerical ID of client which owns the queue, "
+                           "except for one of ALSASeqSpecificClientId.",
+                           0, G_MAXUINT8,
+                           0,
+                           G_PARAM_READWRITE);
 
     seq_queue_info_props[SEQ_QUEUE_INFO_PROP_LOCKED] =
         g_param_spec_boolean("locked", "locked",

--- a/src/seq/queue-info.c
+++ b/src/seq/queue-info.c
@@ -38,7 +38,7 @@ static void seq_queue_info_set_property(GObject *obj, guint id,
 
     switch (id) {
     case SEQ_QUEUE_INFO_PROP_QUEUE_ID:
-        priv->info.queue = g_value_get_int(val);
+        priv->info.queue = (int)g_value_get_uchar(val);
         break;
     case SEQ_QUEUE_INFO_PROP_CLIENT_ID:
         priv->info.owner = g_value_get_int(val);
@@ -64,7 +64,7 @@ static void seq_queue_info_get_property(GObject *obj, guint id, GValue *val,
 
     switch (id) {
     case SEQ_QUEUE_INFO_PROP_QUEUE_ID:
-        g_value_set_int(val, priv->info.queue);
+        g_value_set_uchar(val, (guint8)priv->info.queue);
         break;
     case SEQ_QUEUE_INFO_PROP_CLIENT_ID:
         g_value_set_int(val, priv->info.owner);
@@ -89,12 +89,12 @@ static void alsaseq_queue_info_class_init(ALSASeqQueueInfoClass *klass)
     gobject_class->get_property = seq_queue_info_get_property;
 
     seq_queue_info_props[SEQ_QUEUE_INFO_PROP_QUEUE_ID] =
-        g_param_spec_int("queue-id", "queue-id",
-                         "The numerical ID of queue, except for one of "
-                         "ALSASeqSpecificClientId.",
-                         G_MININT, G_MAXINT,
-                         -1,
-                         G_PARAM_READWRITE);
+        g_param_spec_uchar("queue-id", "queue-id",
+                           "The numerical ID of queue, except for one of "
+                           "ALSASeqSpecificClientId.",
+                           0, G_MAXUINT8,
+                           0,
+                           G_PARAM_READWRITE);
 
     seq_queue_info_props[SEQ_QUEUE_INFO_PROP_CLIENT_ID] =
         g_param_spec_int("client-id", "client-id",

--- a/src/seq/queue-status.c
+++ b/src/seq/queue-status.c
@@ -55,12 +55,12 @@ static void alsaseq_queue_status_class_init(ALSASeqQueueStatusClass *klass)
     gobject_class->get_property = seq_queue_status_get_property;
 
     seq_queue_status_props[SEQ_QUEUE_STATUS_PROP_QUEUE_ID] =
-        g_param_spec_int("queue-id", "queue-id",
-                         "The numerical ID of queue, except for entries in "
-                         "ALSASeqSpecificQueueId.",
-                         G_MININT, G_MAXINT,
-                         -1,
-                         G_PARAM_READABLE);
+        g_param_spec_uchar("queue-id", "queue-id",
+                           "The numerical ID of queue, except for entries in "
+                           "ALSASeqSpecificQueueId.",
+                           0, G_MAXUINT8,
+                           0,
+                           G_PARAM_READABLE);
 
     seq_queue_status_props[SEQ_QUEUE_STATUS_PROP_EVENT_COUNT] =
         g_param_spec_int("event-count", "event-count",

--- a/src/seq/queue-tempo.c
+++ b/src/seq/queue-tempo.c
@@ -33,7 +33,7 @@ static void seq_queue_tempo_set_property(GObject *obj, guint id,
 
     switch (id) {
     case SEQ_QUEUE_TEMPO_PROP_QUEUE_ID:
-        priv->tempo.queue = g_value_get_int(val);
+        priv->tempo.queue = (int)g_value_get_uchar(val);
         break;
     case SEQ_QUEUE_TEMPO_PROP_TEMPO:
         priv->tempo.tempo = g_value_get_int(val);
@@ -56,7 +56,7 @@ static void seq_queue_tempo_get_property(GObject *obj, guint id, GValue *val,
 
     switch (id) {
     case SEQ_QUEUE_TEMPO_PROP_QUEUE_ID:
-        g_value_set_int(val, priv->tempo.queue);
+        g_value_set_uchar(val, (guint8)priv->tempo.queue);
         break;
     case SEQ_QUEUE_TEMPO_PROP_TEMPO:
         g_value_set_uint(val, priv->tempo.tempo);
@@ -78,12 +78,12 @@ static void alsaseq_queue_tempo_class_init(ALSASeqQueueTempoClass *klass)
     gobject_class->get_property = seq_queue_tempo_get_property;
 
     seq_queue_tempo_props[SEQ_QUEUE_TEMPO_PROP_QUEUE_ID] =
-        g_param_spec_int("queue-id", "queue-id",
-                         "The numerical ID of queue, except for one of "
-                         "ALSASeqSpecificClientId.",
-                         G_MININT, G_MAXINT,
-                         -1,
-                         G_PARAM_READWRITE);
+        g_param_spec_uchar("queue-id", "queue-id",
+                           "The numerical ID of queue, except for one of "
+                           "ALSASeqSpecificClientId.",
+                           0, G_MAXUINT8,
+                           0,
+                           G_PARAM_READWRITE);
 
     seq_queue_tempo_props[SEQ_QUEUE_TEMPO_PROP_TEMPO] =
         g_param_spec_uint("tempo", "tempo",

--- a/src/seq/queue-timer.c
+++ b/src/seq/queue-timer.c
@@ -52,12 +52,12 @@ static void alsaseq_queue_timer_class_init(ALSASeqQueueTimerClass *klass)
     gobject_class->get_property = seq_queue_timer_get_property;
 
     seq_queue_timer_props[SEQ_QUEUE_TIMER_PROP_QUEUE_ID] =
-        g_param_spec_int("queue-id", "queue-id",
-                         "The numerical ID of queue, except for one of "
-                         "ALSASeqSpecificClientId.",
-                         G_MININT, G_MAXINT,
-                         -1,
-                         G_PARAM_READABLE);
+        g_param_spec_uchar("queue-id", "queue-id",
+                           "The numerical ID of queue, except for one of "
+                           "ALSASeqSpecificClientId.",
+                           0, G_MAXUINT8,
+                           0,
+                           G_PARAM_READABLE);
 
     seq_queue_timer_props[SEQ_QUEUE_TIMER_PROP_TIMER_TYPE] =
         g_param_spec_enum("type", "type",

--- a/src/seq/user-client.c
+++ b/src/seq/user-client.c
@@ -639,7 +639,7 @@ void alsaseq_user_client_create_queue(ALSASeqUserClient *self,
  * SNDRV_SEQ_IOCTL_DELETE_QUEUE command for ALSA sequencer character device.
  */
 void alsaseq_user_client_delete_queue(ALSASeqUserClient *self,
-                                      guint queue_id, GError **error)
+                                      guint8 queue_id, GError **error)
 {
     ALSASeqUserClientPrivate *priv;
     struct snd_seq_queue_info info = {0};
@@ -695,7 +695,7 @@ void alsaseq_user_client_update_queue(ALSASeqUserClient *self,
  * SNDRV_SEQ_IOCTL_GET_QUEUE_CLIENT command for ALSA sequencer character device.
  */
 void alsaseq_user_client_get_queue_usage(ALSASeqUserClient *self,
-                                         guint queue_id, gboolean *use,
+                                         guint8 queue_id, gboolean *use,
                                          GError **error)
 {
     ALSASeqUserClientPrivate *priv;
@@ -727,7 +727,7 @@ void alsaseq_user_client_get_queue_usage(ALSASeqUserClient *self,
  * SNDRV_SEQ_IOCTL_SET_QUEUE_CLIENT command for ALSA sequencer character device.
  */
 void alsaseq_user_client_set_queue_usage(ALSASeqUserClient *self,
-                                         guint queue_id, gboolean use,
+                                         guint8 queue_id, gboolean use,
                                          GError **error)
 {
     ALSASeqUserClientPrivate *priv;
@@ -758,7 +758,7 @@ void alsaseq_user_client_set_queue_usage(ALSASeqUserClient *self,
  * SNDRV_SEQ_IOCTL_SET_QUEUE_TEMPO command for ALSA sequencer character device.
  */
 void alsaseq_user_client_set_queue_tempo(ALSASeqUserClient *self,
-                                guint queue_id, ALSASeqQueueTempo *queue_tempo,
+                                guint8 queue_id, ALSASeqQueueTempo *queue_tempo,
                                 GError **error)
 {
     ALSASeqUserClientPrivate *priv;
@@ -788,7 +788,7 @@ void alsaseq_user_client_set_queue_tempo(ALSASeqUserClient *self,
  * SNDRV_SEQ_IOCTL_GET_QUEUE_TEMPO command for ALSA sequencer character device.
  */
 void alsaseq_user_client_get_queue_tempo(ALSASeqUserClient *self,
-                                guint queue_id, ALSASeqQueueTempo **queue_tempo,
+                                guint8 queue_id, ALSASeqQueueTempo **queue_tempo,
                                 GError **error)
 {
     ALSASeqUserClientPrivate *priv;
@@ -822,7 +822,7 @@ void alsaseq_user_client_get_queue_tempo(ALSASeqUserClient *self,
  * SNDRV_SEQ_IOCTL_SET_QUEUE_TIMER command for ALSA sequencer character device.
  */
 void alsaseq_user_client_set_queue_timer(ALSASeqUserClient *self,
-                                         guint queue_id,
+                                         guint8 queue_id,
                                          ALSASeqQueueTimer *queue_timer,
                                          GError **error)
 {
@@ -864,7 +864,7 @@ void alsaseq_user_client_set_queue_timer(ALSASeqUserClient *self,
  * SNDRV_SEQ_IOCTL_GET_QUEUE_TIMER command for ALSA sequencer character device.
  */
 void alsaseq_user_client_get_queue_timer(ALSASeqUserClient *self,
-                                         guint queue_id,
+                                         guint8 queue_id,
                                          ALSASeqQueueTimer **queue_timer,
                                          GError **error)
 {

--- a/src/seq/user-client.h
+++ b/src/seq/user-client.h
@@ -119,30 +119,30 @@ void alsaseq_user_client_create_queue(ALSASeqUserClient *self,
                                       ALSASeqQueueInfo *const *queue_info,
                                       GError **error);
 void alsaseq_user_client_delete_queue(ALSASeqUserClient *self,
-                                      guint queue_id, GError **error);
+                                      guint8 queue_id, GError **error);
 void alsaseq_user_client_update_queue(ALSASeqUserClient *self,
                                 ALSASeqQueueInfo *queue_info, GError **error);
 
 void alsaseq_user_client_get_queue_usage(ALSASeqUserClient *self,
-                                         guint queue_id, gboolean *use,
+                                         guint8 queue_id, gboolean *use,
                                          GError **error);
 void alsaseq_user_client_set_queue_usage(ALSASeqUserClient *self,
-                                         guint queue_id, gboolean use,
+                                         guint8 queue_id, gboolean use,
                                          GError **error);
 
 void alsaseq_user_client_set_queue_tempo(ALSASeqUserClient *self,
-                                guint queue_id, ALSASeqQueueTempo *queue_tempo,
+                                guint8 queue_id, ALSASeqQueueTempo *queue_tempo,
                                 GError **error);
 void alsaseq_user_client_get_queue_tempo(ALSASeqUserClient *self,
-                                guint queue_id, ALSASeqQueueTempo **queue_tempo,
+                                guint8 queue_id, ALSASeqQueueTempo **queue_tempo,
                                 GError **error);
 
 void alsaseq_user_client_set_queue_timer(ALSASeqUserClient *self,
-                                         guint queue_id,
+                                         guint8 queue_id,
                                          ALSASeqQueueTimer *queue_timer,
                                          GError **error);
 void alsaseq_user_client_get_queue_timer(ALSASeqUserClient *self,
-                                         guint queue_id,
+                                         guint8 queue_id,
                                          ALSASeqQueueTimer **queue_timer,
                                          GError **error);
 


### PR DESCRIPTION
In ALSA Sequencer core, the number of client/port/queue is defined as below per each:

 - SNDRV_SEQ_MAX_CLIENTS (=192)
 - SNDRV_SEQ_MAX_PORTS (=254)
 - SNDRV_SEQ_MAX_QUEUES (=32)

Following to it, in UAPI of Linux sound subsystem, several structures have `unsigned char` type of members:

 - struct snd_seq_addr.client
 - struct snd_seq_addr.port
 - struct snd_seq_event.queue

On the other hand, within the UAPI, 'int' type is also used for the numerical ID of client/port/queue. Following to the 'int' type, current API of ALSASeq includes API with 'gint' or 'guint' type of argument. However, it's better to use 'guint8' with consideration about the range of value.

This patchset declares the arguments to have 'guint8' type.