### PR TITLE
ctl: enhancement for error reporting

### DIFF
--- a/src/ctl/alsactl-enum-types.h
+++ b/src/ctl/alsactl-enum-types.h
@@ -115,6 +115,7 @@ typedef enum /*< flags >*/
  * @ALSACTL_CARD_ERROR_DISCONNECTED:        The card associated to the instance is in disconnect state.
  * @ALSACTL_CARD_ERROR_ELEM_NOT_FOUND:      The control element not found in the card.
  * @ALSACTL_CARD_ERROR_ELEM_NOT_SUPPORTED:  The operation is not supported by the control element.
+ * @ALSACTL_CARD_ERROR_ELEM_OWNED:          The control element is owned by the other process.
  *
  * A set of error code for GError with domain which equals to #alsactl_card_error_quark()
  */
@@ -123,6 +124,7 @@ typedef enum {
     ALSACTL_CARD_ERROR_DISCONNECTED,
     ALSACTL_CARD_ERROR_ELEM_NOT_FOUND,
     ALSACTL_CARD_ERROR_ELEM_NOT_SUPPORTED,
+    ALSACTL_CARD_ERROR_ELEM_OWNED,
 } ALSACtlCardError;
 
 #endif

--- a/src/ctl/alsactl-enum-types.h
+++ b/src/ctl/alsactl-enum-types.h
@@ -113,12 +113,14 @@ typedef enum /*< flags >*/
  * ALSACtlCardError:
  * @ALSACTL_CARD_ERROR_FAILED:              The system call failed.
  * @ALSACTL_CARD_ERROR_DISCONNECTED:        The card associated to the instance is in disconnect state.
+ * @ALSACTL_CARD_ERROR_ELEM_NOT_FOUND:      The control element not found in the card.
  *
  * A set of error code for GError with domain which equals to #alsactl_card_error_quark()
  */
 typedef enum {
     ALSACTL_CARD_ERROR_FAILED,
     ALSACTL_CARD_ERROR_DISCONNECTED,
+    ALSACTL_CARD_ERROR_ELEM_NOT_FOUND,
 } ALSACtlCardError;
 
 #endif

--- a/src/ctl/alsactl-enum-types.h
+++ b/src/ctl/alsactl-enum-types.h
@@ -114,6 +114,7 @@ typedef enum /*< flags >*/
  * @ALSACTL_CARD_ERROR_FAILED:              The system call failed.
  * @ALSACTL_CARD_ERROR_DISCONNECTED:        The card associated to the instance is in disconnect state.
  * @ALSACTL_CARD_ERROR_ELEM_NOT_FOUND:      The control element not found in the card.
+ * @ALSACTL_CARD_ERROR_ELEM_NOT_SUPPORTED:  The operation is not supported by the control element.
  *
  * A set of error code for GError with domain which equals to #alsactl_card_error_quark()
  */
@@ -121,6 +122,7 @@ typedef enum {
     ALSACTL_CARD_ERROR_FAILED,
     ALSACTL_CARD_ERROR_DISCONNECTED,
     ALSACTL_CARD_ERROR_ELEM_NOT_FOUND,
+    ALSACTL_CARD_ERROR_ELEM_NOT_SUPPORTED,
 } ALSACtlCardError;
 
 #endif

--- a/src/ctl/alsactl-enum-types.h
+++ b/src/ctl/alsactl-enum-types.h
@@ -112,11 +112,13 @@ typedef enum /*< flags >*/
 /**
  * ALSACtlCardError:
  * @ALSACTL_CARD_ERROR_FAILED:              The system call failed.
+ * @ALSACTL_CARD_ERROR_DISCONNECTED:        The card associated to the instance is in disconnect state.
  *
  * A set of error code for GError with domain which equals to #alsactl_card_error_quark()
  */
 typedef enum {
     ALSACTL_CARD_ERROR_FAILED,
+    ALSACTL_CARD_ERROR_DISCONNECTED,
 } ALSACtlCardError;
 
 #endif

--- a/src/ctl/alsactl-enum-types.h
+++ b/src/ctl/alsactl-enum-types.h
@@ -109,4 +109,14 @@ typedef enum /*< flags >*/
     ALSACTL_ELEM_EVENT_MASK_REMOVE  = SNDRV_CTL_EVENT_MASK_TLV << 1,
 } ALSACtlElemEventMask;
 
+/**
+ * ALSACtlCardError:
+ * @ALSACTL_CARD_ERROR_FAILED:              The system call failed.
+ *
+ * A set of error code for GError with domain which equals to #alsactl_card_error_quark()
+ */
+typedef enum {
+    ALSACTL_CARD_ERROR_FAILED,
+} ALSACtlCardError;
+
 #endif

--- a/src/ctl/alsactl-enum-types.h
+++ b/src/ctl/alsactl-enum-types.h
@@ -116,6 +116,7 @@ typedef enum /*< flags >*/
  * @ALSACTL_CARD_ERROR_ELEM_NOT_FOUND:      The control element not found in the card.
  * @ALSACTL_CARD_ERROR_ELEM_NOT_SUPPORTED:  The operation is not supported by the control element.
  * @ALSACTL_CARD_ERROR_ELEM_OWNED:          The control element is owned by the other process.
+ * @ALSACTL_CARD_ERROR_ELEM_EXIST:          The control element already exists.
  *
  * A set of error code for GError with domain which equals to #alsactl_card_error_quark()
  */
@@ -125,6 +126,7 @@ typedef enum {
     ALSACTL_CARD_ERROR_ELEM_NOT_FOUND,
     ALSACTL_CARD_ERROR_ELEM_NOT_SUPPORTED,
     ALSACTL_CARD_ERROR_ELEM_OWNED,
+    ALSACTL_CARD_ERROR_ELEM_EXIST,
 } ALSACtlCardError;
 
 #endif

--- a/src/ctl/alsactl.map
+++ b/src/ctl/alsactl.map
@@ -90,3 +90,7 @@ ALSA_GOBJECT_0_0_0 {
   local:
     *;
 };
+
+ALSA_GOBJECT_0_2_0 {
+    "alsactl_card_error_get_type";
+} ALSA_GOBJECT_0_0_0;

