### PR TITLE
alsa-gobject: reorder documentation sections

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 The alsa-gobject project
 ========================
 
-2020/06/14
+2020/06/21
 Takashi Sakamoto
 
 Introduction
@@ -118,8 +118,8 @@ Supplemental information for language bindings
 
 * PyGObject <https://pygobject.readthedocs.io/> is a dynamic loader for
   libraries compatible with g-i.
-* alsa-gobject-rs <not published yet> includes creates to use these
-  libraries.
+* alsa-gobject-rs <https://github.com/alsa-project/alsa-gobject-rs/> includes
+  creates to use these libraries.
 
 Valgrind suppression file for leak detected in glib
 ===================================================

--- a/doc/reference/seq/alsaseq-docs.xml
+++ b/doc/reference/seq/alsaseq-docs.xml
@@ -33,9 +33,9 @@
 
     <chapter id="alsaseq-objects">
         <title>ALSASeq objects</title>
+        <xi:include href="xml/user-client.xml"/>
         <xi:include href="xml/system-info.xml"/>
         <xi:include href="xml/client-info.xml"/>
-        <xi:include href="xml/user-client.xml"/>
         <xi:include href="xml/client-pool.xml"/>
         <xi:include href="xml/addr.xml"/>
         <xi:include href="xml/port-info.xml"/>

--- a/doc/reference/timer/alsatimer-docs.xml
+++ b/doc/reference/timer/alsatimer-docs.xml
@@ -33,11 +33,11 @@
 
     <chapter id="alsatimer-objects">
         <title>ALSATimer objects</title>
+        <xi:include href="xml/user-instance.xml"/>
         <xi:include href="xml/device-id.xml"/>
         <xi:include href="xml/device-info.xml"/>
         <xi:include href="xml/device-status.xml"/>
         <xi:include href="xml/device-params.xml"/>
-        <xi:include href="xml/user-instance.xml"/>
         <xi:include href="xml/instance-info.xml"/>
         <xi:include href="xml/instance-status.xml"/>
         <xi:include href="xml/instance-params.xml"/>


### PR DESCRIPTION
For better documentation, this patchset reorders sections of ALSATimer/ALSASeq documentation.