### PR TITLE
alsa-gobject: bump version up to 0.1.0 for official release

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('alsa-gobject', 'c',
-  version: '0.0.0',
+  version: '0.1.0',
   license: 'LGPL-3',
 )
 


### PR DESCRIPTION
This patch is a preparation for official v0.1.0 release. After merged, I'm going to push a tag 'v0.1.0' with release note.