### PR TITLE
alsa-gobject: add API to get current protocol version in each interface

### DIFF
--- a/src/ctl/alsactl.map
+++ b/src/ctl/alsactl.map
@@ -14,6 +14,7 @@ ALSA_GOBJECT_0_0_0 {
     "alsactl_card_get_type";
     "alsactl_card_new";
     "alsactl_card_open";
+    "alsactl_card_get_protocol_version";
     "alsactl_card_get_info";
     "alsactl_card_get_elem_id_list";
     "alsactl_card_lock_elem";

--- a/src/ctl/card.h
+++ b/src/ctl/card.h
@@ -79,6 +79,10 @@ ALSACtlCard *alsactl_card_new();
 void alsactl_card_open(ALSACtlCard *self, guint card_id, gint open_flag,
                        GError **error);
 
+void alsactl_card_get_protocol_version(ALSACtlCard *self,
+                                       const guint16 *proto_ver_triplet[3],
+                                       GError **error);
+
 void alsactl_card_get_info(ALSACtlCard *self, ALSACtlCardInfo **card_info,
                            GError **error);
 

--- a/src/rawmidi/alsarawmidi.map
+++ b/src/rawmidi/alsarawmidi.map
@@ -14,6 +14,7 @@ ALSA_GOBJECT_0_0_0 {
     "alsarawmidi_stream_pair_get_type";
     "alsarawmidi_stream_pair_new";
     "alsarawmidi_stream_pair_open";
+    "alsarawmidi_stream_pair_get_protocol_version";
     "alsarawmidi_stream_pair_get_substream_info";
     "alsarawmidi_stream_pair_set_substream_params";
     "alsarawmidi_stream_pair_get_substream_status";

--- a/src/rawmidi/stream-pair.h
+++ b/src/rawmidi/stream-pair.h
@@ -76,6 +76,10 @@ void alsarawmidi_stream_pair_open(ALSARawmidiStreamPair *self, guint card_id,
                                   ALSARawmidiStreamPairInfoFlag access_modes,
                                   gint open_flag, GError **error);
 
+void alsarawmidi_stream_pair_get_protocol_version(ALSARawmidiStreamPair *self,
+                                       const guint16 *proto_ver_triplet[3],
+                                       GError **error);
+
 void alsarawmidi_stream_pair_get_substream_info(ALSARawmidiStreamPair *self,
                                 ALSARawmidiStreamDirection direction,
                                 ALSARawmidiSubstreamInfo **substream_info,

--- a/src/seq/alsaseq.map
+++ b/src/seq/alsaseq.map
@@ -42,6 +42,7 @@ ALSA_GOBJECT_0_0_0 {
     "alsaseq_user_client_get_type";
     "alsaseq_user_client_new";
     "alsaseq_user_client_open";
+    "alsaseq_user_client_get_protocol_version";
     "alsaseq_user_client_set_info";
     "alsaseq_user_client_get_info";
     "alsaseq_user_client_create_port";

--- a/src/seq/user-client.c
+++ b/src/seq/user-client.c
@@ -29,6 +29,7 @@
 struct _ALSASeqUserClientPrivate {
     int fd;
     int client_id;
+    guint16 proto_ver_triplet[3];
 };
 G_DEFINE_TYPE_WITH_PRIVATE(ALSASeqUserClient, alsaseq_user_client, G_TYPE_OBJECT)
 
@@ -155,6 +156,7 @@ void alsaseq_user_client_open(ALSASeqUserClient *self, gint open_flag,
 {
     ALSASeqUserClientPrivate *priv;
     char *devnode;
+    int proto_ver;
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
     priv = alsaseq_user_client_get_instance_private(self);
@@ -176,6 +178,47 @@ void alsaseq_user_client_open(ALSASeqUserClient *self, gint open_flag,
         close(priv->fd);
         priv->fd = -1;
     }
+
+    // Remember the version of protocol currently used.
+    if (ioctl(priv->fd, SNDRV_SEQ_IOCTL_PVERSION, &proto_ver) < 0) {
+        generate_error(error, errno);
+        close(priv->fd);
+        priv->fd = -1;
+        return;
+    }
+
+    priv->proto_ver_triplet[0] = SNDRV_PROTOCOL_MAJOR(proto_ver);
+    priv->proto_ver_triplet[1] = SNDRV_PROTOCOL_MINOR(proto_ver);
+    priv->proto_ver_triplet[2] = SNDRV_PROTOCOL_MICRO(proto_ver);
+}
+
+/**
+ * alsaseq_user_client_get_protocol_version:
+ * @self: A #ALSASeqUserClient.
+ * @proto_ver_triplet: (array fixed-size=3)(out)(transfer none): The version of
+ *                     protocol currently used.
+ * @error: A #GError.
+ *
+ * Get the version of sequencer protocol currently used. The version is
+ * represented as the array with three elements; major, minor, and micro version
+ * in the order. The length of major version is 16 bit, the length of minor
+ * and micro version is 8 bit each.
+ */
+void alsaseq_user_client_get_protocol_version(ALSASeqUserClient *self,
+                                        const guint16 *proto_ver_triplet[3],
+                                        GError **error)
+{
+    ALSASeqUserClientPrivate *priv;
+
+    g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
+    priv = alsaseq_user_client_get_instance_private(self);
+
+    if (priv->fd < 0) {
+        generate_error(error, ENXIO);
+        return;
+    }
+
+    *proto_ver_triplet = (const guint16 *)priv->proto_ver_triplet;
 }
 
 /**

--- a/src/seq/user-client.h
+++ b/src/seq/user-client.h
@@ -74,6 +74,10 @@ ALSASeqUserClient *alsaseq_user_client_new();
 void alsaseq_user_client_open(ALSASeqUserClient *self, gint open_flag,
                               GError **error);
 
+void alsaseq_user_client_get_protocol_version(ALSASeqUserClient *self,
+                                        const guint16 *proto_ver_triplet[3],
+                                        GError **error);
+
 void alsaseq_user_client_set_info(ALSASeqUserClient *self,
                                   ALSASeqClientInfo *client_info,
                                   GError **error);

--- a/src/timer/alsatimer.map
+++ b/src/timer/alsatimer.map
@@ -33,6 +33,7 @@ ALSA_GOBJECT_0_0_0 {
     "alsatimer_user_instance_get_type";
     "alsatimer_user_instance_new";
     "alsatimer_user_instance_open";
+    "alsatimer_user_instance_get_protocol_version";
     "alsatimer_user_instance_choose_event_data_type";
     "alsatimer_user_instance_attach";
     "alsatimer_user_instance_attach_as_slave";

--- a/src/timer/user-instance.h
+++ b/src/timer/user-instance.h
@@ -77,6 +77,10 @@ ALSATimerUserInstance *alsatimer_user_instance_new();
 void alsatimer_user_instance_open(ALSATimerUserInstance *self, gint open_flag,
                                   GError **error);
 
+void alsatimer_user_instance_get_protocol_version(ALSATimerUserInstance *self,
+                                        const guint16 *proto_ver_triplet[3],
+                                        GError **error);
+
 void alsatimer_user_instance_choose_event_data_type(ALSATimerUserInstance *self,
                                         ALSATimerEventDataType event_data_type,
                                         GError **error);

--- a/tests/alsactl-card
+++ b/tests/alsactl-card
@@ -17,6 +17,7 @@ props = (
 methods = (
     'new',
     'open',
+    'get_protocol_version',
     'get_info',
     'get_elem_id_list',
     'lock_elem',

--- a/tests/alsarawmidi-stream-pair
+++ b/tests/alsarawmidi-stream-pair
@@ -16,6 +16,7 @@ props = (
 methods = (
     'new',
     'open',
+    'get_protocol_version',
     'get_substream_info',
     'set_substream_params',
     'get_substream_status',

--- a/tests/alsaseq-user-client
+++ b/tests/alsaseq-user-client
@@ -16,6 +16,7 @@ props = (
 methods = (
     'new',
     'open',
+    'get_protocol_version',
     'set_info',
     'get_info',
     'create_port',

--- a/tests/alsatimer-user-instance
+++ b/tests/alsatimer-user-instance
@@ -14,6 +14,7 @@ props = ()
 methods = (
     'new',
     'open',
+    'get_protocol_version',
     'choose_event_data_type',
     'attach',
     'attach_as_slave',


### PR DESCRIPTION
In UAPI of Linux sound subsystem, interfaces support protocol versioning. This patchset adds API to get current protocol version in each interface.