### PR TITLE
alsa-gobject: supplement to use guint8 for the numerical ID of client/queue

### DIFF
--- a/src/seq/query.c
+++ b/src/seq/query.c
@@ -567,7 +567,7 @@ void alsaseq_get_subscription_list(const ALSASeqAddr *addr,
  * with SNDRV_SEQ_IOCTL_SYSTEM_INFO and SNDRV_SEQ_IOCTL_GET_QUEUE_INFO commands
  * for ALSA sequencer character device.
  */
-void alsaseq_get_queue_id_list(guint **entries, gsize *entry_count,
+void alsaseq_get_queue_id_list(guint8 **entries, gsize *entry_count,
                                GError **error)
 {
     char *devnode;
@@ -575,7 +575,7 @@ void alsaseq_get_queue_id_list(guint **entries, gsize *entry_count,
     struct snd_seq_system_info info = {0};
     unsigned int maximum_count;
     unsigned int count;
-    guint *list;
+    guint8 *list;
     unsigned int index;
     int i;
 

--- a/src/seq/query.c
+++ b/src/seq/query.c
@@ -172,14 +172,14 @@ void alsaseq_get_system_info(ALSASeqSystemInfo **system_info, GError **error)
  * SNDRV_SEQ_IOCTL_QUERY_NEXT_CLIENT command for ALSA sequencer character
  * device.
  */
-void alsaseq_get_client_id_list(guint **entries, gsize *entry_count,
+void alsaseq_get_client_id_list(guint8 **entries, gsize *entry_count,
                                 GError **error)
 {
     char *devnode;
     int my_id;
     struct snd_seq_system_info system_info = {0};
     unsigned int count;
-    guint *list;
+    guint8 *list;
     unsigned int index;
     struct snd_seq_client_info client_info = {0};
     int fd;

--- a/src/seq/query.h
+++ b/src/seq/query.h
@@ -21,7 +21,7 @@ void alsaseq_get_seq_devnode(gchar **devnode, GError **error);
 
 void alsaseq_get_system_info(ALSASeqSystemInfo **system_info, GError **error);
 
-void alsaseq_get_client_id_list(guint **entries, gsize *entry_count,
+void alsaseq_get_client_id_list(guint8 **entries, gsize *entry_count,
                                 GError **error);
 
 void alsaseq_get_client_info(guint8 client_id, ALSASeqClientInfo **client_info,

--- a/src/seq/query.h
+++ b/src/seq/query.h
@@ -40,7 +40,7 @@ void alsaseq_get_subscription_list(const ALSASeqAddr *addr,
                                    ALSASeqQuerySubscribeType query_type,
                                    GList **entries, GError **error);
 
-void alsaseq_get_queue_id_list(guint **entries, gsize *entry_count,
+void alsaseq_get_queue_id_list(guint8 **entries, gsize *entry_count,
                                GError **error);
 
 void alsaseq_get_queue_info_by_id(guint8 queue_id, ALSASeqQueueInfo **queue_info,


### PR DESCRIPTION
Some APIs are missing in #41. This patchset has supplements for them.