### PR TITLE
[PATCH 00/16] alsa-gobject: timer: enhancement for error reporting

### DIFF
--- a/src/timer/alsatimer-enum-types.h
+++ b/src/timer/alsatimer-enum-types.h
@@ -125,11 +125,13 @@ typedef enum {
 /**
  * ALSATimerUserInstanceError:
  * @ALSATIMER_USER_INSTANCE_ERROR_FAILED:           The system call failed.
+ * @ALSATIMER_USER_INSTANCE_ERROR_TIMER_NOT_FOUND:  The timer instance is not found.
  *
  * A set of error code for GError with domain which equals to #alsatimer_user_instance_error_quark()
  */
 typedef enum {
     ALSATIMER_USER_INSTANCE_ERROR_FAILED,
+    ALSATIMER_USER_INSTANCE_ERROR_TIMER_NOT_FOUND,
 } ALSATimerUserInstanceError;
 
 #endif

--- a/src/timer/alsatimer-enum-types.h
+++ b/src/timer/alsatimer-enum-types.h
@@ -122,4 +122,14 @@ typedef enum {
     ALSATIMER_EVENT_DATA_TYPE_TSTAMP,
 } ALSATimerEventDataType;
 
+/**
+ * ALSATimerUserInstanceError:
+ * @ALSATIMER_USER_INSTANCE_ERROR_FAILED:           The system call failed.
+ *
+ * A set of error code for GError with domain which equals to #alsatimer_user_instance_error_quark()
+ */
+typedef enum {
+    ALSATIMER_USER_INSTANCE_ERROR_FAILED,
+} ALSATimerUserInstanceError;
+
 #endif

--- a/src/timer/alsatimer-enum-types.h
+++ b/src/timer/alsatimer-enum-types.h
@@ -128,6 +128,8 @@ typedef enum {
  * @ALSATIMER_USER_INSTANCE_ERROR_TIMER_NOT_FOUND:  The timer instance is not found.
  * @ALSATIMER_USER_INSTANCE_ERROR_NOT_ATTACHED:     The timer instance is not attached to any timer
  *                                                  device or the other instance.
+ * @ALSATIMER_USER_INSTANCE_ERROR_ATTACHED:         The timer instance is already attached to timer
+ *                                                  device or the other instance.
  *
  * A set of error code for GError with domain which equals to #alsatimer_user_instance_error_quark()
  */
@@ -135,6 +137,7 @@ typedef enum {
     ALSATIMER_USER_INSTANCE_ERROR_FAILED,
     ALSATIMER_USER_INSTANCE_ERROR_TIMER_NOT_FOUND,
     ALSATIMER_USER_INSTANCE_ERROR_NOT_ATTACHED,
+    ALSATIMER_USER_INSTANCE_ERROR_ATTACHED,
 } ALSATimerUserInstanceError;
 
 #endif

--- a/src/timer/alsatimer-enum-types.h
+++ b/src/timer/alsatimer-enum-types.h
@@ -126,12 +126,15 @@ typedef enum {
  * ALSATimerUserInstanceError:
  * @ALSATIMER_USER_INSTANCE_ERROR_FAILED:           The system call failed.
  * @ALSATIMER_USER_INSTANCE_ERROR_TIMER_NOT_FOUND:  The timer instance is not found.
+ * @ALSATIMER_USER_INSTANCE_ERROR_NOT_ATTACHED:     The timer instance is not attached to any timer
+ *                                                  device or the other instance.
  *
  * A set of error code for GError with domain which equals to #alsatimer_user_instance_error_quark()
  */
 typedef enum {
     ALSATIMER_USER_INSTANCE_ERROR_FAILED,
     ALSATIMER_USER_INSTANCE_ERROR_TIMER_NOT_FOUND,
+    ALSATIMER_USER_INSTANCE_ERROR_NOT_ATTACHED,
 } ALSATimerUserInstanceError;
 
 #endif

--- a/src/timer/alsatimer.map
+++ b/src/timer/alsatimer.map
@@ -73,3 +73,7 @@ ALSA_GOBJECT_0_0_0 {
   local:
     *;
 };
+
+ALSA_GOBJECT_0_2_0 {
+    "alsatimer_user_instance_error_get_type";
+} ALSA_GOBJECT_0_0_0;

--- a/src/timer/alsatimer.map
+++ b/src/timer/alsatimer.map
@@ -76,4 +76,5 @@ ALSA_GOBJECT_0_0_0 {
 
 ALSA_GOBJECT_0_2_0 {
     "alsatimer_user_instance_error_get_type";
+    "alsatimer_user_instance_error_quark";
 } ALSA_GOBJECT_0_0_0;

--- a/src/timer/instance-params.c
+++ b/src/timer/instance-params.c
@@ -150,6 +150,8 @@ void alsatimer_instance_params_set_event_filter(ALSATimerInstanceParams *self,
     g_return_if_fail(entries != NULL);
     priv = alsatimer_instance_params_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     priv->params.filter = 0;
 
     // Clear the event filter.
@@ -198,6 +200,8 @@ void alsatimer_instance_params_get_event_filter(ALSATimerInstanceParams *self,
     g_return_if_fail(entries != NULL);
     g_return_if_fail(entry_count != NULL);
     priv = alsatimer_instance_params_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     count = 0;
     filter = priv->params.filter;

--- a/src/timer/instance-params.c
+++ b/src/timer/instance-params.c
@@ -209,11 +209,7 @@ void alsatimer_instance_params_get_event_filter(ALSATimerInstanceParams *self,
     if (count == 0)
         return;
 
-    list = g_try_malloc0_n(count, sizeof(*list));
-    if (list == NULL) {
-        generate_error(error, ENOMEM);
-        return;
-    }
+    list = g_malloc0_n(count, sizeof(*list));
 
     index = 0;
     for (i = 0; i < sizeof(filter) * 8; ++i) {

--- a/src/timer/instance-params.c
+++ b/src/timer/instance-params.c
@@ -147,9 +147,9 @@ void alsatimer_instance_params_set_event_filter(ALSATimerInstanceParams *self,
     int i;
 
     g_return_if_fail(ALSATIMER_IS_INSTANCE_PARAMS(self));
-    g_return_if_fail(entries != NULL);
     priv = alsatimer_instance_params_get_instance_private(self);
 
+    g_return_if_fail(entries != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     priv->params.filter = 0;
@@ -197,10 +197,10 @@ void alsatimer_instance_params_get_event_filter(ALSATimerInstanceParams *self,
     int i;
 
     g_return_if_fail(ALSATIMER_IS_INSTANCE_PARAMS(self));
-    g_return_if_fail(entries != NULL);
-    g_return_if_fail(entry_count != NULL);
     priv = alsatimer_instance_params_get_instance_private(self);
 
+    g_return_if_fail(entries != NULL);
+    g_return_if_fail(entry_count != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     count = 0;

--- a/src/timer/instance-params.c
+++ b/src/timer/instance-params.c
@@ -165,8 +165,7 @@ void alsatimer_instance_params_set_event_filter(ALSATimerInstanceParams *self,
             (val > SNDRV_TIMER_EVENT_RESUME &&
              val < SNDRV_TIMER_EVENT_MSTART) ||
             val > SNDRV_TIMER_EVENT_MRESUME) {
-            generate_error(error, EINVAL);
-            return;
+            g_return_if_reached();
         }
         filter |= (1u << val);
     }
@@ -225,9 +224,8 @@ void alsatimer_instance_params_get_event_filter(ALSATimerInstanceParams *self,
     }
 
     if (index != count) {
-        generate_error(error, ENXIO);
         g_free(list);
-        return;
+        g_return_if_reached();
     }
 
     *entries = list;

--- a/src/timer/instance-status.c
+++ b/src/timer/instance-status.c
@@ -116,8 +116,9 @@ void alsatimer_instance_status_get_tstamp(ALSATimerInstanceStatus *self,
     ALSATimerInstanceStatusPrivate *priv;
 
     g_return_if_fail(ALSATIMER_IS_INSTANCE_STATUS(self));
-    g_return_if_fail(tstamp != NULL);
     priv = alsatimer_instance_status_get_instance_private(self);
+
+    g_return_if_fail(tstamp != NULL);
 
     priv->tstamp[0] = (gint64)priv->status.tstamp.tv_sec;
     priv->tstamp[1] = (gint64)priv->status.tstamp.tv_nsec;

--- a/src/timer/privates.h
+++ b/src/timer/privates.h
@@ -13,12 +13,6 @@
 
 G_BEGIN_DECLS
 
-GQuark alsatimer_error_quark(void);
-
-#define generate_error(err, errno)                              \
-    g_set_error(err, alsatimer_error_quark(), errno,            \
-                __FILE__ ":%d: %s", __LINE__, strerror(errno))
-
 void timer_device_info_refer_private(ALSATimerDeviceInfo *self,
                                      struct snd_timer_ginfo **info);
 

--- a/src/timer/query.c
+++ b/src/timer/query.c
@@ -70,6 +70,7 @@ void alsatimer_get_sysname(char **sysname, GError **error)
     char *name;
 
     g_return_if_fail(sysname != NULL);
+    g_return_if_fail(error == NULL || *error == NULL);
 
     name = g_strdup(TIMER_SYSNAME_TEMPLATE);
 
@@ -97,6 +98,7 @@ void alsatimer_get_devnode(char **devnode, GError **error)
     const char *node;
 
     g_return_if_fail(devnode != NULL);
+    g_return_if_fail(error == NULL || *error == NULL);
 
     ctx = udev_new();
     if (ctx == NULL) {
@@ -142,6 +144,7 @@ void alsatimer_get_device_id_list(GList **entries, GError **error)
     int fd;
 
     g_return_if_fail(entries != NULL);
+    g_return_if_fail(error == NULL || *error == NULL);
 
     alsatimer_get_devnode(&devnode, error);
     if (*error != NULL)
@@ -189,6 +192,7 @@ void alsatimer_get_device_info(ALSATimerDeviceId *device_id,
     int fd;
 
     g_return_if_fail(device_id != NULL);
+    g_return_if_fail(error == NULL || *error == NULL);
 
     alsatimer_get_devnode(&devnode, error);
     if (*error != NULL)
@@ -234,6 +238,7 @@ void alsatimer_get_device_status(ALSATimerDeviceId *device_id,
 
     g_return_if_fail(device_id != NULL);
     g_return_if_fail(ALSATIMER_IS_DEVICE_STATUS(*device_status));
+    g_return_if_fail(error == NULL || *error == NULL);
 
     alsatimer_get_devnode(&devnode, error);
     if (*error != NULL)
@@ -278,6 +283,7 @@ void alsatimer_set_device_params(ALSATimerDeviceId *device_id,
 
     g_return_if_fail(device_id != NULL);
     g_return_if_fail(device_params != NULL);
+    g_return_if_fail(error == NULL || *error == NULL);
 
     alsatimer_get_devnode(&devnode, error);
     if (*error != NULL)
@@ -355,6 +361,8 @@ void alsatimer_get_tstamp_source(int *clock_id, GError **error)
     int val;
     gsize size;
     char *buf;
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     // Count required digits.
     val = INT_MAX;

--- a/src/timer/query.c
+++ b/src/timer/query.c
@@ -192,6 +192,7 @@ void alsatimer_get_device_info(ALSATimerDeviceId *device_id,
     int fd;
 
     g_return_if_fail(device_id != NULL);
+    g_return_if_fail(device_info != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     alsatimer_get_devnode(&devnode, error);

--- a/src/timer/query.c
+++ b/src/timer/query.c
@@ -24,9 +24,6 @@
  *                     file descriptor
  */
 
-// For error handling.
-G_DEFINE_QUARK("alsatimer-error", alsatimer_error)
-
 #define TIMER_SYSNAME_TEMPLATE  "timer"
 #define SYSFS_SND_TIMER_NODE    "/sys/module/snd_timer/"
 

--- a/src/timer/query.c
+++ b/src/timer/query.c
@@ -71,11 +71,7 @@ void alsatimer_get_sysname(char **sysname, GError **error)
 
     g_return_if_fail(sysname != NULL);
 
-    name = strdup(TIMER_SYSNAME_TEMPLATE);
-    if (name == NULL) {
-        generate_error(error, ENOMEM);
-        return;
-    }
+    name = g_strdup(TIMER_SYSNAME_TEMPLATE);
 
     if (!check_existence(name, error)) {
         g_free(name);
@@ -118,7 +114,7 @@ void alsatimer_get_devnode(char **devnode, GError **error)
 
     node = udev_device_get_devnode(dev);
     if (node != NULL)
-        *devnode = strdup(node);
+        *devnode = g_strdup(node);
     else
         generate_error(error, ENODEV);
 
@@ -371,11 +367,7 @@ void alsatimer_get_tstamp_source(int *clock_id, GError **error)
     // For codes of sign and new line.
     size += 2;
 
-    buf = g_try_malloc0(size);
-    if (buf == NULL) {
-        generate_error(error, ENOMEM);
-        return;
-    }
+    buf = g_malloc0(size);
 
     timer_get_node_param_value("timer_tstamp_monotonic", buf, size, &val,
                                error);

--- a/src/timer/user-instance.c
+++ b/src/timer/user-instance.c
@@ -179,14 +179,10 @@ void alsatimer_user_instance_get_protocol_version(ALSATimerUserInstance *self,
 
     g_return_if_fail(ALSATIMER_IS_USER_INSTANCE(self));
     priv = alsatimer_user_instance_get_instance_private(self);
+    g_return_if_fail(priv->fd >= 0);
 
     g_return_if_fail(proto_ver_triplet != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
-
-    if (priv->fd < 0) {
-        generate_error(error, ENXIO);
-        return;
-    }
 
     *proto_ver_triplet = (const guint16 *)priv->proto_ver_triplet;
 }
@@ -490,14 +486,10 @@ void alsatimer_user_instance_create_source(ALSATimerUserInstance *self,
 
     g_return_if_fail(ALSATIMER_IS_USER_INSTANCE(self));
     priv = alsatimer_user_instance_get_instance_private(self);
+    g_return_if_fail(priv->fd >= 0);
 
     g_return_if_fail(gsrc != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
-
-    if (priv->fd < 0) {
-        generate_error(error, ENXIO);
-        return;
-    }
 
     buf = g_malloc0(page_size);
 

--- a/src/timer/user-instance.c
+++ b/src/timer/user-instance.c
@@ -254,15 +254,12 @@ void alsatimer_user_instance_attach(ALSATimerUserInstance *self,
  * @slave_id: The numerical identifier of master instance.
  * @error: A #GError.
  *
- * Attach the instance to timer device as an slave to another instance indicated
- * by a pair of slave_class and slave_id. If the slave_class is for application
+ * Attach the instance as an slave to another instance indicated by a pair of
+ * slave_class and slave_id. If the slave_class is for application
  * (=ALSATIMER_SLAVE_CLASS_APPLICATION), the slave_id is for the PID of
  * application process which owns the instance of timer. If the slave_class is
  * for ALSA sequencer (=ALSATIMER_SLAVE_CLASS_SEQUENCER), the slave_id is the
  * numerical ID of queue bound for timer device.
- *
- * Attach the instance to the timer device. If the given device_id is for
- * absent timer device, the instance can be detached with error.
  *
  * The call of function executes ioctl(2) system call with
  * SNDRV_TIMER_IOCTL_SELECT command for ALSA timer character device.

--- a/src/timer/user-instance.c
+++ b/src/timer/user-instance.c
@@ -30,6 +30,15 @@ struct _ALSATimerUserInstancePrivate {
 };
 G_DEFINE_TYPE_WITH_PRIVATE(ALSATimerUserInstance, alsatimer_user_instance, G_TYPE_OBJECT)
 
+/**
+ * alsatimer_user_instance_error_quark:
+ *
+ * Return the GQuark for error domain of GError which has code in #ALSATimerUserInstanceError enumerations.
+ *
+ * Returns: A #GQuark.
+ */
+G_DEFINE_QUARK(alsatimer-user-instance-error-quark, alsatimer_user_instance_error)
+
 typedef struct {
     GSource src;
     ALSATimerUserInstance *self;

--- a/src/timer/user-instance.c
+++ b/src/timer/user-instance.c
@@ -39,6 +39,10 @@ G_DEFINE_TYPE_WITH_PRIVATE(ALSATimerUserInstance, alsatimer_user_instance, G_TYP
  */
 G_DEFINE_QUARK(alsatimer-user-instance-error-quark, alsatimer_user_instance_error)
 
+#define generate_syscall_error(exception, errno, fmt, arg)                                      \
+    g_set_error(exception, ALSATIMER_USER_INSTANCE_ERROR, ALSATIMER_USER_INSTANCE_ERROR_FAILED, \
+                fmt" %d(%s)", arg, errno, strerror(errno))
+
 typedef struct {
     GSource src;
     ALSATimerUserInstance *self;
@@ -152,7 +156,7 @@ void alsatimer_user_instance_open(ALSATimerUserInstance *self, gint open_flag,
 
     // Remember the version of protocol currently used.
     if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_PVERSION, &proto_ver) < 0) {
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", "PVERSION");
         close(priv->fd);
         priv->fd = -1;
         return;
@@ -225,7 +229,7 @@ void alsatimer_user_instance_choose_event_data_type(ALSATimerUserInstance *self,
 
     tread = (int)event_data_type;
     if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_TREAD, &tread) < 0)
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", "TREAD");
     else
         priv->event_data_type = event_data_type;
 }
@@ -257,7 +261,7 @@ void alsatimer_user_instance_attach(ALSATimerUserInstance *self,
 
     sel.id = *device_id;
     if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_SELECT, &sel) < 0)
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", "SELECT");
 }
 
 /**
@@ -295,7 +299,7 @@ void alsatimer_user_instance_attach_as_slave(ALSATimerUserInstance *self,
     sel.id.dev_sclass = slave_class;
     sel.id.device = slave_id;
     if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_SELECT, &sel) < 0)
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", "SELECT");
 }
 
 /**
@@ -326,7 +330,7 @@ void alsatimer_user_instance_get_info(ALSATimerUserInstance *self,
     timer_instance_info_refer_private(*instance_info, &info);
 
     if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_INFO, info) < 0) {
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", "INFO");
         g_object_unref(*instance_info);
     }
 }
@@ -358,7 +362,7 @@ void alsatimer_user_instance_set_params(ALSATimerUserInstance *self,
     timer_instance_params_refer_private(*instance_params, &params);
 
     if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_PARAMS, params) < 0)
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", "PARAMS");
 }
 
 /**
@@ -389,7 +393,7 @@ void alsatimer_user_instance_get_status(ALSATimerUserInstance *self,
     timer_instance_status_refer_private(*instance_status, &status);
 
     if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_STATUS, status) < 0)
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", "STATUS");
 }
 
 static gboolean timer_user_instance_check_src(GSource *gsrc)
@@ -535,7 +539,7 @@ void alsatimer_user_instance_start(ALSATimerUserInstance *self, GError **error)
     g_return_if_fail(error == NULL || *error == NULL);
 
     if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_START) < 0)
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", "START");
 }
 
 /**
@@ -558,7 +562,7 @@ void alsatimer_user_instance_stop(ALSATimerUserInstance *self, GError **error)
     g_return_if_fail(error == NULL || *error == NULL);
 
     if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_STOP) < 0)
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", "STOP");
 }
 
 /**
@@ -581,7 +585,7 @@ void alsatimer_user_instance_pause(ALSATimerUserInstance *self, GError **error)
     g_return_if_fail(error == NULL || *error == NULL);
 
     if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_PAUSE) < 0)
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", "PAUSE");
 }
 
 /**
@@ -605,5 +609,5 @@ void alsatimer_user_instance_continue(ALSATimerUserInstance *self,
     g_return_if_fail(error == NULL || *error == NULL);
 
     if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_CONTINUE) < 0)
-        generate_error(error, errno);
+        generate_syscall_error(error, errno, "ioctl(%s)", "CONTINUE");
 }

--- a/src/timer/user-instance.c
+++ b/src/timer/user-instance.c
@@ -41,6 +41,7 @@ G_DEFINE_QUARK(alsatimer-user-instance-error-quark, alsatimer_user_instance_erro
 
 static const char *const err_msgs[] = {
     [ALSATIMER_USER_INSTANCE_ERROR_TIMER_NOT_FOUND] = "The timer instance is not found",
+    [ALSATIMER_USER_INSTANCE_ERROR_NOT_ATTACHED] = "The timer instance is not attached to any timer device or the other instance",
 };
 
 #define generate_local_error(exception, code) \
@@ -351,7 +352,10 @@ void alsatimer_user_instance_get_info(ALSATimerUserInstance *self,
     timer_instance_info_refer_private(*instance_info, &info);
 
     if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_INFO, info) < 0) {
-        generate_syscall_error(error, errno, "ioctl(%s)", "INFO");
+        if (errno == EBADFD)
+            generate_local_error(error, ALSATIMER_USER_INSTANCE_ERROR_NOT_ATTACHED);
+        else
+            generate_syscall_error(error, errno, "ioctl(%s)", "INFO");
         g_object_unref(*instance_info);
     }
 }
@@ -382,8 +386,12 @@ void alsatimer_user_instance_set_params(ALSATimerUserInstance *self,
 
     timer_instance_params_refer_private(*instance_params, &params);
 
-    if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_PARAMS, params) < 0)
-        generate_syscall_error(error, errno, "ioctl(%s)", "PARAMS");
+    if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_PARAMS, params) < 0) {
+        if (errno == EBADFD)
+            generate_local_error(error, ALSATIMER_USER_INSTANCE_ERROR_NOT_ATTACHED);
+        else
+            generate_syscall_error(error, errno, "ioctl(%s)", "PARAMS");
+    }
 }
 
 /**
@@ -413,8 +421,12 @@ void alsatimer_user_instance_get_status(ALSATimerUserInstance *self,
     g_return_if_fail(ALSATIMER_IS_INSTANCE_STATUS(*instance_status));
     timer_instance_status_refer_private(*instance_status, &status);
 
-    if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_STATUS, status) < 0)
-        generate_syscall_error(error, errno, "ioctl(%s)", "STATUS");
+    if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_STATUS, status) < 0) {
+        if (errno == EBADFD)
+            generate_local_error(error, ALSATIMER_USER_INSTANCE_ERROR_NOT_ATTACHED);
+        else
+            generate_syscall_error(error, errno, "ioctl(%s)", "STATUS");
+    }
 }
 
 static gboolean timer_user_instance_check_src(GSource *gsrc)
@@ -559,8 +571,12 @@ void alsatimer_user_instance_start(ALSATimerUserInstance *self, GError **error)
 
     g_return_if_fail(error == NULL || *error == NULL);
 
-    if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_START) < 0)
-        generate_syscall_error(error, errno, "ioctl(%s)", "START");
+    if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_START) < 0) {
+        if (errno == EBADFD)
+            generate_local_error(error, ALSATIMER_USER_INSTANCE_ERROR_NOT_ATTACHED);
+        else
+            generate_syscall_error(error, errno, "ioctl(%s)", "START");
+    }
 }
 
 /**
@@ -582,8 +598,12 @@ void alsatimer_user_instance_stop(ALSATimerUserInstance *self, GError **error)
 
     g_return_if_fail(error == NULL || *error == NULL);
 
-    if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_STOP) < 0)
-        generate_syscall_error(error, errno, "ioctl(%s)", "STOP");
+    if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_STOP) < 0) {
+        if (errno == EBADFD)
+            generate_local_error(error, ALSATIMER_USER_INSTANCE_ERROR_NOT_ATTACHED);
+        else
+            generate_syscall_error(error, errno, "ioctl(%s)", "STOP");
+    }
 }
 
 /**
@@ -605,8 +625,12 @@ void alsatimer_user_instance_pause(ALSATimerUserInstance *self, GError **error)
 
     g_return_if_fail(error == NULL || *error == NULL);
 
-    if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_PAUSE) < 0)
-        generate_syscall_error(error, errno, "ioctl(%s)", "PAUSE");
+    if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_PAUSE) < 0) {
+        if (errno == EBADFD)
+            generate_local_error(error, ALSATIMER_USER_INSTANCE_ERROR_NOT_ATTACHED);
+        else
+            generate_syscall_error(error, errno, "ioctl(%s)", "PAUSE");
+    }
 }
 
 /**
@@ -629,6 +653,10 @@ void alsatimer_user_instance_continue(ALSATimerUserInstance *self,
 
     g_return_if_fail(error == NULL || *error == NULL);
 
-    if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_CONTINUE) < 0)
-        generate_syscall_error(error, errno, "ioctl(%s)", "CONTINUE");
+    if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_CONTINUE) < 0) {
+        if (errno == EBADFD)
+            generate_local_error(error, ALSATIMER_USER_INSTANCE_ERROR_NOT_ATTACHED);
+        else
+            generate_syscall_error(error, errno, "ioctl(%s)", "CONTINUE");
+    }
 }

--- a/src/timer/user-instance.c
+++ b/src/timer/user-instance.c
@@ -476,11 +476,7 @@ void alsatimer_user_instance_create_source(ALSATimerUserInstance *self,
         return;
     }
 
-    buf = g_try_malloc0(page_size);
-    if (buf == NULL) {
-        generate_error(error, ENOMEM);
-        return;
-    }
+    buf = g_malloc0(page_size);
 
     *gsrc = g_source_new(&funcs, sizeof(TimerUserInstanceSource));
     src = (TimerUserInstanceSource *)(*gsrc);

--- a/src/timer/user-instance.c
+++ b/src/timer/user-instance.c
@@ -127,6 +127,8 @@ void alsatimer_user_instance_open(ALSATimerUserInstance *self, gint open_flag,
     g_return_if_fail(ALSATIMER_IS_USER_INSTANCE(self));
     priv = alsatimer_user_instance_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     alsatimer_get_devnode(&devnode, error);
     if (*error != NULL)
         return;
@@ -178,6 +180,8 @@ void alsatimer_user_instance_get_protocol_version(ALSATimerUserInstance *self,
     g_return_if_fail(ALSATIMER_IS_USER_INSTANCE(self));
     priv = alsatimer_user_instance_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     if (priv->fd < 0) {
         generate_error(error, ENXIO);
         return;
@@ -211,6 +215,8 @@ void alsatimer_user_instance_choose_event_data_type(ALSATimerUserInstance *self,
     g_return_if_fail(ALSATIMER_IS_USER_INSTANCE(self));
     priv = alsatimer_user_instance_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     tread = (int)event_data_type;
     if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_TREAD, &tread) < 0)
         generate_error(error, errno);
@@ -240,6 +246,8 @@ void alsatimer_user_instance_attach(ALSATimerUserInstance *self,
     g_return_if_fail(ALSATIMER_IS_USER_INSTANCE(self));
     g_return_if_fail(device_id != NULL);
     priv = alsatimer_user_instance_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     sel.id = *device_id;
     if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_SELECT, &sel) < 0)
@@ -275,6 +283,8 @@ void alsatimer_user_instance_attach_as_slave(ALSATimerUserInstance *self,
     g_return_if_fail(ALSATIMER_IS_USER_INSTANCE(self));
     priv = alsatimer_user_instance_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     sel.id.dev_class = SNDRV_TIMER_CLASS_SLAVE;
     sel.id.dev_sclass = slave_class;
     sel.id.device = slave_id;
@@ -302,6 +312,8 @@ void alsatimer_user_instance_get_info(ALSATimerUserInstance *self,
 
     g_return_if_fail(ALSATIMER_IS_USER_INSTANCE(self));
     priv = alsatimer_user_instance_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     *instance_info = g_object_new(ALSATIMER_TYPE_INSTANCE_INFO, NULL);
     timer_instance_info_refer_private(*instance_info, &info);
@@ -333,6 +345,8 @@ void alsatimer_user_instance_set_params(ALSATimerUserInstance *self,
     g_return_if_fail(ALSATIMER_IS_USER_INSTANCE(self));
     priv = alsatimer_user_instance_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     timer_instance_params_refer_private(*instance_params, &params);
 
     if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_PARAMS, params) < 0)
@@ -359,6 +373,8 @@ void alsatimer_user_instance_get_status(ALSATimerUserInstance *self,
 
     g_return_if_fail(ALSATIMER_IS_USER_INSTANCE(self));
     priv = alsatimer_user_instance_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     g_return_if_fail(ALSATIMER_IS_INSTANCE_STATUS(*instance_status));
     timer_instance_status_refer_private(*instance_status, &status);
@@ -471,6 +487,8 @@ void alsatimer_user_instance_create_source(ALSATimerUserInstance *self,
     g_return_if_fail(ALSATIMER_IS_USER_INSTANCE(self));
     priv = alsatimer_user_instance_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     if (priv->fd < 0) {
         generate_error(error, ENXIO);
         return;
@@ -508,6 +526,8 @@ void alsatimer_user_instance_start(ALSATimerUserInstance *self, GError **error)
     g_return_if_fail(ALSATIMER_IS_USER_INSTANCE(self));
     priv = alsatimer_user_instance_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_START) < 0)
         generate_error(error, errno);
 }
@@ -528,6 +548,8 @@ void alsatimer_user_instance_stop(ALSATimerUserInstance *self, GError **error)
 
     g_return_if_fail(ALSATIMER_IS_USER_INSTANCE(self));
     priv = alsatimer_user_instance_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_STOP) < 0)
         generate_error(error, errno);
@@ -550,6 +572,8 @@ void alsatimer_user_instance_pause(ALSATimerUserInstance *self, GError **error)
     g_return_if_fail(ALSATIMER_IS_USER_INSTANCE(self));
     priv = alsatimer_user_instance_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_PAUSE) < 0)
         generate_error(error, errno);
 }
@@ -571,6 +595,8 @@ void alsatimer_user_instance_continue(ALSATimerUserInstance *self,
 
     g_return_if_fail(ALSATIMER_IS_USER_INSTANCE(self));
     priv = alsatimer_user_instance_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     if (ioctl(priv->fd, SNDRV_TIMER_IOCTL_CONTINUE) < 0)
         generate_error(error, errno);

--- a/src/timer/user-instance.c
+++ b/src/timer/user-instance.c
@@ -180,6 +180,7 @@ void alsatimer_user_instance_get_protocol_version(ALSATimerUserInstance *self,
     g_return_if_fail(ALSATIMER_IS_USER_INSTANCE(self));
     priv = alsatimer_user_instance_get_instance_private(self);
 
+    g_return_if_fail(proto_ver_triplet != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     if (priv->fd < 0) {
@@ -244,9 +245,9 @@ void alsatimer_user_instance_attach(ALSATimerUserInstance *self,
     struct snd_timer_select sel = {0};
 
     g_return_if_fail(ALSATIMER_IS_USER_INSTANCE(self));
-    g_return_if_fail(device_id != NULL);
     priv = alsatimer_user_instance_get_instance_private(self);
 
+    g_return_if_fail(device_id != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     sel.id = *device_id;
@@ -313,6 +314,7 @@ void alsatimer_user_instance_get_info(ALSATimerUserInstance *self,
     g_return_if_fail(ALSATIMER_IS_USER_INSTANCE(self));
     priv = alsatimer_user_instance_get_instance_private(self);
 
+    g_return_if_fail(instance_info != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     *instance_info = g_object_new(ALSATIMER_TYPE_INSTANCE_INFO, NULL);
@@ -345,6 +347,7 @@ void alsatimer_user_instance_set_params(ALSATimerUserInstance *self,
     g_return_if_fail(ALSATIMER_IS_USER_INSTANCE(self));
     priv = alsatimer_user_instance_get_instance_private(self);
 
+    g_return_if_fail(instance_params != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     timer_instance_params_refer_private(*instance_params, &params);
@@ -374,6 +377,7 @@ void alsatimer_user_instance_get_status(ALSATimerUserInstance *self,
     g_return_if_fail(ALSATIMER_IS_USER_INSTANCE(self));
     priv = alsatimer_user_instance_get_instance_private(self);
 
+    g_return_if_fail(instance_status != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     g_return_if_fail(ALSATIMER_IS_INSTANCE_STATUS(*instance_status));
@@ -487,6 +491,7 @@ void alsatimer_user_instance_create_source(ALSATimerUserInstance *self,
     g_return_if_fail(ALSATIMER_IS_USER_INSTANCE(self));
     priv = alsatimer_user_instance_get_instance_private(self);
 
+    g_return_if_fail(gsrc != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     if (priv->fd < 0) {

--- a/src/timer/user-instance.c
+++ b/src/timer/user-instance.c
@@ -135,7 +135,8 @@ static void alsatimer_user_instance_init(ALSATimerUserInstance *self)
  * alsatimer_user_instance_open:
  * @self: A #ALSATimerUserInstance.
  * @open_flag: The flag of open(2) system call. O_RDONLY is forced to fulfil internally.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with two domains; #g_file_error_quark() and
+ *         #alsaseq_user_client_error_quark().
  *
  * Open ALSA Timer character device to allocate queue.
  *
@@ -223,7 +224,7 @@ void alsatimer_user_instance_get_protocol_version(ALSATimerUserInstance *self,
  * alsatimer_user_instance_choose_event_data_type:
  * @self: A #ALSATimerUserInstance.
  * @event_data_type: The type of event data, one of ALSATimerEventDataType.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark.
  *
  * Choose the type of event data to receive.
  *
@@ -261,7 +262,7 @@ void alsatimer_user_instance_choose_event_data_type(ALSATimerUserInstance *self,
  * alsatimer_user_instance_attach:
  * @self: A #ALSATimerUserInstance.
  * @device_id: A #ALSATimerDeviceId to which the instance is attached.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark.
  *
  * Attach the instance to the timer device. If the given device_id is for
  * absent timer device, the instance can be detached with error.
@@ -297,7 +298,7 @@ void alsatimer_user_instance_attach(ALSATimerUserInstance *self,
  * @slave_class: The class identifier of master instance, one of
  *               #ALSATimerSlaveClass.
  * @slave_id: The numerical identifier of master instance.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark.
  *
  * Attach the instance as an slave to another instance indicated by a pair of
  * slave_class and slave_id. If the slave_class is for application
@@ -333,7 +334,7 @@ void alsatimer_user_instance_attach_as_slave(ALSATimerUserInstance *self,
  * alsatimer_user_instance_get_info:
  * @self: A #ALSATimerUserInstance.
  * @instance_info: (out): A #ALSATimerInstanceInfo.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark.
  *
  * Return the information of device if attached to the instance.
  *
@@ -369,7 +370,7 @@ void alsatimer_user_instance_get_info(ALSATimerUserInstance *self,
  * alsatimer_user_instance_set_params:
  * @self: A #ALSATimerUserInstance.
  * @instance_params: (inout): A #ALSATimerInstanceParams.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark.
  *
  * Configure the instance with the parameters and return the latest parameters.
  *
@@ -403,7 +404,7 @@ void alsatimer_user_instance_set_params(ALSATimerUserInstance *self,
  * alsatimer_user_instance_get_status:
  * @self: A #ALSATimerUserInstance.
  * @instance_status: (inout): A #ALSATimerInstanceStatus.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark.
  *
  * Get the latest status of instance.
  *
@@ -560,7 +561,7 @@ void alsatimer_user_instance_create_source(ALSATimerUserInstance *self,
 /**
  * alsatimer_user_instance_start:
  * @self: A #ALSATimerUserInstance.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark.
  *
  * Start timer event emission.
  *
@@ -587,7 +588,7 @@ void alsatimer_user_instance_start(ALSATimerUserInstance *self, GError **error)
 /**
  * alsatimer_user_instance_stop:
  * @self: A #ALSATimerUserInstance.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark.
  *
  * Stop timer event emission.
  *
@@ -614,7 +615,7 @@ void alsatimer_user_instance_stop(ALSATimerUserInstance *self, GError **error)
 /**
  * alsatimer_user_instance_pause:
  * @self: A #ALSATimerUserInstance.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark.
  *
  * Pause timer event emission.
  *
@@ -641,7 +642,7 @@ void alsatimer_user_instance_pause(ALSATimerUserInstance *self, GError **error)
 /**
  * alsatimer_user_instance_continue:
  * @self: A #ALSATimerUserInstance.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark.
  *
  * Continue timer event emission paused by alsatimer_user_instance_pause().
  *

--- a/src/timer/user-instance.h
+++ b/src/timer/user-instance.h
@@ -35,6 +35,10 @@ G_BEGIN_DECLS
                                ALSATIMER_TYPE_USER_INSTANCE,    \
                                ALSATimerUserInstanceClass))
 
+#define ALSATIMER_USER_INSTANCE_ERROR   alsatimer_user_instance_error_quark()
+
+GQuark alsatimer_user_instance_error_quark();
+
 typedef struct _ALSATimerUserInstance           ALSATimerUserInstance;
 typedef struct _ALSATimerUserInstanceClass      ALSATimerUserInstanceClass;
 typedef struct _ALSATimerUserInstancePrivate    ALSATimerUserInstancePrivate;

--- a/tests/alsatimer-enums
+++ b/tests/alsatimer-enums
@@ -58,6 +58,7 @@ event_data_types = (
 
 user_instance_error_types = (
     'FAILED',
+    'TIMER_NOT_FOUND',
 )
 
 types = {

--- a/tests/alsatimer-enums
+++ b/tests/alsatimer-enums
@@ -56,6 +56,10 @@ event_data_types = (
     'TSTAMP',
 )
 
+user_instance_error_types = (
+    'FAILED',
+)
+
 types = {
     ALSATimer.Class:                class_types,
     ALSATimer.SlaveClass:           slave_class_types,
@@ -64,6 +68,7 @@ types = {
     ALSATimer.InstanceParamFlag:    instance_param_flags,
     ALSATimer.EventType:            event_types,
     ALSATimer.EventDataType:        event_data_types,
+    ALSATimer.UserInstanceError:    user_instance_error_types,
 }
 
 for obj, types in types.items():

--- a/tests/alsatimer-enums
+++ b/tests/alsatimer-enums
@@ -59,6 +59,7 @@ event_data_types = (
 user_instance_error_types = (
     'FAILED',
     'TIMER_NOT_FOUND',
+    'NOT_ATTACHED',
 )
 
 types = {

--- a/tests/alsatimer-enums
+++ b/tests/alsatimer-enums
@@ -60,6 +60,7 @@ user_instance_error_types = (
     'FAILED',
     'TIMER_NOT_FOUND',
     'NOT_ATTACHED',
+    'ATTACHED',
 )
 
 types = {


### PR DESCRIPTION
The patchset is a part of work about #47.

Current implementation uses library-wide error domain to report error. this
is partly against rule of GError usage. Furthermore, the error delivers
information just about errno and hard to know the cause of error.

This patchset enhances error reporting. The library-wide error domain is
obsoleted. A new error domain is added just for ALSATimer.UserInstance.
The error domain delivers information about the cause of error.

```
Takashi Sakamoto (16):
  timer: user_instance: fix function comment
  timer: skip check of return value from g_malloc()
  timer: check whether method argument for GError is available
  timer: add checks for method arguments
  timer: instance-params: add checks for method arguments
  timer: user_instance: just return when character device is not opened
  timer: add GLib enumeration to report type of error for ALSATimer.UserInstance
  timer: user_instance: add GQuark to report error for ALSATimer.UserInstance
  timer: user_instance: report error due to ioctl failure
  timer: user_instance: report error due to open system call
  timer: user_instance: report error for timer instance not found
  timer: user_instance: report error for unattached timer instance
  timer: user_instance: report error for timer already attached
  timer: query: use GFileError to report error
  timer: query: code refactoring to unify open function
  timer: obsolete library-wide GQuark for error reporting

 src/timer/alsatimer-enum-types.h |  18 ++++
 src/timer/alsatimer.map          |   5 +
 src/timer/instance-params.c      |  20 ++--
 src/timer/instance-status.c      |   3 +-
 src/timer/privates.h             |   6 --
 src/timer/query.c                | 127 ++++++++++++------------
 src/timer/user-instance.c        | 165 +++++++++++++++++++++++--------
 src/timer/user-instance.h        |   4 +
 tests/alsatimer-enums            |   8 ++
 9 files changed, 231 insertions(+), 125 deletions(-)
```