### PR TITLE
alsa-gobject: fix indentation

### DIFF
--- a/src/ctl/elem-value.c
+++ b/src/ctl/elem-value.c
@@ -304,7 +304,7 @@ void alsactl_elem_value_set_iec60958_channel_status(ALSACtlElemValue *self,
 
     length = MIN(length, G_N_ELEMENTS(value->value.iec958.status));
     for (i = 0; i < length; ++i)
-	    value->value.iec958.status[i] = status[i];
+        value->value.iec958.status[i] = status[i];
 }
 
 /**
@@ -329,7 +329,7 @@ void alsactl_elem_value_get_iec60958_channel_status(ALSACtlElemValue *self,
 
     *length = MIN(*length, G_N_ELEMENTS(value->value.iec958.status));
     for (i = 0; i < *length; ++i)
-	    (*status)[i] = value->value.iec958.status[i];
+        (*status)[i] = value->value.iec958.status[i];
 }
 
 /**
@@ -354,7 +354,7 @@ void alsactl_elem_value_set_iec60958_user_data(ALSACtlElemValue *self,
 
     length = MIN(length, G_N_ELEMENTS(value->value.iec958.subcode));
     for (i = 0; i < length; ++i)
-	    value->value.iec958.subcode[i] = data[i];
+        value->value.iec958.subcode[i] = data[i];
 }
 
 /**

--- a/src/rawmidi/alsarawmidi-enum-types.h
+++ b/src/rawmidi/alsarawmidi-enum-types.h
@@ -6,8 +6,8 @@
 
 /**
  * ALSARawmidiStreamDirection:
- * @ALSARAWMIDI_STREAM_DIRECTION_OUTPUT:	Output direction of stream.
- * @ALSARAWMIDI_STREAM_DIRECTION_INPUT:		Input direction of stream.
+ * @ALSARAWMIDI_STREAM_DIRECTION_OUTPUT:        Output direction of stream.
+ * @ALSARAWMIDI_STREAM_DIRECTION_INPUT:         Input direction of stream.
  *
  * A set of enumerators for the direction of stream.
  */
@@ -18,9 +18,9 @@ typedef enum {
 
 /**
  * ALSARawmidiStreamPairInfoFlag:
- * @ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_OUTPUT:	The pair of stream supports output substream.
- * @ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_INPUT:	The pair of stream supports input substream.
- * @ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_DUPLEX:	Both directions of stream are available at the same time.
+ * @ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_OUTPUT:   The pair of stream supports output substream.
+ * @ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_INPUT:    The pair of stream supports input substream.
+ * @ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_DUPLEX:   Both directions of stream are available at the same time.
  *
  * A set of flags for information of the pair of streams.
  */

--- a/src/rawmidi/stream-pair.h
+++ b/src/rawmidi/stream-pair.h
@@ -74,7 +74,7 @@ ALSARawmidiStreamPair *alsarawmidi_stream_pair_new();
 void alsarawmidi_stream_pair_open(ALSARawmidiStreamPair *self, guint card_id,
                                   guint device_id, guint subdevice_id,
                                   ALSARawmidiStreamPairInfoFlag access_modes,
-				  gint open_flag, GError **error);
+                                  gint open_flag, GError **error);
 
 void alsarawmidi_stream_pair_get_substream_info(ALSARawmidiStreamPair *self,
                                 ALSARawmidiStreamDirection direction,

--- a/src/seq/client-pool.c
+++ b/src/seq/client-pool.c
@@ -111,7 +111,7 @@ static void alsaseq_client_pool_class_init(ALSASeqClientPoolClass *klass)
     seq_client_pool_props[SEQ_CLIENT_POOL_PROP_OUTPUT_POOL] =
         g_param_spec_int("output-pool", "output-pool",
                          "The total number of cells in memory pool for output "
-			 "direction.",
+                         "direction.",
                          0, G_MAXINT,
                          0,
                          G_PARAM_READWRITE);
@@ -119,7 +119,7 @@ static void alsaseq_client_pool_class_init(ALSASeqClientPoolClass *klass)
     seq_client_pool_props[SEQ_CLIENT_POOL_PROP_INPUT_POOL] =
         g_param_spec_int("input-pool", "input-pool",
                          "The total number of cells in memory pool for input "
-			 "direction.",
+                         "direction.",
                          0, G_MAXINT,
                          0,
                          G_PARAM_READWRITE);
@@ -127,7 +127,7 @@ static void alsaseq_client_pool_class_init(ALSASeqClientPoolClass *klass)
     seq_client_pool_props[SEQ_CLIENT_POOL_PROP_OUTPUT_ROOM] =
         g_param_spec_int("output-room", "output-room",
                          "The number of cells in memory pool for output "
-			 "direction to block user process.",
+                         "direction to block user process.",
                          0, G_MAXINT,
                          0,
                          G_PARAM_READWRITE);
@@ -135,7 +135,7 @@ static void alsaseq_client_pool_class_init(ALSASeqClientPoolClass *klass)
     seq_client_pool_props[SEQ_CLIENT_POOL_PROP_OUTPUT_FREE] =
         g_param_spec_int("output-free", "output-free",
                          "The free number of cells in memory pool for output "
-			 "direction.",
+                         "direction.",
                          0, G_MAXINT,
                          0,
                          G_PARAM_READWRITE);
@@ -143,7 +143,7 @@ static void alsaseq_client_pool_class_init(ALSASeqClientPoolClass *klass)
     seq_client_pool_props[SEQ_CLIENT_POOL_PROP_INPUT_FREE] =
         g_param_spec_int("input-free", "input-free",
                          "The free number of cells in memory pool for input "
-			 "direction.",
+                         "direction.",
                          0, G_MAXINT,
                          0,
                          G_PARAM_READWRITE);

--- a/src/seq/event-cntr.h
+++ b/src/seq/event-cntr.h
@@ -59,7 +59,7 @@ ALSASeqEventCntr *alsaseq_event_cntr_new(guint count, GError **error);
 void alsaseq_event_cntr_count_events(ALSASeqEventCntr *self, gsize *count);
 
 void alsaseq_event_cntr_calculate_pool_consumption(ALSASeqEventCntr *self,
-				gsize count, gsize *cells, GError **error);
+                                    gsize count, gsize *cells, GError **error);
 
 void alsaseq_event_cntr_get_event_type(ALSASeqEventCntr *self, gsize index,
                                     ALSASeqEventType *ev_type, GError **error);