--- a/src/ctl/alsactl.map
+++ b/src/ctl/alsactl.map
@@ -93,4 +93,5 @@ ALSA_GOBJECT_0_0_0 {
 
 ALSA_GOBJECT_0_2_0 {
     "alsactl_card_error_get_type";
+    "alsactl_card_error_quark";
 } ALSA_GOBJECT_0_0_0;

--- a/src/ctl/card.c
+++ b/src/ctl/card.c
@@ -185,6 +185,8 @@ void alsactl_card_open(ALSACtlCard *self, guint card_id, gint open_flag,
     g_return_if_fail(ALSACTL_IS_CARD(self));
     priv = alsactl_card_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     alsactl_get_control_devnode(card_id, &devnode, error);
     if (*error != NULL)
         return;
@@ -233,6 +235,8 @@ void alsactl_card_get_protocol_version(ALSACtlCard *self,
     g_return_if_fail(ALSACTL_IS_CARD(self));
     priv = alsactl_card_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     if (priv->fd < 0) {
         generate_error(error, ENXIO);
         return;
@@ -260,6 +264,8 @@ void alsactl_card_get_info(ALSACtlCard *self, ALSACtlCardInfo **card_info,
 
     g_return_if_fail(ALSACTL_IS_CARD(self));
     priv = alsactl_card_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     *card_info = g_object_new(ALSACTL_TYPE_CARD_INFO, NULL);
 
@@ -341,6 +347,8 @@ void alsactl_card_get_elem_id_list(ALSACtlCard *self, GList **entries,
     g_return_if_fail(ALSACTL_IS_CARD(self));
     priv = alsactl_card_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     allocate_elem_ids(priv->fd, &list, error);
     if (*error != NULL)
         return;
@@ -375,6 +383,8 @@ void alsactl_card_lock_elem(ALSACtlCard *self, const ALSACtlElemId *elem_id,
 
     g_return_if_fail(ALSACTL_IS_CARD(self));
     priv = alsactl_card_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     if (lock)
         ret = ioctl(priv->fd, SNDRV_CTL_IOCTL_ELEM_LOCK, elem_id);
@@ -432,6 +442,8 @@ void alsactl_card_get_elem_info(ALSACtlCard *self, const ALSACtlElemId *elem_id,
     g_return_if_fail(ALSACTL_IS_CARD(self));
     g_return_if_fail(elem_id != NULL);
     priv = alsactl_card_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     *elem_info = g_object_new(ALSACTL_TYPE_ELEM_INFO, NULL);
     ctl_elem_info_refer_private(*elem_info, &info);
@@ -501,6 +513,8 @@ void alsactl_card_write_elem_tlv(ALSACtlCard *self,
     g_return_if_fail(elem_id != NULL);
     priv = alsactl_card_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     // At least two quadlets should be included for type and length.
     if (container == NULL || container_count < 2) {
         generate_error(error, EINVAL);
@@ -546,6 +560,8 @@ void alsactl_card_read_elem_tlv(ALSACtlCard *self, const ALSACtlElemId *elem_id,
     g_return_if_fail(ALSACTL_IS_CARD(self));
     g_return_if_fail(elem_id != NULL);
     priv = alsactl_card_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     // At least two quadlets should be included for type and length.
     if (*container == NULL || *container_count < 2) {
@@ -595,6 +611,8 @@ void alsactl_card_command_elem_tlv(ALSACtlCard *self,
     g_return_if_fail(ALSACTL_IS_CARD(self));
     g_return_if_fail(elem_id != NULL);
     priv = alsactl_card_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     // At least two quadlets should be included for type and length.
     if (*container == NULL || *container_count < 2) {
@@ -689,8 +707,7 @@ static void add_or_replace_elems(int fd, const ALSACtlElemId *elem_id,
         break;
     }
     default:
-        generate_error(error, ENXIO);
-        return;
+        g_return_if_reached();
     }
 
     info->id = *elem_id;
@@ -741,6 +758,8 @@ void alsactl_card_add_elems(ALSACtlCard *self, const ALSACtlElemId *elem_id,
     g_return_if_fail(ALSACTL_IS_ELEM_INFO(elem_info));
     priv = alsactl_card_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     add_or_replace_elems(priv->fd, elem_id, elem_count, elem_info, FALSE,
                          entries, error);
 }
@@ -770,6 +789,8 @@ void alsactl_card_replace_elems(ALSACtlCard *self, const ALSACtlElemId *elem_id,
     g_return_if_fail(ALSACTL_IS_ELEM_INFO(elem_info));
     priv = alsactl_card_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     add_or_replace_elems(priv->fd, elem_id, elem_count, elem_info, TRUE,
                          entries, error);
 }
@@ -793,6 +814,8 @@ void alsactl_card_remove_elems(ALSACtlCard *self, const ALSACtlElemId *elem_id,
     g_return_if_fail(ALSACTL_IS_CARD(self));
     g_return_if_fail(elem_id != NULL);
     priv = alsactl_card_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     if (ioctl(priv->fd, SNDRV_CTL_IOCTL_ELEM_REMOVE, elem_id) < 0)
         generate_error(error, errno);
@@ -821,6 +844,8 @@ void alsactl_card_write_elem_value(ALSACtlCard *self,
     g_return_if_fail(ALSACTL_IS_CARD(self));
     g_return_if_fail(elem_id != NULL);
     g_return_if_fail(ALSACTL_IS_ELEM_VALUE(elem_value));
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     ctl_elem_value_refer_private((ALSACtlElemValue *)elem_value, &value);
     value->id = *elem_id;
@@ -853,6 +878,8 @@ void alsactl_card_read_elem_value(ALSACtlCard *self,
     g_return_if_fail(ALSACTL_IS_CARD(self));
     g_return_if_fail(elem_id != NULL);
     g_return_if_fail(ALSACTL_IS_ELEM_VALUE(*elem_value));
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     ctl_elem_value_refer_private(*elem_value, &value);
     value->id = *elem_id;
@@ -974,6 +1001,8 @@ void alsactl_card_create_source(ALSACtlCard *self, GSource **gsrc,
 
     g_return_if_fail(ALSACTL_IS_CARD(self));
     priv = alsactl_card_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     if (priv->fd < 0) {
         generate_error(error, ENXIO);

--- a/src/ctl/card.c
+++ b/src/ctl/card.c
@@ -195,7 +195,8 @@ ALSACtlCard *alsactl_card_new()
  * @self: A #ALSACtlCard.
  * @card_id: The numerical ID of sound card.
  * @open_flag: The flag of open(2) system call. O_RDONLY is forced to fulfil internally.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with two domains; #g_file_error_quark() and
+ *         #alsactl_card_error_quark().
  *
  * Open ALSA control character device for the sound card.
  *
@@ -286,7 +287,7 @@ void alsactl_card_get_protocol_version(ALSACtlCard *self,
  * alsactl_card_get_info:
  * @self: A #ALSACtlCard.
  * @card_info: (out): A #ALSACtlCardInfo for the sound card.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
  *
  * Get the information of sound card.
  *
@@ -376,7 +377,7 @@ static inline void deallocate_elem_ids(struct snd_ctl_elem_list *list)
  * @self: A #ALSACtlCard.
  * @entries: (element-type ALSACtl.ElemId)(out): The list of entries for
  *           ALSACtlElemId.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
  *
  * Generate a list of ALSACtlElemId for ALSA control character device
  * associated to the sound card.
@@ -415,7 +416,7 @@ void alsactl_card_get_elem_id_list(ALSACtlCard *self, GList **entries,
  * @self: A #ALSACtlCard.
  * @elem_id: A #ALSACtlElemId.
  * @lock: whether to lock or unlock the element.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
  *
  * Lock/Unlock indicated element not to be written by the other processes.
  *
@@ -491,7 +492,7 @@ error:
  * @self: A #ALSACtlCard.
  * @elem_id: A #ALSACtlElemId.
  * @elem_info: (out): A %ALSACtlElemInfo.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
  *
  * Get information of element corresponding to given id.
  *
@@ -565,7 +566,7 @@ void alsactl_card_get_elem_info(ALSACtlCard *self, const ALSACtlElemId *elem_id,
  * @container: (array length=container_count): The array with qudalets for
  *             Type-Length-Value data.
  * @container_count: The number of quadlets in the container.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
  *
  * Write the given array of bytes as Type/Length/Value data for element pointed
  * by the identifier.
@@ -620,7 +621,7 @@ void alsactl_card_write_elem_tlv(ALSACtlCard *self,
  * @container: (array length=container_count)(inout): The array with qudalets
  *             for Type-Length-Value data.
  * @container_count: The number of quadlets in the container.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
  *
  * Read Type/Length/Value data from element pointed by the identifier and fulfil
  * the given array of bytes with the data.
@@ -674,7 +675,7 @@ void alsactl_card_read_elem_tlv(ALSACtlCard *self, const ALSACtlElemId *elem_id,
  * @container: (array length=container_count)(inout): The array with qudalets
  *             for Type-Length-Value data.
  * @container_count: The number of quadlets in the container.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
  *
  * Command the given array of bytes as Type/Length/Value data for  element
  * pointed by the identifier.
@@ -836,7 +837,7 @@ static void add_or_replace_elems(int fd, const ALSACtlElemId *elem_id,
  * @elem_count: The number of elements going to be added.
  * @elem_info: A %ALSACtlElemInfo.
  * @entries: (element-type ALSACtl.ElemId)(out): The list of added element IDs.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
  *
  * Add the user-defined elements and return the list of their identifier.
  *
@@ -868,7 +869,7 @@ void alsactl_card_add_elems(ALSACtlCard *self, const ALSACtlElemId *elem_id,
  * @elem_count: The number of elements going to be added.
  * @elem_info: A %ALSACtlElemInfo.
  * @entries: (element-type ALSACtl.ElemId)(out): The list of renewed element IDs.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
  *
  * Add user-defined elements to replace the existent ones.
  *
@@ -897,7 +898,7 @@ void alsactl_card_replace_elems(ALSACtlCard *self, const ALSACtlElemId *elem_id,
  * alsactl_card_remove_elems:
  * @self: A #ALSACtlCard.
  * @elem_id: A #ALSACtlElemId.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
  *
  * Remove user-defined elements pointed by the identifier.
  *
@@ -932,7 +933,7 @@ void alsactl_card_remove_elems(ALSACtlCard *self, const ALSACtlElemId *elem_id,
  * @self: A #ALSACtlCard.
  * @elem_id: A #ALSACtlElemId.
  * @elem_value: A derivative of #ALSACtlElemValue.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
  *
  * Write given value to element indicated by given ID.
  *
@@ -974,7 +975,7 @@ void alsactl_card_write_elem_value(ALSACtlCard *self,
  * @self: A #ALSACtlCard.
  * @elem_id: A #ALSACtlElemId.
  * @elem_value: (inout): A derivative of #ALSACtlElemValue.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
  *
  * Read given value from element indicated by given ID.
  *
@@ -1101,7 +1102,7 @@ static void ctl_card_finalize_src(GSource *gsrc)
  * alsactl_card_create_source:
  * @self: A #ALSACtlCard.
  * @gsrc: (out): A #GSource to handle events from ALSA control character device.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
  *
  * Allocate GSource structure to handle events from ALSA control character
  * device. In each iteration of GManContext, the read(2) system call is

--- a/src/ctl/card.c
+++ b/src/ctl/card.c
@@ -30,6 +30,15 @@ struct _ALSACtlCardPrivate {
 };
 G_DEFINE_TYPE_WITH_PRIVATE(ALSACtlCard, alsactl_card, G_TYPE_OBJECT)
 
+/**
+ * alsactl_card_error_quark:
+ *
+ * Return the GQuark for error domain of GError which has code in #ALSACtlCardError enumerations.
+ *
+ * Returns: A #GQuark.
+ */
+G_DEFINE_QUARK(alsactl-card-error-quark, alsactl_card_error)
+
 typedef struct {
     GSource src;
     ALSACtlCard *self;

--- a/src/ctl/card.c
+++ b/src/ctl/card.c
@@ -235,6 +235,7 @@ void alsactl_card_get_protocol_version(ALSACtlCard *self,
     g_return_if_fail(ALSACTL_IS_CARD(self));
     priv = alsactl_card_get_instance_private(self);
 
+    g_return_if_fail(proto_ver_triplet != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     if (priv->fd < 0) {
@@ -265,6 +266,7 @@ void alsactl_card_get_info(ALSACtlCard *self, ALSACtlCardInfo **card_info,
     g_return_if_fail(ALSACTL_IS_CARD(self));
     priv = alsactl_card_get_instance_private(self);
 
+    g_return_if_fail(card_info != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     *card_info = g_object_new(ALSACTL_TYPE_CARD_INFO, NULL);
@@ -347,6 +349,7 @@ void alsactl_card_get_elem_id_list(ALSACtlCard *self, GList **entries,
     g_return_if_fail(ALSACTL_IS_CARD(self));
     priv = alsactl_card_get_instance_private(self);
 
+    g_return_if_fail(entries != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     allocate_elem_ids(priv->fd, &list, error);
@@ -384,6 +387,7 @@ void alsactl_card_lock_elem(ALSACtlCard *self, const ALSACtlElemId *elem_id,
     g_return_if_fail(ALSACTL_IS_CARD(self));
     priv = alsactl_card_get_instance_private(self);
 
+    g_return_if_fail(elem_id != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     if (lock)
@@ -440,9 +444,10 @@ void alsactl_card_get_elem_info(ALSACtlCard *self, const ALSACtlElemId *elem_id,
     struct snd_ctl_elem_info *info;
 
     g_return_if_fail(ALSACTL_IS_CARD(self));
-    g_return_if_fail(elem_id != NULL);
     priv = alsactl_card_get_instance_private(self);
 
+    g_return_if_fail(elem_id != NULL);
+    g_return_if_fail(elem_info != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     *elem_info = g_object_new(ALSACTL_TYPE_ELEM_INFO, NULL);
@@ -480,7 +485,7 @@ void alsactl_card_get_elem_info(ALSACtlCard *self, const ALSACtlElemId *elem_id,
         break;
     }
     default:
-        generate_error(error, ENXIO);
+        g_return_if_reached();
         return;
     }
 }
@@ -510,16 +515,14 @@ void alsactl_card_write_elem_tlv(ALSACtlCard *self,
     size_t container_size;
 
     g_return_if_fail(ALSACTL_IS_CARD(self));
-    g_return_if_fail(elem_id != NULL);
     priv = alsactl_card_get_instance_private(self);
 
+    g_return_if_fail(elem_id != NULL);
+    // At least two quadlets should be included for type and length.
+    g_return_if_fail(container != NULL);
+    g_return_if_fail(container_count >= 2);
     g_return_if_fail(error == NULL || *error == NULL);
 
-    // At least two quadlets should be included for type and length.
-    if (container == NULL || container_count < 2) {
-        generate_error(error, EINVAL);
-        return;
-    }
     container_size = container_count * sizeof(*container);
 
     packet = g_malloc0(sizeof(*packet) + container_size);
@@ -558,16 +561,14 @@ void alsactl_card_read_elem_tlv(ALSACtlCard *self, const ALSACtlElemId *elem_id,
     size_t container_size;
 
     g_return_if_fail(ALSACTL_IS_CARD(self));
-    g_return_if_fail(elem_id != NULL);
     priv = alsactl_card_get_instance_private(self);
 
+    g_return_if_fail(elem_id != NULL);
+    // At least two quadlets should be included for type and length.
+    g_return_if_fail(container != NULL);
+    g_return_if_fail(container_count != NULL && *container_count >= 2);
     g_return_if_fail(error == NULL || *error == NULL);
 
-    // At least two quadlets should be included for type and length.
-    if (*container == NULL || *container_count < 2) {
-        generate_error(error, EINVAL);
-        return;
-    }
     container_size = *container_count * sizeof(**container);
 
     packet = g_malloc0(sizeof(*packet) + container_size);
@@ -609,16 +610,14 @@ void alsactl_card_command_elem_tlv(ALSACtlCard *self,
     size_t container_size;
 
     g_return_if_fail(ALSACTL_IS_CARD(self));
-    g_return_if_fail(elem_id != NULL);
     priv = alsactl_card_get_instance_private(self);
 
+    g_return_if_fail(elem_id != NULL);
+    // At least two quadlets should be included for type and length.
+    g_return_if_fail(container != NULL);
+    g_return_if_fail(container_count != NULL && *container_count >= 2);
     g_return_if_fail(error == NULL || *error == NULL);
 
-    // At least two quadlets should be included for type and length.
-    if (*container == NULL || *container_count < 2) {
-        generate_error(error, EINVAL);
-        return;
-    }
     container_size = *container_count * sizeof(**container);
 
     packet = g_malloc0(sizeof(*packet) + container_size);
@@ -636,7 +635,7 @@ void alsactl_card_command_elem_tlv(ALSACtlCard *self,
     g_free(packet);
 }
 
-static int prepare_enum_names(struct snd_ctl_elem_info *info, const gchar **labels)
+static void prepare_enum_names(struct snd_ctl_elem_info *info, const gchar **labels)
 {
     unsigned int count;
     unsigned int length;
@@ -646,14 +645,12 @@ static int prepare_enum_names(struct snd_ctl_elem_info *info, const gchar **labe
     for (count = 0; labels[count] != NULL; ++count) {
         const gchar *label = labels[count];
 
-        if (strlen(label) >= 64)
-            return -EINVAL;
+        g_return_if_fail(strlen(label) < 64);
 
         length += strlen(label) + 1;
     }
 
-    if (length > 64 * 1024)
-        return -EINVAL;
+    g_return_if_fail(length <= 64 * 1024);
 
     pos = g_malloc0(length);
 
@@ -667,8 +664,6 @@ static int prepare_enum_names(struct snd_ctl_elem_info *info, const gchar **labe
         pos += strlen(label) + 1;
     }
     info->value.enumerated.items = count;
-
-    return 0;
 }
 
 static void add_or_replace_elems(int fd, const ALSACtlElemId *elem_id,
@@ -692,17 +687,12 @@ static void add_or_replace_elems(int fd, const ALSACtlElemId *elem_id,
     case SNDRV_CTL_ELEM_TYPE_ENUMERATED:
     {
         const gchar **labels;
-        int err;
 
         alsactl_elem_info_get_enum_data(elem_info, &labels, error);
         if (*error != NULL)
             return;
 
-        err = prepare_enum_names(info, labels);
-        if (err < 0) {
-            generate_error(error, -err);
-            return;
-        }
+        prepare_enum_names(info, labels);
 
         break;
     }
@@ -754,10 +744,11 @@ void alsactl_card_add_elems(ALSACtlCard *self, const ALSACtlElemId *elem_id,
     ALSACtlCardPrivate *priv;
 
     g_return_if_fail(ALSACTL_IS_CARD(self));
-    g_return_if_fail(elem_id != NULL);
-    g_return_if_fail(ALSACTL_IS_ELEM_INFO(elem_info));
     priv = alsactl_card_get_instance_private(self);
 
+    g_return_if_fail(elem_id != NULL);
+    g_return_if_fail(elem_count > 0);
+    g_return_if_fail(ALSACTL_IS_ELEM_INFO(elem_info));
     g_return_if_fail(error == NULL || *error == NULL);
 
     add_or_replace_elems(priv->fd, elem_id, elem_count, elem_info, FALSE,
@@ -785,10 +776,11 @@ void alsactl_card_replace_elems(ALSACtlCard *self, const ALSACtlElemId *elem_id,
     ALSACtlCardPrivate *priv;
 
     g_return_if_fail(ALSACTL_IS_CARD(self));
-    g_return_if_fail(elem_id != NULL);
-    g_return_if_fail(ALSACTL_IS_ELEM_INFO(elem_info));
     priv = alsactl_card_get_instance_private(self);
 
+    g_return_if_fail(elem_id != NULL);
+    g_return_if_fail(elem_count > 0);
+    g_return_if_fail(ALSACTL_IS_ELEM_INFO(elem_info));
     g_return_if_fail(error == NULL || *error == NULL);
 
     add_or_replace_elems(priv->fd, elem_id, elem_count, elem_info, TRUE,
@@ -812,9 +804,9 @@ void alsactl_card_remove_elems(ALSACtlCard *self, const ALSACtlElemId *elem_id,
     ALSACtlCardPrivate *priv;
 
     g_return_if_fail(ALSACTL_IS_CARD(self));
-    g_return_if_fail(elem_id != NULL);
     priv = alsactl_card_get_instance_private(self);
 
+    g_return_if_fail(elem_id != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     if (ioctl(priv->fd, SNDRV_CTL_IOCTL_ELEM_REMOVE, elem_id) < 0)
@@ -842,15 +834,15 @@ void alsactl_card_write_elem_value(ALSACtlCard *self,
     struct snd_ctl_elem_value *value;
 
     g_return_if_fail(ALSACTL_IS_CARD(self));
+    priv = alsactl_card_get_instance_private(self);
+
     g_return_if_fail(elem_id != NULL);
     g_return_if_fail(ALSACTL_IS_ELEM_VALUE(elem_value));
-
     g_return_if_fail(error == NULL || *error == NULL);
 
     ctl_elem_value_refer_private((ALSACtlElemValue *)elem_value, &value);
     value->id = *elem_id;
 
-    priv = alsactl_card_get_instance_private(self);
     if (ioctl(priv->fd, SNDRV_CTL_IOCTL_ELEM_WRITE, value) < 0)
         generate_error(error, errno);
 }
@@ -876,15 +868,15 @@ void alsactl_card_read_elem_value(ALSACtlCard *self,
     struct snd_ctl_elem_value *value;
 
     g_return_if_fail(ALSACTL_IS_CARD(self));
-    g_return_if_fail(elem_id != NULL);
-    g_return_if_fail(ALSACTL_IS_ELEM_VALUE(*elem_value));
+    priv = alsactl_card_get_instance_private(self);
 
+    g_return_if_fail(elem_id != NULL);
+    g_return_if_fail(elem_value != NULL && ALSACTL_IS_ELEM_VALUE(*elem_value));
     g_return_if_fail(error == NULL || *error == NULL);
 
     ctl_elem_value_refer_private(*elem_value, &value);
     value->id = *elem_id;
 
-    priv = alsactl_card_get_instance_private(self);
     if (ioctl(priv->fd, SNDRV_CTL_IOCTL_ELEM_READ, value) < 0)
         generate_error(error, errno);
 }
@@ -1002,6 +994,7 @@ void alsactl_card_create_source(ALSACtlCard *self, GSource **gsrc,
     g_return_if_fail(ALSACTL_IS_CARD(self));
     priv = alsactl_card_get_instance_private(self);
 
+    g_return_if_fail(gsrc != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     if (priv->fd < 0) {

--- a/src/ctl/card.c
+++ b/src/ctl/card.c
@@ -289,11 +289,7 @@ static void allocate_elem_ids(int fd, struct snd_ctl_elem_list *list,
         return;
 
     // Allocate spaces for these elements.
-    ids = calloc(list->count, sizeof(*ids));
-    if (!ids) {
-        generate_error(error, ENOMEM);
-        return;
-    }
+    ids = g_malloc_n(list->count, sizeof(*ids));
 
     list->offset = 0;
     while (list->offset < list->count) {
@@ -396,10 +392,6 @@ static void parse_enum_names(ALSACtlCardPrivate *priv,
     int i;
 
     *labels = g_malloc0_n(count + 1, sizeof(**labels));
-    if (*labels == NULL) {
-        generate_error(error, ENOMEM);
-        return;
-    }
 
     for (i = 0; i < count; ++i) {
         info->value.enumerated.item = i;
@@ -408,11 +400,7 @@ static void parse_enum_names(ALSACtlCardPrivate *priv,
             goto error;
         }
 
-        (*labels)[i] = strdup(info->value.enumerated.name);
-        if ((*labels)[i] == NULL) {
-            generate_error(error, ENOMEM);
-            goto error;
-        }
+        (*labels)[i] = g_strdup(info->value.enumerated.name);
     }
 
     (*labels)[count] = NULL;
@@ -521,10 +509,6 @@ void alsactl_card_write_elem_tlv(ALSACtlCard *self,
     container_size = container_count * sizeof(*container);
 
     packet = g_malloc0(sizeof(*packet) + container_size);
-    if (packet == NULL) {
-        generate_error(error, ENOMEM);
-        return;
-    }
 
     packet->numid = elem_id->numid;
     packet->length = container_size;
@@ -571,10 +555,6 @@ void alsactl_card_read_elem_tlv(ALSACtlCard *self, const ALSACtlElemId *elem_id,
     container_size = *container_count * sizeof(**container);
 
     packet = g_malloc0(sizeof(*packet) + container_size);
-    if (packet == NULL) {
-        generate_error(error, ENOMEM);
-        return;
-    }
 
     packet->numid = elem_id->numid;
     packet->length = container_size;
@@ -624,10 +604,6 @@ void alsactl_card_command_elem_tlv(ALSACtlCard *self,
     container_size = *container_count * sizeof(**container);
 
     packet = g_malloc0(sizeof(*packet) + container_size);
-    if (packet == NULL) {
-        generate_error(error, ENOMEM);
-        return;
-    }
 
     packet->numid = elem_id->numid;
     packet->length = container_size;
@@ -662,8 +638,7 @@ static int prepare_enum_names(struct snd_ctl_elem_info *info, const gchar **labe
         return -EINVAL;
 
     pos = g_malloc0(length);
-    if (pos == NULL)
-        return -ENOMEM;
+
     info->value.enumerated.names_ptr = (__u64)pos;
     info->value.enumerated.names_length = length;
 
@@ -1005,11 +980,7 @@ void alsactl_card_create_source(ALSACtlCard *self, GSource **gsrc,
         return;
     }
 
-    buf = g_try_malloc0(page_size);
-    if (buf == NULL) {
-        generate_error(error, ENOMEM);
-        return;
-    }
+    buf = g_malloc0(page_size);
 
     *gsrc = g_source_new(&funcs, sizeof(CtlCardSource));
     src = (CtlCardSource *)(*gsrc);

--- a/src/ctl/card.c
+++ b/src/ctl/card.c
@@ -39,6 +39,10 @@ G_DEFINE_TYPE_WITH_PRIVATE(ALSACtlCard, alsactl_card, G_TYPE_OBJECT)
  */
 G_DEFINE_QUARK(alsactl-card-error-quark, alsactl_card_error)
 
+#define generate_syscall_error(exception, errno, fmt, arg)                  \
+    g_set_error(exception, ALSACTL_CARD_ERROR, ALSACTL_CARD_ERROR_FAILED,   \
+                fmt" %d(%s)", arg, errno, strerror(errno))
+
 typedef struct {
     GSource src;
     ALSACtlCard *self;
@@ -210,7 +214,7 @@ void alsactl_card_open(ALSACtlCard *self, guint card_id, gint open_flag,
 
     // Remember the version of protocol currently used.
     if (ioctl(priv->fd, SNDRV_CTL_IOCTL_PVERSION, &proto_ver) < 0) {
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", "PVERSION");
         close(priv->fd);
         priv->fd = -1;
         g_free(devnode);
@@ -278,7 +282,7 @@ void alsactl_card_get_info(ALSACtlCard *self, ALSACtlCardInfo **card_info,
 
     ctl_card_info_refer_private(*card_info, &info);
     if (ioctl(priv->fd, SNDRV_CTL_IOCTL_CARD_INFO, info) < 0) {
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", "CARD_INFO");
         g_object_unref(*card_info);
     }
 }
@@ -293,7 +297,7 @@ static void allocate_elem_ids(int fd, struct snd_ctl_elem_list *list,
 
     // Get the number of elements in this control device.
     if (ioctl(fd, SNDRV_CTL_IOCTL_ELEM_LIST, list) < 0) {
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", "ELEM_LIST");
         return;
     }
 
@@ -313,7 +317,7 @@ static void allocate_elem_ids(int fd, struct snd_ctl_elem_list *list,
 
         // Get the IDs of elements in this control device.
         if (ioctl(fd, SNDRV_CTL_IOCTL_ELEM_LIST, list) < 0) {
-            generate_error(error, errno);
+            generate_syscall_error(error, errno, "ioctl(%s)", "ELEM_LIST");
             free(ids);
             list->pids = NULL;
             return;
@@ -387,6 +391,8 @@ void alsactl_card_lock_elem(ALSACtlCard *self, const ALSACtlElemId *elem_id,
                             gboolean lock, GError **error)
 {
     ALSACtlCardPrivate *priv;
+    unsigned long req;
+    const char *req_name;
     int ret;
 
     g_return_if_fail(ALSACTL_IS_CARD(self));
@@ -395,12 +401,17 @@ void alsactl_card_lock_elem(ALSACtlCard *self, const ALSACtlElemId *elem_id,
     g_return_if_fail(elem_id != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
-    if (lock)
-        ret = ioctl(priv->fd, SNDRV_CTL_IOCTL_ELEM_LOCK, elem_id);
-    else
-        ret = ioctl(priv->fd, SNDRV_CTL_IOCTL_ELEM_UNLOCK, elem_id);
+    if (lock) {
+        req = SNDRV_CTL_IOCTL_ELEM_LOCK;
+        req_name = "ELEM_LOCK";
+    } else {
+        req = SNDRV_CTL_IOCTL_ELEM_UNLOCK;
+        req_name = "ELEM_UNLOCK";
+    }
+
+    ret = ioctl(priv->fd, req, elem_id);
     if (ret < 0)
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", req_name);
 }
 
 static void parse_enum_names(ALSACtlCardPrivate *priv,
@@ -415,7 +426,7 @@ static void parse_enum_names(ALSACtlCardPrivate *priv,
     for (i = 0; i < count; ++i) {
         info->value.enumerated.item = i;
         if (ioctl(priv->fd, SNDRV_CTL_IOCTL_ELEM_INFO, info)) {
-            generate_error(error, errno);
+            generate_syscall_error(error, errno, "ioctl(%s)", "ELEM_INFO");
             goto error;
         }
 
@@ -460,7 +471,7 @@ void alsactl_card_get_elem_info(ALSACtlCard *self, const ALSACtlElemId *elem_id,
 
     info->id = *elem_id;
     if (ioctl(priv->fd, SNDRV_CTL_IOCTL_ELEM_INFO, info)) {
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", "ELEM_INFO");
         return;
     }
 
@@ -537,7 +548,7 @@ void alsactl_card_write_elem_tlv(ALSACtlCard *self,
     memcpy(packet->tlv, container, container_size);
 
     if (ioctl(priv->fd, SNDRV_CTL_IOCTL_TLV_WRITE, packet) < 0)
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", "TLV_WRITE");
 
     g_free(packet);
 }
@@ -582,7 +593,7 @@ void alsactl_card_read_elem_tlv(ALSACtlCard *self, const ALSACtlElemId *elem_id,
     packet->length = container_size;
 
     if (ioctl(priv->fd, SNDRV_CTL_IOCTL_TLV_READ, packet) < 0)
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", "TLV_READ");
 
     memcpy(*container, packet->tlv, packet->length);
     *container_count = packet->length / sizeof(**container);
@@ -632,7 +643,7 @@ void alsactl_card_command_elem_tlv(ALSACtlCard *self,
     memcpy(packet->tlv, *container, container_size);
 
     if (ioctl(priv->fd, SNDRV_CTL_IOCTL_TLV_COMMAND, packet) < 0)
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", "TLV_COMMAND");
 
     memcpy(*container, packet->tlv, packet->length);
     *container_count = packet->length / sizeof(**container);
@@ -678,6 +689,7 @@ static void add_or_replace_elems(int fd, const ALSACtlElemId *elem_id,
 {
     struct snd_ctl_elem_info *info;
     long request;
+    const char *req_name;
     int i;
 
     ctl_elem_info_refer_private(elem_info, &info);
@@ -707,14 +719,17 @@ static void add_or_replace_elems(int fd, const ALSACtlElemId *elem_id,
 
     info->id = *elem_id;
 
-    if (!replace)
+    if (!replace) {
         request = SNDRV_CTL_IOCTL_ELEM_ADD;
-    else
+        req_name = "ELEM_ADD";
+    } else {
         request = SNDRV_CTL_IOCTL_ELEM_REPLACE;
+        req_name = "ELEM_REPLACE";
+    }
 
     info->owner = (__kernel_pid_t)elem_count;
     if (ioctl(fd, request, info) < 0)
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", req_name);
     g_free((void *)info->value.enumerated.names_ptr);
     if (*error != NULL)
         return;
@@ -815,7 +830,7 @@ void alsactl_card_remove_elems(ALSACtlCard *self, const ALSACtlElemId *elem_id,
     g_return_if_fail(error == NULL || *error == NULL);
 
     if (ioctl(priv->fd, SNDRV_CTL_IOCTL_ELEM_REMOVE, elem_id) < 0)
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", "ELEM_REMOVE");
 }
 
 /**
@@ -849,7 +864,7 @@ void alsactl_card_write_elem_value(ALSACtlCard *self,
     value->id = *elem_id;
 
     if (ioctl(priv->fd, SNDRV_CTL_IOCTL_ELEM_WRITE, value) < 0)
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", "ELEM_WRITE");
 }
 
 /**
@@ -883,7 +898,7 @@ void alsactl_card_read_elem_value(ALSACtlCard *self,
     value->id = *elem_id;
 
     if (ioctl(priv->fd, SNDRV_CTL_IOCTL_ELEM_READ, value) < 0)
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", "ELEM_READ");
 }
 
 static void handle_elem_event(CtlCardSource *src, struct snd_ctl_event *ev)
@@ -1024,7 +1039,7 @@ void alsactl_card_create_source(ALSACtlCard *self, GSource **gsrc,
         g_atomic_int_inc(&priv->subscribers);
 
         if (ioctl(priv->fd, SNDRV_CTL_IOCTL_SUBSCRIBE_EVENTS, &subscribe)) {
-            generate_error(error, errno);
+            generate_syscall_error(error, errno, "ioctl(%s)", "SUBSCRIBE_EVENTS");
             g_source_unref(*gsrc);
         }
     }

--- a/src/ctl/card.c
+++ b/src/ctl/card.c
@@ -42,6 +42,7 @@ G_DEFINE_QUARK(alsactl-card-error-quark, alsactl_card_error)
 static const char *const err_msgs[] = {
     [ALSACTL_CARD_ERROR_DISCONNECTED] = "The card associated to the instance is in disconnect state",
     [ALSACTL_CARD_ERROR_ELEM_NOT_FOUND] = "The control element not found in the card",
+    [ALSACTL_CARD_ERROR_ELEM_NOT_SUPPORTED] = "The operation is not supported by the control element.",
 };
 
 #define generate_local_error(exception, code) \
@@ -945,6 +946,8 @@ void alsactl_card_write_elem_value(ALSACtlCard *self,
             generate_local_error(error, ALSACTL_CARD_ERROR_DISCONNECTED);
         else if (errno == ENOENT)
             generate_local_error(error, ALSACTL_CARD_ERROR_ELEM_NOT_FOUND);
+        else if (errno == EPERM)
+            generate_local_error(error, ALSACTL_CARD_ERROR_ELEM_NOT_SUPPORTED);
         else
             generate_syscall_error(error, errno, "ioctl(%s)", "ELEM_WRITE");
     }
@@ -985,6 +988,8 @@ void alsactl_card_read_elem_value(ALSACtlCard *self,
             generate_local_error(error, ALSACTL_CARD_ERROR_DISCONNECTED);
         else if (errno == ENOENT)
             generate_local_error(error, ALSACTL_CARD_ERROR_ELEM_NOT_FOUND);
+        else if (errno == EPERM)
+            generate_local_error(error, ALSACTL_CARD_ERROR_ELEM_NOT_SUPPORTED);
         else
             generate_syscall_error(error, errno, "ioctl(%s)", "ELEM_READ");
     }

--- a/src/ctl/card.c
+++ b/src/ctl/card.c
@@ -44,6 +44,7 @@ static const char *const err_msgs[] = {
     [ALSACTL_CARD_ERROR_ELEM_NOT_FOUND] = "The control element not found in the card",
     [ALSACTL_CARD_ERROR_ELEM_NOT_SUPPORTED] = "The operation is not supported by the control element.",
     [ALSACTL_CARD_ERROR_ELEM_OWNED] = "The control element is owned by the other process.",
+    [ALSACTL_CARD_ERROR_ELEM_EXIST] = "The control element already exists.",
 };
 
 #define generate_local_error(exception, code) \
@@ -809,6 +810,8 @@ static void add_or_replace_elems(int fd, const ALSACtlElemId *elem_id,
         } else if (errno == EBUSY) {
             if (replace)
                 generate_local_error(error, ALSACTL_CARD_ERROR_ELEM_OWNED);
+            else
+                generate_local_error(error, ALSACTL_CARD_ERROR_ELEM_EXIST);
         } else {
             generate_syscall_error(error, errno, "ioctl(%s)", req_name);
         }

--- a/src/ctl/card.c
+++ b/src/ctl/card.c
@@ -234,14 +234,10 @@ void alsactl_card_get_protocol_version(ALSACtlCard *self,
 
     g_return_if_fail(ALSACTL_IS_CARD(self));
     priv = alsactl_card_get_instance_private(self);
+    g_return_if_fail(priv->fd >= 0);
 
     g_return_if_fail(proto_ver_triplet != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
-
-    if (priv->fd < 0) {
-        generate_error(error, ENXIO);
-        return;
-    }
 
     *proto_ver_triplet = (const guint16 *)priv->proto_ver_triplet;
 }
@@ -993,14 +989,10 @@ void alsactl_card_create_source(ALSACtlCard *self, GSource **gsrc,
 
     g_return_if_fail(ALSACTL_IS_CARD(self));
     priv = alsactl_card_get_instance_private(self);
+    g_return_if_fail(priv->fd >= 0);
 
     g_return_if_fail(gsrc != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
-
-    if (priv->fd < 0) {
-        generate_error(error, ENXIO);
-        return;
-    }
 
     buf = g_malloc0(page_size);
 

--- a/src/ctl/card.c
+++ b/src/ctl/card.c
@@ -41,6 +41,7 @@ G_DEFINE_QUARK(alsactl-card-error-quark, alsactl_card_error)
 
 static const char *const err_msgs[] = {
     [ALSACTL_CARD_ERROR_DISCONNECTED] = "The card associated to the instance is in disconnect state",
+    [ALSACTL_CARD_ERROR_ELEM_NOT_FOUND] = "The control element not found in the card",
 };
 
 #define generate_local_error(exception, code) \
@@ -445,6 +446,8 @@ void alsactl_card_lock_elem(ALSACtlCard *self, const ALSACtlElemId *elem_id,
     if (ret < 0) {
         if (errno == ENODEV)
             generate_local_error(error, ALSACTL_CARD_ERROR_DISCONNECTED);
+        else if (errno == ENOENT)
+            generate_local_error(error, ALSACTL_CARD_ERROR_ELEM_NOT_FOUND);
         else
             generate_syscall_error(error, errno, "ioctl(%s)", req_name);
     }
@@ -512,6 +515,8 @@ void alsactl_card_get_elem_info(ALSACtlCard *self, const ALSACtlElemId *elem_id,
     if (ioctl(priv->fd, SNDRV_CTL_IOCTL_ELEM_INFO, info)) {
         if (errno == ENODEV)
             generate_local_error(error, ALSACTL_CARD_ERROR_DISCONNECTED);
+        else if (errno == ENOENT)
+            generate_local_error(error, ALSACTL_CARD_ERROR_ELEM_NOT_FOUND);
         else
             generate_syscall_error(error, errno, "ioctl(%s)", "ELEM_INFO");
         return;
@@ -592,6 +597,8 @@ void alsactl_card_write_elem_tlv(ALSACtlCard *self,
     if (ioctl(priv->fd, SNDRV_CTL_IOCTL_TLV_WRITE, packet) < 0) {
         if (errno == ENODEV)
             generate_local_error(error, ALSACTL_CARD_ERROR_DISCONNECTED);
+        else if (errno == ENOENT)
+            generate_local_error(error, ALSACTL_CARD_ERROR_ELEM_NOT_FOUND);
         else
             generate_syscall_error(error, errno, "ioctl(%s)", "TLV_WRITE");
     }
@@ -641,6 +648,8 @@ void alsactl_card_read_elem_tlv(ALSACtlCard *self, const ALSACtlElemId *elem_id,
     if (ioctl(priv->fd, SNDRV_CTL_IOCTL_TLV_READ, packet) < 0) {
         if (errno == ENODEV)
             generate_local_error(error, ALSACTL_CARD_ERROR_DISCONNECTED);
+        else if (errno == ENOENT)
+            generate_local_error(error, ALSACTL_CARD_ERROR_ELEM_NOT_FOUND);
         else
             generate_syscall_error(error, errno, "ioctl(%s)", "TLV_READ");
     }
@@ -695,6 +704,8 @@ void alsactl_card_command_elem_tlv(ALSACtlCard *self,
     if (ioctl(priv->fd, SNDRV_CTL_IOCTL_TLV_COMMAND, packet) < 0) {
         if (errno == ENODEV)
             generate_local_error(error, ALSACTL_CARD_ERROR_DISCONNECTED);
+        else if (errno == ENOENT)
+            generate_local_error(error, ALSACTL_CARD_ERROR_ELEM_NOT_FOUND);
         else
             generate_syscall_error(error, errno, "ioctl(%s)", "TLV_COMMAND");
     }
@@ -785,6 +796,8 @@ static void add_or_replace_elems(int fd, const ALSACtlElemId *elem_id,
     if (ioctl(fd, request, info) < 0) {
         if (errno == ENODEV)
             generate_local_error(error, ALSACTL_CARD_ERROR_DISCONNECTED);
+        else if (errno == ENOENT)
+            generate_local_error(error, ALSACTL_CARD_ERROR_ELEM_NOT_FOUND);
         else
             generate_syscall_error(error, errno, "ioctl(%s)", req_name);
     }
@@ -890,6 +903,8 @@ void alsactl_card_remove_elems(ALSACtlCard *self, const ALSACtlElemId *elem_id,
     if (ioctl(priv->fd, SNDRV_CTL_IOCTL_ELEM_REMOVE, elem_id) < 0) {
         if (errno == ENODEV)
             generate_local_error(error, ALSACTL_CARD_ERROR_DISCONNECTED);
+        else if (errno == ENOENT)
+            generate_local_error(error, ALSACTL_CARD_ERROR_ELEM_NOT_FOUND);
         else
             generate_syscall_error(error, errno, "ioctl(%s)", "ELEM_REMOVE");
     }
@@ -928,6 +943,8 @@ void alsactl_card_write_elem_value(ALSACtlCard *self,
     if (ioctl(priv->fd, SNDRV_CTL_IOCTL_ELEM_WRITE, value) < 0) {
         if (errno == ENODEV)
             generate_local_error(error, ALSACTL_CARD_ERROR_DISCONNECTED);
+        else if (errno == ENOENT)
+            generate_local_error(error, ALSACTL_CARD_ERROR_ELEM_NOT_FOUND);
         else
             generate_syscall_error(error, errno, "ioctl(%s)", "ELEM_WRITE");
     }
@@ -966,6 +983,8 @@ void alsactl_card_read_elem_value(ALSACtlCard *self,
     if (ioctl(priv->fd, SNDRV_CTL_IOCTL_ELEM_READ, value) < 0) {
         if (errno == ENODEV)
             generate_local_error(error, ALSACTL_CARD_ERROR_DISCONNECTED);
+        else if (errno == ENOENT)
+            generate_local_error(error, ALSACTL_CARD_ERROR_ELEM_NOT_FOUND);
         else
             generate_syscall_error(error, errno, "ioctl(%s)", "ELEM_READ");
     }

--- a/src/ctl/card.h
+++ b/src/ctl/card.h
@@ -36,6 +36,10 @@ G_BEGIN_DECLS
                                ALSACTL_TYPE_CARD,   \
                                ALSACtlCardClass))
 
+#define ALSACTL_CARD_ERROR	alsactl_card_error_quark()
+
+GQuark alsactl_card_error_quark();
+
 typedef struct _ALSACtlCard         ALSACtlCard;
 typedef struct _ALSACtlCardClass    ALSACtlCardClass;
 typedef struct _ALSACtlCardPrivate  ALSACtlCardPrivate;

--- a/src/ctl/elem-id.c
+++ b/src/ctl/elem-id.c
@@ -57,6 +57,8 @@ ALSACtlElemId *alsactl_elem_id_new_by_name(ALSACtlElemIfaceType iface,
 {
     struct snd_ctl_elem_id *id;
 
+    g_return_val_if_fail(name != NULL && strlen(name) > 0, NULL);
+
     id = g_malloc0(sizeof(*id));
 
     id->iface = iface;

--- a/src/ctl/elem-info.c
+++ b/src/ctl/elem-info.c
@@ -175,8 +175,7 @@ ALSACtlElemInfo *alsactl_elem_info_new(ALSACtlElemType elem_type, GError **error
     case ALSACTL_ELEM_TYPE_INTEGER64:
         break;
     default:
-        generate_error(error, EINVAL);
-        return NULL;
+        g_return_val_if_reached(NULL);
     }
 
     return g_object_new(ALSACTL_TYPE_ELEM_INFO, "type", elem_type, NULL);
@@ -202,12 +201,10 @@ void alsactl_elem_info_get_int_data(ALSACtlElemInfo *self,
     g_return_if_fail(ALSACTL_IS_ELEM_INFO(self));
     priv = alsactl_elem_info_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
-    if (priv->info.type != SNDRV_CTL_ELEM_TYPE_INTEGER) {
-        generate_error(error, ENXIO);
-        return;
-    }
+    g_return_if_fail(priv->info.type == SNDRV_CTL_ELEM_TYPE_INTEGER);
 
     priv->int_data.min = (gint32)priv->info.value.integer.min;
     priv->int_data.max = (gint32)priv->info.value.integer.max;
@@ -236,12 +233,10 @@ void alsactl_elem_info_set_int_data(ALSACtlElemInfo *self,
     g_return_if_fail(ALSACTL_IS_ELEM_INFO(self));
     priv = alsactl_elem_info_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
-    if (priv->info.type != SNDRV_CTL_ELEM_TYPE_INTEGER) {
-        generate_error(error, ENXIO);
-        return;
-    }
+    g_return_if_fail(priv->info.type == SNDRV_CTL_ELEM_TYPE_INTEGER);
 
     priv->info.value.integer.min = (long)data[0];
     priv->info.value.integer.max = (long)data[1];
@@ -268,12 +263,10 @@ void alsactl_elem_info_get_int64_data(ALSACtlElemInfo *self,
     g_return_if_fail(ALSACTL_IS_ELEM_INFO(self));
     priv = alsactl_elem_info_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
-    if (priv->info.type != SNDRV_CTL_ELEM_TYPE_INTEGER64) {
-        generate_error(error, ENXIO);
-        return;
-    }
+    g_return_if_fail(priv->info.type == SNDRV_CTL_ELEM_TYPE_INTEGER64);
 
     priv->int_data.min = (gint64)priv->info.value.integer.min;
     priv->int_data.max = (gint64)priv->info.value.integer.max;
@@ -302,12 +295,10 @@ void alsactl_elem_info_set_int64_data(ALSACtlElemInfo *self,
     g_return_if_fail(ALSACTL_IS_ELEM_INFO(self));
     priv = alsactl_elem_info_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
-    if (priv->info.type != SNDRV_CTL_ELEM_TYPE_INTEGER64) {
-        generate_error(error, ENXIO);
-        return;
-    }
+    g_return_if_fail(priv->info.type == SNDRV_CTL_ELEM_TYPE_INTEGER64);
 
     priv->info.value.integer.min = (long long)data[0];
     priv->info.value.integer.max = (long long)data[1];
@@ -333,12 +324,10 @@ void alsactl_elem_info_get_enum_data(ALSACtlElemInfo *self,
     g_return_if_fail(ALSACTL_IS_ELEM_INFO(self));
     priv = alsactl_elem_info_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
-    if (priv->info.type != SNDRV_CTL_ELEM_TYPE_ENUMERATED) {
-        generate_error(error, ENXIO);
-        return;
-    }
+    g_return_if_fail(priv->info.type == SNDRV_CTL_ELEM_TYPE_ENUMERATED);
 
     *data = (const gchar **)priv->enum_data;
 }
@@ -362,12 +351,10 @@ void alsactl_elem_info_set_enum_data(ALSACtlElemInfo *self,
     g_return_if_fail(ALSACTL_IS_ELEM_INFO(self));
     priv = alsactl_elem_info_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
-    if (priv->info.type != SNDRV_CTL_ELEM_TYPE_ENUMERATED) {
-        generate_error(error, ENXIO);
-        return;
-    }
+    g_return_if_fail(priv->info.type == SNDRV_CTL_ELEM_TYPE_ENUMERATED);
 
     g_strfreev(priv->enum_data);
 

--- a/src/ctl/elem-info.c
+++ b/src/ctl/elem-info.c
@@ -164,6 +164,8 @@ static void alsactl_elem_info_init(ALSACtlElemInfo *self)
  */
 ALSACtlElemInfo *alsactl_elem_info_new(ALSACtlElemType elem_type, GError **error)
 {
+    g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
     switch (elem_type) {
     case ALSACTL_ELEM_TYPE_BOOLEAN:
     case ALSACTL_ELEM_TYPE_INTEGER:
@@ -200,6 +202,8 @@ void alsactl_elem_info_get_int_data(ALSACtlElemInfo *self,
     g_return_if_fail(ALSACTL_IS_ELEM_INFO(self));
     priv = alsactl_elem_info_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     if (priv->info.type != SNDRV_CTL_ELEM_TYPE_INTEGER) {
         generate_error(error, ENXIO);
         return;
@@ -232,6 +236,8 @@ void alsactl_elem_info_set_int_data(ALSACtlElemInfo *self,
     g_return_if_fail(ALSACTL_IS_ELEM_INFO(self));
     priv = alsactl_elem_info_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     if (priv->info.type != SNDRV_CTL_ELEM_TYPE_INTEGER) {
         generate_error(error, ENXIO);
         return;
@@ -261,6 +267,8 @@ void alsactl_elem_info_get_int64_data(ALSACtlElemInfo *self,
 
     g_return_if_fail(ALSACTL_IS_ELEM_INFO(self));
     priv = alsactl_elem_info_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     if (priv->info.type != SNDRV_CTL_ELEM_TYPE_INTEGER64) {
         generate_error(error, ENXIO);
@@ -294,6 +302,8 @@ void alsactl_elem_info_set_int64_data(ALSACtlElemInfo *self,
     g_return_if_fail(ALSACTL_IS_ELEM_INFO(self));
     priv = alsactl_elem_info_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     if (priv->info.type != SNDRV_CTL_ELEM_TYPE_INTEGER64) {
         generate_error(error, ENXIO);
         return;
@@ -323,6 +333,8 @@ void alsactl_elem_info_get_enum_data(ALSACtlElemInfo *self,
     g_return_if_fail(ALSACTL_IS_ELEM_INFO(self));
     priv = alsactl_elem_info_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     if (priv->info.type != SNDRV_CTL_ELEM_TYPE_ENUMERATED) {
         generate_error(error, ENXIO);
         return;
@@ -349,6 +361,8 @@ void alsactl_elem_info_set_enum_data(ALSACtlElemInfo *self,
 
     g_return_if_fail(ALSACTL_IS_ELEM_INFO(self));
     priv = alsactl_elem_info_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     if (priv->info.type != SNDRV_CTL_ELEM_TYPE_ENUMERATED) {
         generate_error(error, ENXIO);

--- a/src/ctl/elem-value.c
+++ b/src/ctl/elem-value.c
@@ -103,8 +103,10 @@ void alsactl_elem_value_set_bool(ALSACtlElemValue *self,
 
     g_return_if_fail(ALSACTL_IS_ELEM_VALUE(self));
     priv = alsactl_elem_value_get_instance_private(self);
-    value = &priv->value;
 
+    g_return_if_fail(values != NULL);
+
+    value = &priv->value;
     value_count = MIN(value_count, G_N_ELEMENTS(value->value.integer.value));
     for (i = 0; i < value_count; ++i)
         value->value.integer.value[i] = (long)values[i];
@@ -128,8 +130,11 @@ void alsactl_elem_value_get_bool(ALSACtlElemValue *self,
 
     g_return_if_fail(ALSACTL_IS_ELEM_VALUE(self));
     priv = alsactl_elem_value_get_instance_private(self);
-    value = &priv->value;
 
+    g_return_if_fail(values != NULL);
+    g_return_if_fail(value_count != NULL);
+
+    value = &priv->value;
     *value_count = MIN(*value_count, G_N_ELEMENTS(value->value.integer.value));
     for (i = 0; i < *value_count; ++i)
         (*values)[i] = (gboolean)value->value.integer.value[i];
@@ -152,8 +157,10 @@ void alsactl_elem_value_set_int(ALSACtlElemValue *self, const gint32 *values,
 
     g_return_if_fail(ALSACTL_IS_ELEM_VALUE(self));
     priv = alsactl_elem_value_get_instance_private(self);
-    value = &priv->value;
 
+    g_return_if_fail(values != NULL);
+
+    value = &priv->value;
     value_count = MIN(value_count, G_N_ELEMENTS(value->value.integer.value));
     for (i = 0; i < value_count; ++i)
         value->value.integer.value[i] = (long)values[i];
@@ -177,8 +184,11 @@ void alsactl_elem_value_get_int(ALSACtlElemValue *self, gint32 *const *values,
 
     g_return_if_fail(ALSACTL_IS_ELEM_VALUE(self));
     priv = alsactl_elem_value_get_instance_private(self);
-    value = &priv->value;
 
+    g_return_if_fail(values != NULL);
+    g_return_if_fail(value_count != NULL);
+
+    value = &priv->value;
     *value_count = MIN(*value_count, G_N_ELEMENTS(value->value.integer.value));
     for (i = 0; i < *value_count; ++i)
         (*values)[i] = (gint32)value->value.integer.value[i];
@@ -202,8 +212,10 @@ void alsactl_elem_value_set_enum(ALSACtlElemValue *self,
 
     g_return_if_fail(ALSACTL_IS_ELEM_VALUE(self));
     priv = alsactl_elem_value_get_instance_private(self);
-    value = &priv->value;
 
+    g_return_if_fail(values != NULL);
+
+    value = &priv->value;
     value_count = MIN(value_count, G_N_ELEMENTS(value->value.enumerated.item));
     for (i = 0; i < value_count; ++i)
         value->value.enumerated.item[i] = (unsigned int)values[i];
@@ -227,8 +239,11 @@ void alsactl_elem_value_get_enum(ALSACtlElemValue *self,
 
     g_return_if_fail(ALSACTL_IS_ELEM_VALUE(self));
     priv = alsactl_elem_value_get_instance_private(self);
-    value = &priv->value;
 
+    g_return_if_fail(values != NULL);
+    g_return_if_fail(value_count != NULL);
+
+    value = &priv->value;
     *value_count = MIN(*value_count, G_N_ELEMENTS(value->value.enumerated.item));
     for (i = 0; i < *value_count; ++i)
         (*values)[i] = (guint32)value->value.enumerated.item[i];
@@ -251,8 +266,10 @@ void alsactl_elem_value_set_bytes(ALSACtlElemValue *self,
 
     g_return_if_fail(ALSACTL_IS_ELEM_VALUE(self));
     priv = alsactl_elem_value_get_instance_private(self);
-    value = &priv->value;
 
+    g_return_if_fail(values != NULL);
+
+    value = &priv->value;
     value_count = MIN(value_count, G_N_ELEMENTS(value->value.bytes.data));
     for (i = 0; i < value_count; ++i)
         value->value.bytes.data[i] = (long)values[i];
@@ -275,8 +292,11 @@ void alsactl_elem_value_get_bytes(ALSACtlElemValue *self,
 
     g_return_if_fail(ALSACTL_IS_ELEM_VALUE(self));
     priv = alsactl_elem_value_get_instance_private(self);
-    value = &priv->value;
 
+    g_return_if_fail(values != NULL);
+    g_return_if_fail(value_count != NULL);
+
+    value = &priv->value;
     *value_count = MIN(*value_count, G_N_ELEMENTS(value->value.bytes.data));
     for (i = 0; i < *value_count; ++i)
         (*values)[i] = (guint8)value->value.bytes.data[i];
@@ -300,8 +320,10 @@ void alsactl_elem_value_set_iec60958_channel_status(ALSACtlElemValue *self,
 
     g_return_if_fail(ALSACTL_IS_ELEM_VALUE(self));
     priv = alsactl_elem_value_get_instance_private(self);
-    value = &priv->value;
 
+    g_return_if_fail(status != NULL);
+
+    value = &priv->value;
     length = MIN(length, G_N_ELEMENTS(value->value.iec958.status));
     for (i = 0; i < length; ++i)
         value->value.iec958.status[i] = status[i];
@@ -325,8 +347,11 @@ void alsactl_elem_value_get_iec60958_channel_status(ALSACtlElemValue *self,
 
     g_return_if_fail(ALSACTL_IS_ELEM_VALUE(self));
     priv = alsactl_elem_value_get_instance_private(self);
-    value = &priv->value;
 
+    g_return_if_fail(status != NULL);
+    g_return_if_fail(length != NULL);
+
+    value = &priv->value;
     *length = MIN(*length, G_N_ELEMENTS(value->value.iec958.status));
     for (i = 0; i < *length; ++i)
         (*status)[i] = value->value.iec958.status[i];
@@ -350,8 +375,10 @@ void alsactl_elem_value_set_iec60958_user_data(ALSACtlElemValue *self,
 
     g_return_if_fail(ALSACTL_IS_ELEM_VALUE(self));
     priv = alsactl_elem_value_get_instance_private(self);
-    value = &priv->value;
 
+    g_return_if_fail(data != NULL);
+
+    value = &priv->value;
     length = MIN(length, G_N_ELEMENTS(value->value.iec958.subcode));
     for (i = 0; i < length; ++i)
         value->value.iec958.subcode[i] = data[i];
@@ -375,8 +402,11 @@ void alsactl_elem_value_get_iec60958_user_data(ALSACtlElemValue *self,
 
     g_return_if_fail(ALSACTL_IS_ELEM_VALUE(self));
     priv = alsactl_elem_value_get_instance_private(self);
-    value = &priv->value;
 
+    g_return_if_fail(data != NULL);
+    g_return_if_fail(length != NULL);
+
+    value = &priv->value;
     *length = MIN(*length, G_N_ELEMENTS(value->value.iec958.subcode));
     for (i = 0; i < *length; ++i)
         (*data)[i] = value->value.iec958.subcode[i];
@@ -399,8 +429,10 @@ void alsactl_elem_value_set_int64(ALSACtlElemValue *self, const gint64 *values,
 
     g_return_if_fail(ALSACTL_IS_ELEM_VALUE(self));
     priv = alsactl_elem_value_get_instance_private(self);
-    value = &priv->value;
 
+    g_return_if_fail(values != NULL);
+
+    value = &priv->value;
     value_count = MIN(value_count, G_N_ELEMENTS(value->value.integer64.value));
     for (i = 0; i < value_count; ++i)
         value->value.integer64.value[i] = (long long)values[i];
@@ -424,8 +456,11 @@ void alsactl_elem_value_get_int64(ALSACtlElemValue *self,
 
     g_return_if_fail(ALSACTL_IS_ELEM_VALUE(self));
     priv = alsactl_elem_value_get_instance_private(self);
-    value = &priv->value;
 
+    g_return_if_fail(values != NULL);
+    g_return_if_fail(value_count != NULL);
+
+    value = &priv->value;
     *value_count = MIN(*value_count, G_N_ELEMENTS(value->value.integer64.value));
     for (i = 0; i < *value_count; ++i)
         (*values)[i] = (gint64)value->value.integer64.value[i];

--- a/src/ctl/privates.h
+++ b/src/ctl/privates.h
@@ -16,12 +16,6 @@
 
 G_BEGIN_DECLS
 
-GQuark alsactl_error_quark(void);
-
-#define generate_error(err, errno)                      \
-    g_set_error(err, alsactl_error_quark(), errno,      \
-                __FILE__ ":%d: %s", __LINE__, strerror(errno))
-
 void ctl_card_info_refer_private(ALSACtlCardInfo *self,
                                  struct snd_ctl_card_info **info);
 

--- a/src/ctl/query.c
+++ b/src/ctl/query.c
@@ -16,9 +16,6 @@
  *                     descriptor
  */
 
-// For error handling.
-G_DEFINE_QUARK("alsactl-error", alsactl_error)
-
 #define CARD_SYSNAME_TEMPLATE       "card%u"
 #define CONTROL_SYSNAME_TEMPLATE    "controlC%u"
 

--- a/src/ctl/query.c
+++ b/src/ctl/query.c
@@ -127,6 +127,7 @@ void alsactl_get_card_id_list(guint **entries, gsize *entry_count,
         generate_error(error, EINVAL);
         return;
     }
+    g_return_if_fail(error == NULL || *error == NULL);
 
     prepare_udev_enum(&enumerator, error);
     if (enumerator == NULL)
@@ -240,6 +241,7 @@ void alsactl_get_card_sysname(guint card_id, char **sysname, GError **error)
     char *name;
 
     g_return_if_fail(sysname != NULL);
+    g_return_if_fail(error == NULL || *error == NULL);
 
     allocate_sysname(&name, CARD_SYSNAME_TEMPLATE, card_id, error);
     if (*error != NULL)
@@ -269,6 +271,7 @@ void alsactl_get_control_sysname(guint card_id, char **sysname, GError **error)
     char *name;
 
     g_return_if_fail(sysname != NULL);
+    g_return_if_fail(error == NULL || *error == NULL);
 
     allocate_sysname(&name, CONTROL_SYSNAME_TEMPLATE, card_id, error);
     if (*error != NULL)
@@ -301,6 +304,7 @@ void alsactl_get_control_devnode(guint card_id, char **devnode, GError **error)
     const char *node;
 
     g_return_if_fail(devnode != NULL);
+    g_return_if_fail(error == NULL || *error == NULL);
 
     allocate_sysname(&sysname, CONTROL_SYSNAME_TEMPLATE, card_id, error);
     if (*error != NULL)

--- a/src/ctl/query.c
+++ b/src/ctl/query.c
@@ -147,11 +147,7 @@ void alsactl_get_card_id_list(guint **entries, gsize *entry_count,
     if (count == 0)
         goto end;
 
-    *entries = g_try_malloc0_n(count, sizeof(**entries));
-    if (*entries == NULL) {
-        generate_error(error, ENOMEM);
-        goto end;
-    }
+    *entries = g_malloc0_n(count, sizeof(**entries));
 
     index = 0;
     udev_list_entry_foreach(entry, entry_list) {
@@ -198,11 +194,7 @@ static void allocate_sysname(char **sysname ,const char *template,
     }
 
     length = strlen(template) + digits;
-    *sysname = g_try_malloc0(length + 1);
-    if (*sysname == NULL) {
-        generate_error(error, ENOMEM);
-        return;
-    }
+    *sysname = g_malloc0(length + 1);
 
     snprintf(*sysname, length, template, card_id);
 }
@@ -332,7 +324,7 @@ void alsactl_get_control_devnode(guint card_id, char **devnode, GError **error)
 
     node = udev_device_get_devnode(dev);
     if (node != NULL)
-        *devnode = strdup(node);
+        *devnode = g_strdup(node);
     else
         generate_error(error, ENODEV);
 

--- a/src/ctl/query.c
+++ b/src/ctl/query.c
@@ -123,10 +123,8 @@ void alsactl_get_card_id_list(guint **entries, gsize *entry_count,
     unsigned int count;
     unsigned int index;
 
-    if (entries == NULL || entry_count == NULL || error == NULL) {
-        generate_error(error, EINVAL);
-        return;
-    }
+    g_return_if_fail(entries != NULL);
+    g_return_if_fail(entry_count != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     prepare_udev_enum(&enumerator, error);
@@ -168,7 +166,7 @@ void alsactl_get_card_id_list(guint **entries, gsize *entry_count,
         }
     }
     if (index != count) {
-        generate_error(error, ENOENT);
+        g_warn_if_reached();
         g_free(*entries);
         *entries = NULL;
         goto end;

--- a/tests/alsactl-enums
+++ b/tests/alsactl-enums
@@ -56,6 +56,7 @@ card_error_types = (
     'DISCONNECTED',
     'ELEM_NOT_FOUND',
     'ELEM_NOT_SUPPORTED',
+    'ELEM_OWNED',
 )
 
 types = {

--- a/tests/alsactl-enums
+++ b/tests/alsactl-enums
@@ -51,6 +51,10 @@ elem_event_mask_flags = (
     'REMOVE',
 )
 
+card_error_types = (
+    'FAILED',
+)
+
 types = {
     ALSACtl.ElemType:       elem_types,
     ALSACtl.ElemIfaceType:  elem_iface_types,
@@ -58,6 +62,7 @@ types = {
     ALSACtl.ElemAccessFlag: elem_access_flags,
     ALSACtl.EventType:      event_types,
     ALSACtl.ElemEventMask:  elem_event_mask_flags,
+    ALSACtl.CardError:      card_error_types,
 }
 
 for obj, types in types.items():

--- a/tests/alsactl-enums
+++ b/tests/alsactl-enums
@@ -57,6 +57,7 @@ card_error_types = (
     'ELEM_NOT_FOUND',
     'ELEM_NOT_SUPPORTED',
     'ELEM_OWNED',
+    'ELEM_EXIST',
 )
 
 types = {

--- a/tests/alsactl-enums
+++ b/tests/alsactl-enums
@@ -55,6 +55,7 @@ card_error_types = (
     'FAILED',
     'DISCONNECTED',
     'ELEM_NOT_FOUND',
+    'ELEM_NOT_SUPPORTED',
 )
 
 types = {

--- a/tests/alsactl-enums
+++ b/tests/alsactl-enums
@@ -53,6 +53,7 @@ elem_event_mask_flags = (
 
 card_error_types = (
     'FAILED',
+    'DISCONNECTED',
 )
 
 types = {

--- a/tests/alsactl-enums
+++ b/tests/alsactl-enums
@@ -54,6 +54,7 @@ elem_event_mask_flags = (
 card_error_types = (
     'FAILED',
     'DISCONNECTED',
+    'ELEM_NOT_FOUND',
 )
 
 types = {


### PR DESCRIPTION
Current implementation uses library-wide error domain to report error, however this is partly against rule of GError usage. Furthermore, the error delivers information just about errno and hard to know the cause of error.

This patchset enhances error reporting. The library-wide error domain is obsoleted. A new error domain is added just for ALSACtl.Card. The error domain delivers information about the cause of error.