--- a/src/seq/query.h
+++ b/src/seq/query.h
@@ -25,7 +25,7 @@ void alsaseq_get_client_id_list(guint8 **entries, gsize *entry_count,
                                 GError **error);
 
 void alsaseq_get_client_info(guint8 client_id, ALSASeqClientInfo **client_info,
-			     GError **error);
+                             GError **error);
 
 void alsaseq_get_port_id_list(guint8 client_id, guint8 **entries,
                               gsize *entry_count, GError **error);

--- a/src/seq/remove-filter.h
+++ b/src/seq/remove-filter.h
@@ -41,7 +41,7 @@ ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_tag(
 ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_tick_time(
                                 ALSASeqRemoveFilterFlag inout, guint8 queue_id,
                                 gint32 tick_time, gboolean after,
-				GError **error);
+                                GError **error);
 
 ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_real_time(
                                 ALSASeqRemoveFilterFlag inout, guint8 queue_id,

--- a/src/seq/user-client.c
+++ b/src/seq/user-client.c
@@ -612,7 +612,7 @@ void alsaseq_user_client_operate_subscription(ALSASeqUserClient *self,
  */
 void alsaseq_user_client_create_queue(ALSASeqUserClient *self,
                                       ALSASeqQueueInfo *const *queue_info,
-				      GError **error)
+                                      GError **error)
 {
     ALSASeqUserClientPrivate *priv;
     struct snd_seq_queue_info *info;

--- a/src/timer/instance-params.c
+++ b/src/timer/instance-params.c
@@ -88,7 +88,7 @@ static void alsatimer_instance_params_class_init(ALSATimerInstanceParamsClass *k
     timer_instance_params_props[TIMER_INSTANCE_PARAMS_PROP_FLAGS] =
         g_param_spec_flags("flags", "flags",
                            "The flags for user instance, as a set of "
-			   "ALSATimerInstanceParamFlag",
+                           "ALSATimerInstanceParamFlag",
                            ALSATIMER_TYPE_INSTANCE_PARAM_FLAG,
                            0,
                            G_PARAM_READWRITE);


### PR DESCRIPTION
This patchset is trivial to apply fixes for 4-spaces indentation.