### PR TITLE
[PATCH 00/15] alsa-gobject: seq: enhancement for error reporting

### DIFF
--- a/src/seq/alsaseq-enum-types.h
+++ b/src/seq/alsaseq-enum-types.h
@@ -366,12 +366,14 @@ typedef enum /*< flags >*/
  * ALSASeqUserClientError:
  * @ALSASEQ_USER_CLIENT_ERROR_FAILED:	            The system call failed.
  * @ALSASEQ_USER_CLIENT_ERROR_PORT_PERMISSION:      The operation fails due to access permission of port.
+ * @ALSASEQ_USER_CLIENT_ERROR_QUEUE_PERMISSION:     The operation fails due to access permission of queue.
  *
  * A set of error code for GError with domain which equals to #alsaseq_user_client_error_quark()
  */
 typedef enum {
     ALSASEQ_USER_CLIENT_ERROR_FAILED,
     ALSASEQ_USER_CLIENT_ERROR_PORT_PERMISSION,
+    ALSASEQ_USER_CLIENT_ERROR_QUEUE_PERMISSION,
 } ALSASeqUserClientError;
 
 #endif

--- a/src/seq/alsaseq-enum-types.h
+++ b/src/seq/alsaseq-enum-types.h
@@ -364,12 +364,14 @@ typedef enum /*< flags >*/
 
 /**
  * ALSASeqUserClientError:
- * @ALSASEQ_USER_CLIENT_ERROR_FAILED:	The system call failed.
+ * @ALSASEQ_USER_CLIENT_ERROR_FAILED:	            The system call failed.
+ * @ALSASEQ_USER_CLIENT_ERROR_PORT_PERMISSION:      The operation fails due to access permission of port.
  *
  * A set of error code for GError with domain which equals to #alsaseq_user_client_error_quark()
  */
 typedef enum {
     ALSASEQ_USER_CLIENT_ERROR_FAILED,
+    ALSASEQ_USER_CLIENT_ERROR_PORT_PERMISSION,
 } ALSASeqUserClientError;
 
 #endif

--- a/src/seq/alsaseq-enum-types.h
+++ b/src/seq/alsaseq-enum-types.h
@@ -362,4 +362,14 @@ typedef enum /*< flags >*/
     ALSASEQ_REMOVE_FILTER_FLAG_OUTPUT   = SNDRV_SEQ_REMOVE_OUTPUT,
 } ALSASeqRemoveFilterFlag;
 
+/**
+ * ALSASeqUserClientError:
+ * @ALSASEQ_USER_CLIENT_ERROR_FAILED:	The system call failed.
+ *
+ * A set of error code for GError with domain which equals to #alsaseq_user_client_error_quark()
+ */
+typedef enum {
+    ALSASEQ_USER_CLIENT_ERROR_FAILED,
+} ALSASeqUserClientError;
+
 #endif

--- a/src/seq/alsaseq.map
+++ b/src/seq/alsaseq.map
@@ -217,4 +217,5 @@ ALSA_GOBJECT_0_0_0 {
 
 ALSA_GOBJECT_0_2_0 {
     "alsaseq_user_client_error_get_type";
+    "alsaseq_user_client_error_quark";
 } ALSA_GOBJECT_0_0_0;

--- a/src/seq/alsaseq.map
+++ b/src/seq/alsaseq.map
@@ -214,3 +214,7 @@ ALSA_GOBJECT_0_0_0 {
   local:
     *;
 };
+
+ALSA_GOBJECT_0_2_0 {
+    "alsaseq_user_client_error_get_type";
+} ALSA_GOBJECT_0_0_0;

--- a/src/seq/client-info.c
+++ b/src/seq/client-info.c
@@ -283,11 +283,8 @@ void alsaseq_client_info_get_event_filter(ALSASeqClientInfo *self,
         return;
     }
 
-    *event_types = g_try_malloc0_n(count, sizeof(*event_types));
-    if (*event_types == NULL) {
-        generate_error(error, ENOMEM);
-        return;
-    }
+    *event_types = g_malloc0_n(count, sizeof(*event_types));
+
     *event_type_count = count;
 
     index = 0;

--- a/src/seq/client-info.c
+++ b/src/seq/client-info.c
@@ -224,12 +224,10 @@ void alsaseq_client_info_set_event_filter(ALSASeqClientInfo *self,
     g_return_if_fail(ALSASEQ_IS_CLIENT_INFO(self));
     priv = alsaseq_client_info_get_instance_private(self);
 
+    g_return_if_fail(event_types != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     memset(priv->info.event_filter, 0, sizeof(priv->info.event_filter));
-
-    if (event_types == NULL)
-        return;
 
     for (i = 0; i < event_type_count; ++i) {
         ALSASeqEventType event_type = (int)event_types[i];
@@ -264,12 +262,9 @@ void alsaseq_client_info_get_event_filter(ALSASeqClientInfo *self,
     g_return_if_fail(ALSASEQ_IS_CLIENT_INFO(self));
     priv = alsaseq_client_info_get_instance_private(self);
 
+    g_return_if_fail(event_types != NULL);
+    g_return_if_fail(event_type_count != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
-
-    if (event_types == NULL || event_type_count == NULL) {
-        generate_error(error, EINVAL);
-        return;
-    }
 
     count = 0;
     for (i = 0; i < SNDRV_SEQ_EVENT_NONE + 1; ++i) {

--- a/src/seq/client-info.c
+++ b/src/seq/client-info.c
@@ -224,6 +224,8 @@ void alsaseq_client_info_set_event_filter(ALSASeqClientInfo *self,
     g_return_if_fail(ALSASEQ_IS_CLIENT_INFO(self));
     priv = alsaseq_client_info_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     memset(priv->info.event_filter, 0, sizeof(priv->info.event_filter));
 
     if (event_types == NULL)
@@ -261,6 +263,8 @@ void alsaseq_client_info_get_event_filter(ALSASeqClientInfo *self,
 
     g_return_if_fail(ALSASEQ_IS_CLIENT_INFO(self));
     priv = alsaseq_client_info_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     if (event_types == NULL || event_type_count == NULL) {
         generate_error(error, EINVAL);

--- a/src/seq/event-cntr.c
+++ b/src/seq/event-cntr.c
@@ -92,11 +92,15 @@ static void alsaseq_event_cntr_init(ALSASeqEventCntr *self)
  */
 ALSASeqEventCntr *alsaseq_event_cntr_new(guint count, GError **error)
 {
-    ALSASeqEventCntr *self = g_object_new(ALSASEQ_TYPE_EVENT_CNTR, NULL);
-    ALSASeqEventCntrPrivate *priv =
-                                alsaseq_event_cntr_get_instance_private(self);
+    ALSASeqEventCntr *self;
+    ALSASeqEventCntrPrivate *priv;
     struct snd_seq_event *ev;
     int i;
+
+    g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+    self = g_object_new(ALSASEQ_TYPE_EVENT_CNTR, NULL);
+    priv = alsaseq_event_cntr_get_instance_private(self);
 
     priv->length = sizeof(struct snd_seq_event) * count;
     priv->buf = g_malloc0(priv->length);
@@ -227,6 +231,8 @@ void alsaseq_event_cntr_calculate_pool_consumption(ALSASeqEventCntr *self,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     *cells = 0;
     total = 0;
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
@@ -259,6 +265,8 @@ void alsaseq_event_cntr_get_event_type(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
@@ -289,6 +297,8 @@ void alsaseq_event_cntr_set_event_type(ALSASeqEventCntr *self,
 
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
@@ -321,6 +331,8 @@ void alsaseq_event_cntr_get_tstamp_mode(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
@@ -351,6 +363,8 @@ void alsaseq_event_cntr_set_tstamp_mode(ALSASeqEventCntr *self, gsize index,
 
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
@@ -384,6 +398,8 @@ void alsaseq_event_cntr_get_time_mode(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
@@ -414,6 +430,8 @@ void alsaseq_event_cntr_set_time_mode(ALSASeqEventCntr *self, gsize index,
 
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
@@ -447,6 +465,8 @@ void alsaseq_event_cntr_get_length_mode(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
@@ -477,6 +497,8 @@ void alsaseq_event_cntr_get_priority_mode(
 
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
@@ -509,6 +531,8 @@ void alsaseq_event_cntr_set_priority_mode(
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
@@ -540,6 +564,8 @@ void alsaseq_event_cntr_get_tag(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
@@ -569,6 +595,8 @@ void alsaseq_event_cntr_set_tag(ALSASeqEventCntr *self, gsize index,
 
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
@@ -601,6 +629,8 @@ void alsaseq_event_cntr_get_queue_id(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
@@ -631,6 +661,8 @@ void alsaseq_event_cntr_set_queue_id(ALSASeqEventCntr *self, gsize index,
 
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
@@ -663,6 +695,8 @@ void alsaseq_event_cntr_get_tstamp(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
@@ -694,6 +728,8 @@ void alsaseq_event_cntr_set_tstamp(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
@@ -723,6 +759,8 @@ void alsaseq_event_cntr_get_dst(ALSASeqEventCntr *self, gsize index,
 
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
@@ -754,6 +792,8 @@ void alsaseq_event_cntr_set_dst(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
@@ -784,6 +824,8 @@ void alsaseq_event_cntr_get_src(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
@@ -813,6 +855,8 @@ void alsaseq_event_cntr_set_src(ALSASeqEventCntr *self, gsize index,
 
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
@@ -923,6 +967,8 @@ void alsaseq_event_cntr_get_note_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
     if (ev == NULL) {
@@ -951,6 +997,8 @@ void alsaseq_event_cntr_set_note_data(ALSASeqEventCntr *self, gsize index,
 
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
@@ -985,6 +1033,8 @@ void alsaseq_event_cntr_get_ctl_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
     if (ev == NULL) {
@@ -1013,6 +1063,8 @@ void alsaseq_event_cntr_set_ctl_data(ALSASeqEventCntr *self, gsize index,
 
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
@@ -1047,6 +1099,8 @@ void alsaseq_event_cntr_get_byte_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
     if (ev == NULL) {
@@ -1075,6 +1129,8 @@ void alsaseq_event_cntr_set_byte_data(ALSASeqEventCntr *self, gsize index,
 
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
@@ -1109,6 +1165,8 @@ void alsaseq_event_cntr_get_quadlet_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
@@ -1138,6 +1196,8 @@ void alsaseq_event_cntr_set_quadlet_data(ALSASeqEventCntr *self, gsize index,
 
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
@@ -1174,6 +1234,8 @@ void alsaseq_event_cntr_get_blob_data(ALSASeqEventCntr *self, gsize index,
 
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
@@ -1220,6 +1282,8 @@ void alsaseq_event_cntr_set_blob_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
     if (ev == NULL) {
@@ -1249,6 +1313,8 @@ void alsaseq_event_cntr_get_queue_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
     if (ev == NULL) {
@@ -1277,6 +1343,8 @@ void alsaseq_event_cntr_set_queue_data(ALSASeqEventCntr *self, gsize index,
 
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
@@ -1311,6 +1379,8 @@ void alsaseq_event_cntr_get_tstamp_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
     if (ev == NULL) {
@@ -1339,6 +1409,8 @@ void alsaseq_event_cntr_set_tstamp_data(ALSASeqEventCntr *self, gsize index,
 
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
@@ -1373,6 +1445,8 @@ void alsaseq_event_cntr_get_addr_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
     if (ev == NULL) {
@@ -1401,6 +1475,8 @@ void alsaseq_event_cntr_set_addr_data(ALSASeqEventCntr *self, gsize index,
 
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
@@ -1435,6 +1511,8 @@ void alsaseq_event_cntr_get_connect_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
     if (ev == NULL) {
@@ -1463,6 +1541,8 @@ void alsaseq_event_cntr_set_connect_data(ALSASeqEventCntr *self, gsize index,
 
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
@@ -1497,6 +1577,8 @@ void alsaseq_event_cntr_get_result_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
     if (ev == NULL) {
@@ -1525,6 +1607,8 @@ void alsaseq_event_cntr_set_result_data(ALSASeqEventCntr *self, gsize index,
 
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);

--- a/src/seq/event-cntr.c
+++ b/src/seq/event-cntr.c
@@ -203,6 +203,8 @@ void alsaseq_event_cntr_count_events(ALSASeqEventCntr *self, gsize *count)
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(count != NULL);
+
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     *count = 0;
@@ -231,6 +233,7 @@ void alsaseq_event_cntr_calculate_pool_consumption(ALSASeqEventCntr *self,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(cells != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     *cells = 0;
@@ -265,15 +268,13 @@ void alsaseq_event_cntr_get_event_type(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(ev_type != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, ENOENT);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     *ev_type = (ALSASeqEventType)ev->type;
 }
@@ -303,10 +304,7 @@ void alsaseq_event_cntr_set_event_type(ALSASeqEventCntr *self,
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, ENOENT);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     ev->type = (snd_seq_event_type_t)ev_type;
 }
@@ -331,15 +329,13 @@ void alsaseq_event_cntr_get_tstamp_mode(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(mode != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, ENOENT);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     *mode = (ALSASeqEventTimestampMode)(ev->flags & SNDRV_SEQ_TIME_STAMP_MASK);
 }
@@ -369,10 +365,7 @@ void alsaseq_event_cntr_set_tstamp_mode(ALSASeqEventCntr *self, gsize index,
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, ENOENT);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     ev->flags &= ~SNDRV_SEQ_TIME_STAMP_MASK;
     ev->flags |= (unsigned char)mode;
@@ -398,15 +391,13 @@ void alsaseq_event_cntr_get_time_mode(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(mode != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, ENOENT);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     *mode = (ALSASeqEventTimeMode)(ev->flags & SNDRV_SEQ_TIME_MODE_MASK);
 }
@@ -436,10 +427,7 @@ void alsaseq_event_cntr_set_time_mode(ALSASeqEventCntr *self, gsize index,
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, ENOENT);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     ev->flags &= ~SNDRV_SEQ_TIME_MODE_MASK;
     ev->flags |= (unsigned char)mode;
@@ -465,15 +453,13 @@ void alsaseq_event_cntr_get_length_mode(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(mode != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, ENOENT);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     *mode = (ALSASeqEventLengthMode)(ev->flags & SNDRV_SEQ_EVENT_LENGTH_MASK);
 }
@@ -498,15 +484,13 @@ void alsaseq_event_cntr_get_priority_mode(
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(mode != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, ENOENT);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     *mode = (ALSASeqEventPriorityMode)(ev->flags & SNDRV_SEQ_PRIORITY_MASK);
 }
@@ -536,10 +520,7 @@ void alsaseq_event_cntr_set_priority_mode(
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, ENOENT);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     ev->flags &= ~SNDRV_SEQ_PRIORITY_MASK;
     ev->flags |= (unsigned char)mode;
@@ -564,15 +545,13 @@ void alsaseq_event_cntr_get_tag(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(tag != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, ENOENT);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     *tag = ev->tag;
 }
@@ -601,10 +580,7 @@ void alsaseq_event_cntr_set_tag(ALSASeqEventCntr *self, gsize index,
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, ENOENT);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     ev->tag = tag;
 }
@@ -629,15 +605,13 @@ void alsaseq_event_cntr_get_queue_id(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(queue_id != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, ENOENT);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     *queue_id = ev->queue;
 }
@@ -667,10 +641,7 @@ void alsaseq_event_cntr_set_queue_id(ALSASeqEventCntr *self, gsize index,
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, ENOENT);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     ev->queue = queue_id;
 }
@@ -695,15 +666,13 @@ void alsaseq_event_cntr_get_tstamp(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(tstamp != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, ENOENT);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     *tstamp = (const ALSASeqTstamp *)&ev->time;
 }
@@ -728,15 +697,13 @@ void alsaseq_event_cntr_set_tstamp(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(tstamp != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, ENOENT);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     ev->time = *tstamp;
 }
@@ -760,15 +727,13 @@ void alsaseq_event_cntr_get_dst(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(dst != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, ENOENT);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     *dst = (const ALSASeqAddr *)&ev->dest;
 }
@@ -792,15 +757,13 @@ void alsaseq_event_cntr_set_dst(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(dst != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, ENOENT);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     ev->dest = *dst;
 }
@@ -824,15 +787,13 @@ void alsaseq_event_cntr_get_src(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(src != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, ENOENT);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     *src = (const ALSASeqAddr *)&ev->source;
 }
@@ -856,15 +817,13 @@ void alsaseq_event_cntr_set_src(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(src != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, ENOENT);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     ev->source = *src;
 }
@@ -873,7 +832,7 @@ static void ensure_fixed_length_event(ALSASeqEventCntrPrivate *priv,
                                       struct snd_seq_event *ev, GError **error)
 {
     if (!priv->allocated) {
-        generate_error(error, ENOBUFS);
+        g_return_if_fail(priv->allocated);
         return;
     }
 
@@ -912,7 +871,7 @@ static void ensure_variable_length_event(ALSASeqEventCntrPrivate *priv,
     guint8 *new;
 
     if (!priv->allocated) {
-        generate_error(error, ENOBUFS);
+        g_return_if_fail(priv->allocated);
         return;
     }
 
@@ -967,14 +926,12 @@ void alsaseq_event_cntr_get_note_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, EINVAL);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     *data = (const ALSASeqEventDataNote *)&ev->data.note;
 }
@@ -998,14 +955,12 @@ void alsaseq_event_cntr_set_note_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, EINVAL);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     ensure_fixed_length_event(priv, ev, error);
     if (*error != NULL)
@@ -1033,14 +988,12 @@ void alsaseq_event_cntr_get_ctl_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, EINVAL);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     *data = (const ALSASeqEventDataCtl *)&ev->data.control;
 }
@@ -1064,14 +1017,12 @@ void alsaseq_event_cntr_set_ctl_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, EINVAL);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     ensure_fixed_length_event(priv, ev, error);
     if (*error != NULL)
@@ -1099,14 +1050,12 @@ void alsaseq_event_cntr_get_byte_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, EINVAL);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     *data = ev->data.raw8.d;
 }
@@ -1130,14 +1079,12 @@ void alsaseq_event_cntr_set_byte_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, EINVAL);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     ensure_fixed_length_event(priv, ev, error);
     if (*error != NULL)
@@ -1165,15 +1112,13 @@ void alsaseq_event_cntr_get_quadlet_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, EINVAL);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     *data = ev->data.raw32.d;
 }
@@ -1197,15 +1142,13 @@ void alsaseq_event_cntr_set_quadlet_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
 
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, EINVAL);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     ensure_fixed_length_event(priv, ev, error);
     if (*error != NULL)
@@ -1235,14 +1178,13 @@ void alsaseq_event_cntr_get_blob_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
+    g_return_if_fail(size != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, EINVAL);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     switch (ev->flags & SNDRV_SEQ_EVENT_LENGTH_MASK) {
     case SNDRV_SEQ_EVENT_LENGTH_VARIABLE:
@@ -1256,7 +1198,7 @@ void alsaseq_event_cntr_get_blob_data(ALSASeqEventCntr *self, gsize index,
         break;
     }
     default:
-        generate_error(error, ENODATA);
+        g_return_if_reached();
         break;
     }
 }
@@ -1282,14 +1224,12 @@ void alsaseq_event_cntr_set_blob_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, EINVAL);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     ensure_variable_length_event(priv, ev, data, size, error);
 }
@@ -1313,14 +1253,12 @@ void alsaseq_event_cntr_get_queue_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, EINVAL);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     *data = (const ALSASeqEventDataQueue *)&ev->data.queue;
 }
@@ -1344,14 +1282,12 @@ void alsaseq_event_cntr_set_queue_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, EINVAL);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     ensure_fixed_length_event(priv, ev, error);
     if (*error != NULL)
@@ -1379,14 +1315,12 @@ void alsaseq_event_cntr_get_tstamp_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, EINVAL);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     *data = (const ALSASeqTstamp *)&ev->data.time;
 }
@@ -1410,14 +1344,12 @@ void alsaseq_event_cntr_set_tstamp_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, EINVAL);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     ensure_fixed_length_event(priv, ev, error);
     if (*error != NULL)
@@ -1445,14 +1377,12 @@ void alsaseq_event_cntr_get_addr_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, EINVAL);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     *data = (const ALSASeqAddr *)&ev->data.time;
 }
@@ -1476,14 +1406,12 @@ void alsaseq_event_cntr_set_addr_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, EINVAL);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     ensure_fixed_length_event(priv, ev, error);
     if (*error != NULL)
@@ -1511,14 +1439,12 @@ void alsaseq_event_cntr_get_connect_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, EINVAL);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     *data = (const ALSASeqEventDataConnect *)&ev->data.connect;
 }
@@ -1542,14 +1468,12 @@ void alsaseq_event_cntr_set_connect_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, EINVAL);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     ensure_fixed_length_event(priv, ev, error);
     if (*error != NULL)
@@ -1577,14 +1501,12 @@ void alsaseq_event_cntr_get_result_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, ENOENT);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     *data = (const ALSASeqEventDataResult *)&ev->data.result;
 }
@@ -1608,14 +1530,12 @@ void alsaseq_event_cntr_set_result_data(ALSASeqEventCntr *self, gsize index,
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(self));
     priv = alsaseq_event_cntr_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     event_iterator_init(&iter, priv->buf, priv->length, priv->allocated);
     ev = event_iterator_find(&iter, index);
-    if (ev == NULL) {
-        generate_error(error, ENOENT);
-        return;
-    }
+    g_return_if_fail(ev != NULL);
 
     ensure_fixed_length_event(priv, ev, error);
     if (*error != NULL)

--- a/src/seq/event-cntr.c
+++ b/src/seq/event-cntr.c
@@ -99,11 +99,8 @@ ALSASeqEventCntr *alsaseq_event_cntr_new(guint count, GError **error)
     int i;
 
     priv->length = sizeof(struct snd_seq_event) * count;
-    priv->buf = g_try_malloc0(priv->length);
-    if (priv->buf == NULL) {
-        generate_error(error, ENOMEM);
-        return NULL;
-    }
+    priv->buf = g_malloc0(priv->length);
+
     priv->allocated = TRUE;
 
     ev = (struct snd_seq_event *)priv->buf;
@@ -888,11 +885,7 @@ static void ensure_variable_length_event(ALSASeqEventCntrPrivate *priv,
 
     to_tail = priv->length - (next_ev - priv->buf);
 
-    new = g_try_malloc(from_head + size + to_tail);
-    if (new == NULL) {
-        generate_error(error, ENOMEM);
-        return;
-    }
+    new = g_malloc(from_head + size + to_tail);
 
     memcpy(new, priv->buf, from_head);
     memcpy(new + from_head, data, size);

--- a/src/seq/privates.h
+++ b/src/seq/privates.h
@@ -22,12 +22,6 @@
 
 G_BEGIN_DECLS
 
-GQuark alsaseq_error_quark(void);
-
-#define generate_error(err, errno)                      \
-    g_set_error(err, alsaseq_error_quark(), errno,      \
-                __FILE__ ":%d: %s", __LINE__, strerror(errno))
-
 void seq_system_info_refer_private(ALSASeqSystemInfo *self,
                                    struct snd_seq_system_info **info);
 

--- a/src/seq/query.c
+++ b/src/seq/query.c
@@ -39,6 +39,8 @@ void alsaseq_get_seq_sysname(gchar **sysname, GError **error)
     struct udev_device *dev;
     const char *name;
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     ctx = udev_new();
     if (ctx == NULL) {
         generate_error(error, errno);
@@ -80,6 +82,8 @@ void alsaseq_get_seq_devnode(gchar **devnode, GError **error)
     struct udev *ctx;
     struct udev_device *dev;
     const char *node;
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     ctx = udev_new();
     if (ctx == NULL) {
@@ -123,6 +127,8 @@ void alsaseq_get_system_info(ALSASeqSystemInfo **system_info, GError **error)
     char *devnode;
     struct snd_seq_system_info *info;
     int fd;
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     alsaseq_get_seq_devnode(&devnode, error);
     if (*error != NULL)
@@ -179,6 +185,8 @@ void alsaseq_get_client_id_list(guint8 **entries, gsize *entry_count,
     unsigned int index;
     struct snd_seq_client_info client_info = {0};
     int fd;
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     alsaseq_get_seq_devnode(&devnode, error);
     if (*error != NULL)
@@ -258,6 +266,8 @@ void alsaseq_get_client_info(guint8 client_id, ALSASeqClientInfo **client_info,
     struct snd_seq_client_info *info;
     int fd;
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     alsaseq_get_seq_devnode(&devnode, error);
     if (*error != NULL)
         return;
@@ -311,6 +321,8 @@ void alsaseq_get_port_id_list(guint8 client_id, guint8 **entries,
     unsigned int index;
     struct snd_seq_port_info port_info = {0};
     int fd;
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     alsaseq_get_seq_devnode(&devnode, error);
     if (*error != NULL)
@@ -380,6 +392,8 @@ void alsaseq_get_port_info(guint8 client_id, guint8 port_id,
     struct snd_seq_port_info *info;
     int fd;
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     alsaseq_get_seq_devnode(&devnode, error);
     if (*error != NULL)
         return;
@@ -427,6 +441,8 @@ void alsaseq_get_client_pool(guint8 client_id, ALSASeqClientPool **client_pool,
     char *devnode;
     int fd;
     struct snd_seq_client_pool *pool;
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     alsaseq_get_seq_devnode(&devnode, error);
     if (*error != NULL)
@@ -489,6 +505,8 @@ void alsaseq_get_subscription_list(const ALSASeqAddr *addr,
     struct snd_seq_query_subs query = {0};
     unsigned int count;
     unsigned int index;
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     alsaseq_get_seq_devnode(&devnode, error);
     if (*error != NULL)
@@ -567,6 +585,8 @@ void alsaseq_get_queue_id_list(guint8 **entries, gsize *entry_count,
     unsigned int index;
     int i;
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     alsaseq_get_seq_devnode(&devnode, error);
     if (*error != NULL)
         return;
@@ -636,6 +656,8 @@ void alsaseq_get_queue_info_by_id(guint8 queue_id, ALSASeqQueueInfo **queue_info
     char *devnode;
     int fd;
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     alsaseq_get_seq_devnode(&devnode, error);
     if (*error != NULL)
         return;
@@ -680,6 +702,8 @@ void alsaseq_get_queue_info_by_name(const gchar *name,
     struct snd_seq_queue_info *info;
     char *devnode;
     int fd;
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     alsaseq_get_seq_devnode(&devnode, error);
     if (*error != NULL)
@@ -726,6 +750,8 @@ void alsaseq_get_queue_status(guint8 queue_id,
     struct snd_seq_queue_status *status;
     char *devnode;
     int fd;
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     alsaseq_get_seq_devnode(&devnode, error);
     if (*error != NULL)

--- a/src/seq/query.c
+++ b/src/seq/query.c
@@ -19,9 +19,6 @@
  *                     descriptor
  */
 
-// For error handling.
-G_DEFINE_QUARK("alsaseq-error", alsaseq_error)
-
 #define SEQ_SYSNAME   "seq"
 
 #define generate_file_error(exception, errno, msg) \

--- a/src/seq/query.c
+++ b/src/seq/query.c
@@ -60,9 +60,7 @@ void alsaseq_get_seq_sysname(gchar **sysname, GError **error)
         return;
     }
 
-    *sysname = strdup(name);
-    if (*sysname == NULL)
-        generate_error(error, ENOMEM);
+    *sysname = g_strdup(name);
 
     udev_device_unref(dev);
     udev_unref(ctx);
@@ -104,9 +102,7 @@ void alsaseq_get_seq_devnode(gchar **devnode, GError **error)
         return;
     }
 
-    *devnode = strdup(node);
-    if (*devnode == NULL)
-        generate_error(error, ENOMEM);
+    *devnode = g_strdup(node);
 
     udev_device_unref(dev);
     udev_unref(ctx);
@@ -215,12 +211,8 @@ void alsaseq_get_client_id_list(guint8 **entries, gsize *entry_count,
         return;
     }
 
-    list = g_try_malloc0_n(count, sizeof(guint));
-    if (list == NULL) {
-        *entry_count = 0;
-        close(fd);
-        return;
-    }
+    list = g_malloc0_n(count, sizeof(guint));
+
     index = 0;
 
     client_info.client = -1;
@@ -339,12 +331,8 @@ void alsaseq_get_port_id_list(guint8 client_id, guint8 **entries,
     }
 
     count = client_info.num_ports;
-    list = g_try_malloc0_n(count, sizeof(*list));
-    if (list == NULL) {
-        generate_error(error, ENOMEM);
-        close(fd);
-        return;
-    }
+    list = g_malloc0_n(count, sizeof(*list));
+
     index = 0;
 
     port_info.addr.client = client_id;
@@ -603,12 +591,7 @@ void alsaseq_get_queue_id_list(guint8 **entries, gsize *entry_count,
         return;
     }
 
-    list = g_try_malloc0_n(count, sizeof(*entries));
-    if (list == NULL) {
-        generate_error(error, ENOMEM);
-        close(fd);
-        return;
-    }
+    list = g_malloc0_n(count, sizeof(*entries));
 
     index = 0;
     for (i = 0; i < maximum_count; ++i) {

--- a/src/seq/query.c
+++ b/src/seq/query.c
@@ -39,6 +39,7 @@ void alsaseq_get_seq_sysname(gchar **sysname, GError **error)
     struct udev_device *dev;
     const char *name;
 
+    g_return_if_fail(sysname != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     ctx = udev_new();
@@ -83,6 +84,7 @@ void alsaseq_get_seq_devnode(gchar **devnode, GError **error)
     struct udev_device *dev;
     const char *node;
 
+    g_return_if_fail(devnode != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     ctx = udev_new();
@@ -128,6 +130,7 @@ void alsaseq_get_system_info(ALSASeqSystemInfo **system_info, GError **error)
     struct snd_seq_system_info *info;
     int fd;
 
+    g_return_if_fail(system_info != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     alsaseq_get_seq_devnode(&devnode, error);
@@ -186,6 +189,8 @@ void alsaseq_get_client_id_list(guint8 **entries, gsize *entry_count,
     struct snd_seq_client_info client_info = {0};
     int fd;
 
+    g_return_if_fail(entries != NULL);
+    g_return_if_fail(entry_count != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     alsaseq_get_seq_devnode(&devnode, error);
@@ -266,6 +271,7 @@ void alsaseq_get_client_info(guint8 client_id, ALSASeqClientInfo **client_info,
     struct snd_seq_client_info *info;
     int fd;
 
+    g_return_if_fail(client_info != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     alsaseq_get_seq_devnode(&devnode, error);
@@ -322,6 +328,8 @@ void alsaseq_get_port_id_list(guint8 client_id, guint8 **entries,
     struct snd_seq_port_info port_info = {0};
     int fd;
 
+    g_return_if_fail(entries != NULL);
+    g_return_if_fail(entry_count != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     alsaseq_get_seq_devnode(&devnode, error);
@@ -392,6 +400,7 @@ void alsaseq_get_port_info(guint8 client_id, guint8 port_id,
     struct snd_seq_port_info *info;
     int fd;
 
+    g_return_if_fail(port_info != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     alsaseq_get_seq_devnode(&devnode, error);
@@ -442,6 +451,7 @@ void alsaseq_get_client_pool(guint8 client_id, ALSASeqClientPool **client_pool,
     int fd;
     struct snd_seq_client_pool *pool;
 
+    g_return_if_fail(client_pool != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     alsaseq_get_seq_devnode(&devnode, error);
@@ -506,6 +516,7 @@ void alsaseq_get_subscription_list(const ALSASeqAddr *addr,
     unsigned int count;
     unsigned int index;
 
+    g_return_if_fail(entries != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     alsaseq_get_seq_devnode(&devnode, error);
@@ -585,6 +596,8 @@ void alsaseq_get_queue_id_list(guint8 **entries, gsize *entry_count,
     unsigned int index;
     int i;
 
+    g_return_if_fail(entries != NULL);
+    g_return_if_fail(entry_count != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     alsaseq_get_seq_devnode(&devnode, error);
@@ -656,6 +669,7 @@ void alsaseq_get_queue_info_by_id(guint8 queue_id, ALSASeqQueueInfo **queue_info
     char *devnode;
     int fd;
 
+    g_return_if_fail(queue_info != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     alsaseq_get_seq_devnode(&devnode, error);
@@ -703,6 +717,7 @@ void alsaseq_get_queue_info_by_name(const gchar *name,
     char *devnode;
     int fd;
 
+    g_return_if_fail(queue_info != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     alsaseq_get_seq_devnode(&devnode, error);
@@ -751,6 +766,7 @@ void alsaseq_get_queue_status(guint8 queue_id,
     char *devnode;
     int fd;
 
+    g_return_if_fail(queue_status != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     alsaseq_get_seq_devnode(&devnode, error);

--- a/src/seq/queue-status.c
+++ b/src/seq/queue-status.c
@@ -112,6 +112,8 @@ void alsaseq_queue_status_get_tick_time(ALSASeqQueueStatus *self,
     g_return_if_fail(ALSASEQ_IS_QUEUE_STATUS(self));
     priv = alsaseq_queue_status_get_instance_private(self);
 
+    g_return_if_fail(tick_time != NULL);
+
     *tick_time = priv->status.tick;
 }
 
@@ -130,6 +132,8 @@ void alsaseq_queue_status_get_real_time(ALSASeqQueueStatus *self,
 
     g_return_if_fail(ALSASEQ_IS_QUEUE_STATUS(self));
     priv = alsaseq_queue_status_get_instance_private(self);
+
+    g_return_if_fail(real_time != NULL);
 
     // MEMO: I wish 32-bit storage size is aligned to 32 bit offset in all of
     // supported ABIs.

--- a/src/seq/queue-tempo.c
+++ b/src/seq/queue-tempo.c
@@ -136,6 +136,8 @@ void alsaseq_queue_tempo_get_skew(ALSASeqQueueTempo *self, const guint32 *skew[2
     g_return_if_fail(ALSASEQ_IS_QUEUE_TEMPO(self));
     priv = alsaseq_queue_tempo_get_instance_private(self);
 
+    g_return_if_fail(skew != NULL);
+
     // MEMO: I wish 32-bit storage size is aligned to 32 bit offset in all of
     // supported ABIs.
     *skew = (guint32 *)&priv->tempo.skew_value;
@@ -156,6 +158,8 @@ void alsaseq_queue_tempo_set_skew(ALSASeqQueueTempo *self, const guint32 skew[2]
 
     g_return_if_fail(ALSASEQ_IS_QUEUE_TEMPO(self));
     priv = alsaseq_queue_tempo_get_instance_private(self);
+
+    g_return_if_fail(skew != NULL);
 
     priv->tempo.skew_value = skew[0];
     priv->tempo.skew_base = skew[1];

--- a/src/seq/queue-timer.c
+++ b/src/seq/queue-timer.c
@@ -105,6 +105,8 @@ void alsaseq_queue_timer_get_alsa_data(ALSASeqQueueTimer *self,
     g_return_if_fail(ALSASEQ_IS_QUEUE_TIMER(self));
     priv = alsaseq_queue_timer_get_instance_private(self);
 
+    g_return_if_fail(data != NULL);
+
     *data = (const ALSASeqQueueTimerDataAlsa *)&priv->timer.u.alsa;
 }
 
@@ -123,6 +125,8 @@ void alsaseq_queue_timer_set_alsa_data(ALSASeqQueueTimer *self,
 
     g_return_if_fail(ALSASEQ_IS_QUEUE_TIMER(self));
     priv = alsaseq_queue_timer_get_instance_private(self);
+
+    g_return_if_fail(data != NULL);
 
     priv->timer.type = SNDRV_SEQ_TIMER_ALSA;
     priv->timer.u.alsa.id = data->device_id;

--- a/src/seq/remove-filter.c
+++ b/src/seq/remove-filter.c
@@ -42,6 +42,8 @@ ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_dest_addr(
 {
     struct snd_seq_remove_events filter;
 
+    g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
     if (inout & ~(SNDRV_SEQ_REMOVE_INPUT | SNDRV_SEQ_REMOVE_OUTPUT)) {
         generate_error(error, EINVAL);
         return NULL;
@@ -70,6 +72,8 @@ ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_note_channel(
                                 guint8 channel, GError **error)
 {
     struct snd_seq_remove_events filter;
+
+    g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
     if (inout & ~(SNDRV_SEQ_REMOVE_INPUT | SNDRV_SEQ_REMOVE_OUTPUT)) {
         generate_error(error, EINVAL);
@@ -100,6 +104,8 @@ ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_event_type(
 {
     struct snd_seq_remove_events filter;
 
+    g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
     if (inout & ~(SNDRV_SEQ_REMOVE_INPUT | SNDRV_SEQ_REMOVE_OUTPUT)) {
         generate_error(error, EINVAL);
         return NULL;
@@ -128,6 +134,8 @@ ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_note(
 {
     struct snd_seq_remove_events filter;
 
+    g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
     if (inout & ~(SNDRV_SEQ_REMOVE_INPUT | SNDRV_SEQ_REMOVE_OUTPUT)) {
         generate_error(error, EINVAL);
         return NULL;
@@ -155,6 +163,8 @@ ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_tag(
                                 gint8 tag, GError **error)
 {
     struct snd_seq_remove_events filter;
+
+    g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
     if (inout & ~(SNDRV_SEQ_REMOVE_INPUT | SNDRV_SEQ_REMOVE_OUTPUT)) {
         generate_error(error, EINVAL);
@@ -187,6 +197,8 @@ ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_tick_time(
                                 GError **error)
 {
     struct snd_seq_remove_events filter;
+
+    g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
     if (inout & ~(SNDRV_SEQ_REMOVE_INPUT | SNDRV_SEQ_REMOVE_OUTPUT)) {
         generate_error(error, EINVAL);
@@ -224,6 +236,8 @@ ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_real_time(
                                 GError **error)
 {
     struct snd_seq_remove_events filter;
+
+    g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
     if (inout & ~(SNDRV_SEQ_REMOVE_INPUT | SNDRV_SEQ_REMOVE_OUTPUT)) {
         generate_error(error, EINVAL);

--- a/src/seq/remove-filter.c
+++ b/src/seq/remove-filter.c
@@ -43,11 +43,7 @@ ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_dest_addr(
     struct snd_seq_remove_events filter;
 
     g_return_val_if_fail(error == NULL || *error == NULL, NULL);
-
-    if (inout & ~(SNDRV_SEQ_REMOVE_INPUT | SNDRV_SEQ_REMOVE_OUTPUT)) {
-        generate_error(error, EINVAL);
-        return NULL;
-    }
+    g_return_val_if_fail(!(inout & ~(SNDRV_SEQ_REMOVE_INPUT | SNDRV_SEQ_REMOVE_OUTPUT)), NULL);
 
     filter.remove_mode = inout | SNDRV_SEQ_REMOVE_DEST;
     filter.queue = queue_id;
@@ -74,11 +70,7 @@ ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_note_channel(
     struct snd_seq_remove_events filter;
 
     g_return_val_if_fail(error == NULL || *error == NULL, NULL);
-
-    if (inout & ~(SNDRV_SEQ_REMOVE_INPUT | SNDRV_SEQ_REMOVE_OUTPUT)) {
-        generate_error(error, EINVAL);
-        return NULL;
-    }
+    g_return_val_if_fail(!(inout & ~(SNDRV_SEQ_REMOVE_INPUT | SNDRV_SEQ_REMOVE_OUTPUT)), NULL);
 
     filter.remove_mode = inout | SNDRV_SEQ_REMOVE_DEST_CHANNEL;
     filter.queue = queue_id;
@@ -105,11 +97,7 @@ ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_event_type(
     struct snd_seq_remove_events filter;
 
     g_return_val_if_fail(error == NULL || *error == NULL, NULL);
-
-    if (inout & ~(SNDRV_SEQ_REMOVE_INPUT | SNDRV_SEQ_REMOVE_OUTPUT)) {
-        generate_error(error, EINVAL);
-        return NULL;
-    }
+    g_return_val_if_fail(!(inout & ~(SNDRV_SEQ_REMOVE_INPUT | SNDRV_SEQ_REMOVE_OUTPUT)), NULL);
 
     filter.remove_mode = inout | SNDRV_SEQ_REMOVE_EVENT_TYPE;
     filter.queue = queue_id;
@@ -135,11 +123,7 @@ ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_note(
     struct snd_seq_remove_events filter;
 
     g_return_val_if_fail(error == NULL || *error == NULL, NULL);
-
-    if (inout & ~(SNDRV_SEQ_REMOVE_INPUT | SNDRV_SEQ_REMOVE_OUTPUT)) {
-        generate_error(error, EINVAL);
-        return NULL;
-    }
+    g_return_val_if_fail(!(inout & ~(SNDRV_SEQ_REMOVE_INPUT | SNDRV_SEQ_REMOVE_OUTPUT)), NULL);
 
     filter.remove_mode = inout | SNDRV_SEQ_REMOVE_IGNORE_OFF;
     filter.queue = queue_id;
@@ -165,11 +149,7 @@ ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_tag(
     struct snd_seq_remove_events filter;
 
     g_return_val_if_fail(error == NULL || *error == NULL, NULL);
-
-    if (inout & ~(SNDRV_SEQ_REMOVE_INPUT | SNDRV_SEQ_REMOVE_OUTPUT)) {
-        generate_error(error, EINVAL);
-        return NULL;
-    }
+    g_return_val_if_fail(!(inout & ~(SNDRV_SEQ_REMOVE_INPUT | SNDRV_SEQ_REMOVE_OUTPUT)), NULL);
 
     filter.remove_mode = inout | SNDRV_SEQ_REMOVE_TAG_MATCH;
     filter.queue = queue_id;
@@ -199,11 +179,7 @@ ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_tick_time(
     struct snd_seq_remove_events filter;
 
     g_return_val_if_fail(error == NULL || *error == NULL, NULL);
-
-    if (inout & ~(SNDRV_SEQ_REMOVE_INPUT | SNDRV_SEQ_REMOVE_OUTPUT)) {
-        generate_error(error, EINVAL);
-        return NULL;
-    }
+    g_return_val_if_fail(!(inout & ~(SNDRV_SEQ_REMOVE_INPUT | SNDRV_SEQ_REMOVE_OUTPUT)), NULL);
 
     filter.remove_mode = inout | SNDRV_SEQ_REMOVE_TIME_TICK;
     if (after)
@@ -238,11 +214,7 @@ ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_real_time(
     struct snd_seq_remove_events filter;
 
     g_return_val_if_fail(error == NULL || *error == NULL, NULL);
-
-    if (inout & ~(SNDRV_SEQ_REMOVE_INPUT | SNDRV_SEQ_REMOVE_OUTPUT)) {
-        generate_error(error, EINVAL);
-        return NULL;
-    }
+    g_return_val_if_fail(!(inout & ~(SNDRV_SEQ_REMOVE_INPUT | SNDRV_SEQ_REMOVE_OUTPUT)), NULL);
 
     filter.remove_mode = inout;
     if (after)

--- a/src/seq/user-client.c
+++ b/src/seq/user-client.c
@@ -583,11 +583,7 @@ void alsaseq_user_client_create_source(ALSASeqUserClient *self,
         return;
     }
 
-    buf = g_try_malloc0(page_size);
-    if (buf == NULL) {
-        generate_error(error, ENOMEM);
-        return;
-    }
+    buf = g_malloc0(page_size);
 
     *gsrc = g_source_new(&funcs, sizeof(*src));
     src = (UserClientSource *)(*gsrc);

--- a/src/seq/user-client.c
+++ b/src/seq/user-client.c
@@ -215,6 +215,7 @@ void alsaseq_user_client_get_protocol_version(ALSASeqUserClient *self,
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(proto_ver_triplet != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     if (priv->fd < 0) {
@@ -244,9 +245,9 @@ void alsaseq_user_client_set_info(ALSASeqUserClient *self,
     struct snd_seq_client_info *info;
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
-    g_return_if_fail(ALSASEQ_IS_CLIENT_INFO(client_info));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(ALSASEQ_IS_CLIENT_INFO(client_info));
     g_return_if_fail(error == NULL || *error == NULL);
 
     seq_client_info_refer_private(client_info, &info);
@@ -275,10 +276,10 @@ void alsaseq_user_client_get_info(ALSASeqUserClient *self,
     struct snd_seq_client_info *info;
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
-    g_return_if_fail(client_info != NULL);
-    g_return_if_fail(ALSASEQ_IS_CLIENT_INFO(*client_info));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(client_info != NULL);
+    g_return_if_fail(ALSASEQ_IS_CLIENT_INFO(*client_info));
     g_return_if_fail(error == NULL || *error == NULL);
 
     seq_client_info_refer_private(*client_info, &info);
@@ -306,9 +307,9 @@ void alsaseq_user_client_create_port(ALSASeqUserClient *self,
     struct snd_seq_port_info *info;
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
-    g_return_if_fail(ALSASEQ_IS_PORT_INFO(*port_info));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(ALSASEQ_IS_PORT_INFO(*port_info));
     g_return_if_fail(error == NULL || *error == NULL);
 
     seq_port_info_refer_private(*port_info, &info);
@@ -368,9 +369,9 @@ void alsaseq_user_client_update_port(ALSASeqUserClient *self,
     struct snd_seq_port_info *info;
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
-    g_return_if_fail(ALSASEQ_IS_PORT_INFO(port_info));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(ALSASEQ_IS_PORT_INFO(port_info));
     g_return_if_fail(error == NULL || *error == NULL);
 
     seq_port_info_refer_private(port_info, &info);
@@ -429,9 +430,9 @@ void alsaseq_user_client_set_pool(ALSASeqUserClient *self,
     struct snd_seq_client_pool *pool;
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
-    g_return_if_fail(ALSASEQ_IS_CLIENT_POOL(client_pool));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(ALSASEQ_IS_CLIENT_POOL(client_pool));
     g_return_if_fail(error == NULL || *error == NULL);
 
     seq_client_pool_refer_private(client_pool, &pool);
@@ -459,10 +460,9 @@ void alsaseq_user_client_get_pool(ALSASeqUserClient *self,
     struct snd_seq_client_pool *pool;
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
-    g_return_if_fail(*client_pool != NULL);
-    g_return_if_fail(ALSASEQ_IS_CLIENT_POOL(*client_pool));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(ALSASEQ_IS_CLIENT_POOL(*client_pool));
     g_return_if_fail(error == NULL || *error == NULL);
 
     seq_client_pool_refer_private(*client_pool, &pool);
@@ -494,22 +494,16 @@ void alsaseq_user_client_schedule_event(ALSASeqUserClient *self,
     ssize_t len;
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
-    g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(ev_cntr));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(ev_cntr));
     g_return_if_fail(error == NULL || *error == NULL);
 
     alsaseq_event_cntr_count_events(ev_cntr, &total);
-    if (count > total) {
-        generate_error(error, ENOBUFS);
-        return;
-    }
+    g_return_if_fail(count <= total);
 
     seq_event_cntr_get_buf(ev_cntr, count, &buf, &length);
-    if (buf == NULL || length == 0) {
-        generate_error(error, ENODATA);
-        return;
-    }
+    g_return_if_fail(buf != NULL && length > 0);
 
     len = write(priv->fd, buf, length);
     if (len < 0)
@@ -599,6 +593,7 @@ void alsaseq_user_client_create_source(ALSASeqUserClient *self,
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(gsrc != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     if (priv->fd < 0) {
@@ -646,9 +641,9 @@ void alsaseq_user_client_operate_subscription(ALSASeqUserClient *self,
     long request;
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
-    g_return_if_fail(ALSASEQ_IS_SUBSCRIBE_DATA(subs_data));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(ALSASEQ_IS_SUBSCRIBE_DATA(subs_data));
     g_return_if_fail(error == NULL || *error == NULL);
 
     seq_subscribe_data_refer_private(subs_data, &data);
@@ -682,9 +677,9 @@ void alsaseq_user_client_create_queue(ALSASeqUserClient *self,
     struct snd_seq_queue_info *info;
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
-    g_return_if_fail(ALSASEQ_IS_QUEUE_INFO(*queue_info));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(ALSASEQ_IS_QUEUE_INFO(*queue_info));
     g_return_if_fail(error == NULL || *error == NULL);
 
     seq_queue_info_refer_private(*queue_info, &info);
@@ -740,9 +735,9 @@ void alsaseq_user_client_update_queue(ALSASeqUserClient *self,
     struct snd_seq_queue_info *info;
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
-    g_return_if_fail(ALSASEQ_IS_QUEUE_INFO(queue_info));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(ALSASEQ_IS_QUEUE_INFO(queue_info));
     g_return_if_fail(error == NULL || *error == NULL);
 
     seq_queue_info_refer_private(queue_info, &info);
@@ -774,6 +769,7 @@ void alsaseq_user_client_get_queue_usage(ALSASeqUserClient *self,
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(use != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     data.queue = (int)queue_id;
@@ -839,9 +835,9 @@ void alsaseq_user_client_set_queue_tempo(ALSASeqUserClient *self,
     struct snd_seq_queue_tempo *tempo;
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
-    g_return_if_fail(ALSASEQ_IS_QUEUE_TEMPO(queue_tempo));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(ALSASEQ_IS_QUEUE_TEMPO(queue_tempo));
     g_return_if_fail(error == NULL || *error == NULL);
 
     seq_queue_tempo_refer_private(queue_tempo, &tempo);
@@ -871,9 +867,9 @@ void alsaseq_user_client_get_queue_tempo(ALSASeqUserClient *self,
     struct snd_seq_queue_tempo *tempo;
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
-    g_return_if_fail(queue_tempo != NULL);
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(queue_tempo != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     *queue_tempo = g_object_new(ALSASEQ_TYPE_QUEUE_TEMPO, NULL);
@@ -908,9 +904,9 @@ void alsaseq_user_client_set_queue_timer(ALSASeqUserClient *self,
     struct snd_seq_queue_timer *timer;
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
-    g_return_if_fail(ALSASEQ_IS_QUEUE_TIMER(queue_timer));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(ALSASEQ_IS_QUEUE_TIMER(queue_timer));
     g_return_if_fail(error == NULL || *error == NULL);
 
     seq_queue_timer_refer_private(queue_timer, &timer);
@@ -921,8 +917,7 @@ void alsaseq_user_client_set_queue_timer(ALSASeqUserClient *self,
     case SNDRV_SEQ_TIMER_MIDI_CLOCK:
     case SNDRV_SEQ_TIMER_MIDI_TICK:
     default:
-        generate_error(error, EINVAL);
-        return;
+        g_return_if_reached();
     }
 
     timer->queue = queue_id;
@@ -952,9 +947,9 @@ void alsaseq_user_client_get_queue_timer(ALSASeqUserClient *self,
     struct snd_seq_queue_timer *timer;
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
-    g_return_if_fail(queue_timer != NULL);
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(queue_timer != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     *queue_timer = g_object_new(ALSASEQ_TYPE_QUEUE_TIMER, NULL);
@@ -975,8 +970,7 @@ void alsaseq_user_client_get_queue_timer(ALSASeqUserClient *self,
         // Not available.
         g_object_unref(*queue_timer);
         *queue_timer = NULL;
-        generate_error(error, ENXIO);
-        return;
+        g_return_if_reached();
     }
 }
 
@@ -1000,6 +994,7 @@ void alsaseq_user_client_remove_events(ALSASeqUserClient *self,
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(filter != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     if (ioctl(priv->fd, SNDRV_SEQ_IOCTL_REMOVE_EVENTS, filter) < 0) {

--- a/src/seq/user-client.c
+++ b/src/seq/user-client.c
@@ -45,6 +45,7 @@ G_DEFINE_QUARK(alsaseq-user-client-error-quark, alsaseq_user_client_error)
 
 static const char *const err_msgs[] = {
         [ALSASEQ_USER_CLIENT_ERROR_PORT_PERMISSION] = "The operation fails due to access permission of port",
+        [ALSASEQ_USER_CLIENT_ERROR_QUEUE_PERMISSION] = "The operation fails due to access permission of queue",
 };
 
 #define generate_local_error(exception, code) \
@@ -780,8 +781,12 @@ void alsaseq_user_client_update_queue(ALSASeqUserClient *self,
 
     seq_queue_info_refer_private(queue_info, &info);
 
-    if (ioctl(priv->fd, SNDRV_SEQ_IOCTL_SET_QUEUE_INFO, info) < 0)
-        generate_syscall_error(error, errno, "ioctl(%s)", "SET_QUEUE_INFO");
+    if (ioctl(priv->fd, SNDRV_SEQ_IOCTL_SET_QUEUE_INFO, info) < 0) {
+        if (errno == EPERM)
+            generate_local_error(error, ALSASEQ_USER_CLIENT_ERROR_QUEUE_PERMISSION);
+        else
+            generate_syscall_error(error, errno, "ioctl(%s)", "SET_QUEUE_INFO");
+    }
 }
 
 /**
@@ -880,8 +885,12 @@ void alsaseq_user_client_set_queue_tempo(ALSASeqUserClient *self,
 
     seq_queue_tempo_refer_private(queue_tempo, &tempo);
     tempo->queue = queue_id;
-    if (ioctl(priv->fd, SNDRV_SEQ_IOCTL_SET_QUEUE_TEMPO, tempo) < 0)
-        generate_syscall_error(error, errno, "ioctl(%s)", "SET_QUEUE_TEMPO");
+    if (ioctl(priv->fd, SNDRV_SEQ_IOCTL_SET_QUEUE_TEMPO, tempo) < 0) {
+        if (errno == EPERM)
+            generate_local_error(error, ALSASEQ_USER_CLIENT_ERROR_QUEUE_PERMISSION);
+        else
+            generate_syscall_error(error, errno, "ioctl(%s)", "SET_QUEUE_TEMPO");
+    }
 }
 
 /**
@@ -959,8 +968,12 @@ void alsaseq_user_client_set_queue_timer(ALSASeqUserClient *self,
     }
 
     timer->queue = queue_id;
-    if (ioctl(priv->fd, SNDRV_SEQ_IOCTL_SET_QUEUE_TIMER, timer) < 0)
-        generate_syscall_error(error, errno, "ioctl(%s)", "SET_QUEUE_TIMER");
+    if (ioctl(priv->fd, SNDRV_SEQ_IOCTL_SET_QUEUE_TIMER, timer) < 0) {
+        if (errno == EPERM)
+            generate_local_error(error, ALSASEQ_USER_CLIENT_ERROR_QUEUE_PERMISSION);
+        else
+            generate_syscall_error(error, errno, "ioctl(%s)", "SET_QUEUE_TIMER");
+    }
 }
 
 /**

--- a/src/seq/user-client.c
+++ b/src/seq/user-client.c
@@ -33,6 +33,15 @@ struct _ALSASeqUserClientPrivate {
 };
 G_DEFINE_TYPE_WITH_PRIVATE(ALSASeqUserClient, alsaseq_user_client, G_TYPE_OBJECT)
 
+/**
+ * alsaseq_user_client_error_quark:
+ *
+ * Return the GQuark for error domain of GError which has code in #ALSASeqUserClientError enumerations.
+ *
+ * Returns: A #GQuark.
+ */
+G_DEFINE_QUARK(alsaseq-user-client-error-quark, alsaseq_user_client_error)
+
 typedef struct {
     GSource src;
     ALSASeqUserClient *self;

--- a/src/seq/user-client.c
+++ b/src/seq/user-client.c
@@ -161,6 +161,8 @@ void alsaseq_user_client_open(ALSASeqUserClient *self, gint open_flag,
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     alsaseq_get_seq_devnode(&devnode, error);
     if (*error != NULL)
         return;
@@ -213,6 +215,8 @@ void alsaseq_user_client_get_protocol_version(ALSASeqUserClient *self,
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     if (priv->fd < 0) {
         generate_error(error, ENXIO);
         return;
@@ -242,6 +246,8 @@ void alsaseq_user_client_set_info(ALSASeqUserClient *self,
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
     g_return_if_fail(ALSASEQ_IS_CLIENT_INFO(client_info));
     priv = alsaseq_user_client_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     seq_client_info_refer_private(client_info, &info);
     info->client = priv->client_id;
@@ -273,6 +279,8 @@ void alsaseq_user_client_get_info(ALSASeqUserClient *self,
     g_return_if_fail(ALSASEQ_IS_CLIENT_INFO(*client_info));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     seq_client_info_refer_private(*client_info, &info);
     info->client = priv->client_id;
     if (ioctl(priv->fd, SNDRV_SEQ_IOCTL_GET_CLIENT_INFO, info) < 0)
@@ -301,6 +309,8 @@ void alsaseq_user_client_create_port(ALSASeqUserClient *self,
     g_return_if_fail(ALSASEQ_IS_PORT_INFO(*port_info));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     seq_port_info_refer_private(*port_info, &info);
 
     info->addr.client = priv->client_id;
@@ -328,6 +338,7 @@ void alsaseq_user_client_create_port_at(ALSASeqUserClient *self,
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
     g_return_if_fail(ALSASEQ_IS_PORT_INFO(*port_info));
+    g_return_if_fail(error == NULL || *error == NULL);
 
     seq_port_info_refer_private(*port_info, &info);
 
@@ -360,6 +371,8 @@ void alsaseq_user_client_update_port(ALSASeqUserClient *self,
     g_return_if_fail(ALSASEQ_IS_PORT_INFO(port_info));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     seq_port_info_refer_private(port_info, &info);
 
     info->addr.client = priv->client_id;
@@ -389,6 +402,8 @@ void alsaseq_user_client_delete_port(ALSASeqUserClient *self,
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     info.addr.client = priv->client_id;
     info.addr.port = port_id;
     if (ioctl(priv->fd, SNDRV_SEQ_IOCTL_DELETE_PORT, &info) < 0)
@@ -416,6 +431,8 @@ void alsaseq_user_client_set_pool(ALSASeqUserClient *self,
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
     g_return_if_fail(ALSASEQ_IS_CLIENT_POOL(client_pool));
     priv = alsaseq_user_client_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     seq_client_pool_refer_private(client_pool, &pool);
     pool->client = priv->client_id;
@@ -445,6 +462,8 @@ void alsaseq_user_client_get_pool(ALSASeqUserClient *self,
     g_return_if_fail(*client_pool != NULL);
     g_return_if_fail(ALSASEQ_IS_CLIENT_POOL(*client_pool));
     priv = alsaseq_user_client_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     seq_client_pool_refer_private(*client_pool, &pool);
     pool->client = priv->client_id;
@@ -477,6 +496,8 @@ void alsaseq_user_client_schedule_event(ALSASeqUserClient *self,
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
     g_return_if_fail(ALSASEQ_IS_EVENT_CNTR(ev_cntr));
     priv = alsaseq_user_client_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     alsaseq_event_cntr_count_events(ev_cntr, &total);
     if (count > total) {
@@ -578,6 +599,8 @@ void alsaseq_user_client_create_source(ALSASeqUserClient *self,
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     if (priv->fd < 0) {
         generate_error(error, ENXIO);
         return;
@@ -626,6 +649,8 @@ void alsaseq_user_client_operate_subscription(ALSASeqUserClient *self,
     g_return_if_fail(ALSASEQ_IS_SUBSCRIBE_DATA(subs_data));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     seq_subscribe_data_refer_private(subs_data, &data);
 
     if (establish)
@@ -660,6 +685,8 @@ void alsaseq_user_client_create_queue(ALSASeqUserClient *self,
     g_return_if_fail(ALSASEQ_IS_QUEUE_INFO(*queue_info));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     seq_queue_info_refer_private(*queue_info, &info);
 
     if (ioctl(priv->fd, SNDRV_SEQ_IOCTL_CREATE_QUEUE, info) < 0)
@@ -685,6 +712,8 @@ void alsaseq_user_client_delete_queue(ALSASeqUserClient *self,
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
     priv = alsaseq_user_client_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     info.queue = (int)queue_id;
     info.owner = priv->client_id;
@@ -714,6 +743,8 @@ void alsaseq_user_client_update_queue(ALSASeqUserClient *self,
     g_return_if_fail(ALSASEQ_IS_QUEUE_INFO(queue_info));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     seq_queue_info_refer_private(queue_info, &info);
 
     if (ioctl(priv->fd, SNDRV_SEQ_IOCTL_SET_QUEUE_INFO, info) < 0)
@@ -742,6 +773,8 @@ void alsaseq_user_client_get_queue_usage(ALSASeqUserClient *self,
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
     priv = alsaseq_user_client_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     data.queue = (int)queue_id;
     if (ioctl(priv->fd, SNDRV_SEQ_IOCTL_GET_QUEUE_CLIENT, &data) < 0) {
@@ -775,6 +808,8 @@ void alsaseq_user_client_set_queue_usage(ALSASeqUserClient *self,
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     data.queue = (int)queue_id;
     data.client = priv->client_id;
     data.used = use;
@@ -807,6 +842,8 @@ void alsaseq_user_client_set_queue_tempo(ALSASeqUserClient *self,
     g_return_if_fail(ALSASEQ_IS_QUEUE_TEMPO(queue_tempo));
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     seq_queue_tempo_refer_private(queue_tempo, &tempo);
     tempo->queue = queue_id;
     if (ioctl(priv->fd, SNDRV_SEQ_IOCTL_SET_QUEUE_TEMPO, tempo) < 0)
@@ -836,6 +873,8 @@ void alsaseq_user_client_get_queue_tempo(ALSASeqUserClient *self,
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
     g_return_if_fail(queue_tempo != NULL);
     priv = alsaseq_user_client_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     *queue_tempo = g_object_new(ALSASEQ_TYPE_QUEUE_TEMPO, NULL);
     seq_queue_tempo_refer_private(*queue_tempo, &tempo);
@@ -871,6 +910,8 @@ void alsaseq_user_client_set_queue_timer(ALSASeqUserClient *self,
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
     g_return_if_fail(ALSASEQ_IS_QUEUE_TIMER(queue_timer));
     priv = alsaseq_user_client_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     seq_queue_timer_refer_private(queue_timer, &timer);
 
@@ -914,6 +955,8 @@ void alsaseq_user_client_get_queue_timer(ALSASeqUserClient *self,
     g_return_if_fail(queue_timer != NULL);
     priv = alsaseq_user_client_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     *queue_timer = g_object_new(ALSASEQ_TYPE_QUEUE_TIMER, NULL);
     seq_queue_timer_refer_private(*queue_timer, &timer);
 
@@ -956,6 +999,8 @@ void alsaseq_user_client_remove_events(ALSASeqUserClient *self,
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
     priv = alsaseq_user_client_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     if (ioctl(priv->fd, SNDRV_SEQ_IOCTL_REMOVE_EVENTS, filter) < 0) {
         generate_error(error, errno);

--- a/src/seq/user-client.c
+++ b/src/seq/user-client.c
@@ -214,14 +214,10 @@ void alsaseq_user_client_get_protocol_version(ALSASeqUserClient *self,
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
     priv = alsaseq_user_client_get_instance_private(self);
+    g_return_if_fail(priv->fd >= 0);
 
     g_return_if_fail(proto_ver_triplet != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
-
-    if (priv->fd < 0) {
-        generate_error(error, ENXIO);
-        return;
-    }
 
     *proto_ver_triplet = (const guint16 *)priv->proto_ver_triplet;
 }
@@ -592,14 +588,10 @@ void alsaseq_user_client_create_source(ALSASeqUserClient *self,
 
     g_return_if_fail(ALSASEQ_IS_USER_CLIENT(self));
     priv = alsaseq_user_client_get_instance_private(self);
+    g_return_if_fail(priv->fd >= 0);
 
     g_return_if_fail(gsrc != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
-
-    if (priv->fd < 0) {
-        generate_error(error, ENXIO);
-        return;
-    }
 
     buf = g_malloc0(page_size);
 

--- a/src/seq/user-client.c
+++ b/src/seq/user-client.c
@@ -169,7 +169,8 @@ ALSASeqUserClient *alsaseq_user_client_new()
  * alsaseq_user_client_open:
  * @self: A #ALSASeqUserClient.
  * @open_flag: The flag of open(2) system call. O_RDWR is forced to fulfil internally.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with two domains; #g_file_error_quark() and
+ *         #alsaseq_user_client_error_quark().
  *
  * Open ALSA sequencer character device.
  *
@@ -259,7 +260,7 @@ void alsaseq_user_client_get_protocol_version(ALSASeqUserClient *self,
  * alsaseq_user_client_set_info:
  * @self: A #ALSASeqUserClient.
  * @client_info: A #ALSASeqClientInfo.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
  *
  * Get client information.
  *
@@ -290,7 +291,7 @@ void alsaseq_user_client_set_info(ALSASeqUserClient *self,
  * alsaseq_user_client_get_info:
  * @self: A #ALSASeqUserClient.
  * @client_info: (inout): A #ALSASeqClientInfo.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
  *
  * Set client information.
  *
@@ -321,7 +322,7 @@ void alsaseq_user_client_get_info(ALSASeqUserClient *self,
  * alsaseq_user_client_create_port:
  * @self: A #ALSASeqUserClient.
  * @port_info: (inout): A #ALSASeqPortInfo.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
  *
  * Create a port into the client.
  *
@@ -353,7 +354,7 @@ void alsaseq_user_client_create_port(ALSASeqUserClient *self,
  * @self: A #ALSASeqUserClient.
  * @port_info: (inout): A #ALSASeqPortInfo.
  * @port_id: The numerical ID of port to create.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
  *
  * Create a port into the client with the given numerical port ID.
  *
@@ -383,7 +384,7 @@ void alsaseq_user_client_create_port_at(ALSASeqUserClient *self,
  * @self: A #ALSASeqUserClient.
  * @port_info: A #ALSASeqPortInfo.
  * @port_id: The numerical ID of port.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
  *
  * Update port information.
  *
@@ -416,7 +417,7 @@ void alsaseq_user_client_update_port(ALSASeqUserClient *self,
  * alsaseq_user_client_delete_port:
  * @self: A #ALSASeqUserClient.
  * @port_id: The numerical ID of port.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
  *
  * Delete a port from the client.
  *
@@ -444,7 +445,7 @@ void alsaseq_user_client_delete_port(ALSASeqUserClient *self,
  * alsaseq_user_client_set_pool:
  * @self: A #ALSASeqUserClient.
  * @client_pool: A #ALSASeqClientPool to be configured for the client.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
  *
  * Configure memory pool in the client.
  *
@@ -474,7 +475,7 @@ void alsaseq_user_client_set_pool(ALSASeqUserClient *self,
  * alsaseq_user_client_get_pool:
  * @self: A #ALSASeqUserClient.
  * @client_pool: (inout): A #ALSASeqClientPool to be configured for the client.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
  *
  * Get information of memory pool in the client.
  *
@@ -505,7 +506,8 @@ void alsaseq_user_client_get_pool(ALSASeqUserClient *self,
  * @self: A #ALSASeqUserClient.
  * @ev_cntr: An instance of #ALSASeqEventCntr pointing to events.
  * @count: The number of events in the ev_cntr to write.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with two domains; #g_file_error_quark()
+ *         and #alsaseq_user_client_error_quark().
  *
  * Deliver the event immediately, or schedule it into memory pool of the client.
  *
@@ -654,7 +656,7 @@ void alsaseq_user_client_create_source(ALSASeqUserClient *self,
  * @self: A #ALSASeqUserClient.
  * @subs_data: A #ALSASeqSubscribeData.
  * @establish: Whether to establish subscription between two ports, or break it.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
  *
  * Operate subscription between two ports pointed by the data.
  *
@@ -700,7 +702,7 @@ void alsaseq_user_client_operate_subscription(ALSASeqUserClient *self,
  * alsaseq_user_client_create_queue:
  * @self: A #ALSASeqUserClient.
  * @queue_info: (inout): The information of queue to add.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
  *
  * Create a new queue owned by the client. The content of information is updated
  * if success.
@@ -731,7 +733,7 @@ void alsaseq_user_client_create_queue(ALSASeqUserClient *self,
  * alsaseq_user_client_delete_queue:
  * @self: A #ALSASeqUserClient.
  * @queue_id: The numerical ID of queue, except for one of ALSASeqSpecificQueueId.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
  *
  * Delete the queue owned by the client.
  *
@@ -759,7 +761,7 @@ void alsaseq_user_client_delete_queue(ALSASeqUserClient *self,
  * alsaseq_user_client_update_queue:
  * @self: A #ALSASeqUserClient.
  * @queue_info: The information of queue to add.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
  *
  * Update owned queue according to the information.
  *
@@ -795,7 +797,7 @@ void alsaseq_user_client_update_queue(ALSASeqUserClient *self,
  * @queue_id: The numerical ID of queue, except for entries in
  *            ALSASeqSpecificQueueId.
  * @use: (out): Whether the client uses the queue or not.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
  *
  * Get usage of the queue by the client.
  *
@@ -830,7 +832,7 @@ void alsaseq_user_client_get_queue_usage(ALSASeqUserClient *self,
  * @queue_id: The numerical ID of queue, except for entries in
  *            ALSASeqSpecificQueueId.
  * @use: Whether to use the queue or not.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
  *
  * Start the queue to use or not.
  *
@@ -863,7 +865,7 @@ void alsaseq_user_client_set_queue_usage(ALSASeqUserClient *self,
  * @queue_id: The numerical ID of queue, except for entries in
  *            ALSASeqSpecificQueueId.
  * @queue_tempo: The data of tempo for queue.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
  *
  * Set the data of tempo to the queue.
  *
@@ -899,7 +901,7 @@ void alsaseq_user_client_set_queue_tempo(ALSASeqUserClient *self,
  * @queue_id: The numerical ID of queue, except for entries in
  *            ALSASeqSpecificQueueId.
  * @queue_tempo: (out): The data of tempo for queue.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
  *
  * Get the data of tempo for the queue.
  *
@@ -935,7 +937,7 @@ void alsaseq_user_client_get_queue_tempo(ALSASeqUserClient *self,
  * @queue_id: The numerical ID of queue, except for entries in
  *            ALSASeqSpecificQueueId.
  * @queue_timer: The data of timer for queue.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
  *
  * Set the data of timer for the queue.
  *
@@ -982,7 +984,7 @@ void alsaseq_user_client_set_queue_timer(ALSASeqUserClient *self,
  * @queue_id: The numerical ID of queue, except for entries in
  *            ALSASeqSpecificQueueId.
  * @queue_timer: (out): The data of timer for queue.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
  *
  * Get the data of timer for the queue.
  *
@@ -1029,7 +1031,7 @@ void alsaseq_user_client_get_queue_timer(ALSASeqUserClient *self,
  * alsaseq_user_client_remove_events:
  * @self: A #ALSASeqUserClient.
  * @filter: A #ALSASeqRemoveFilter.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
  *
  * Remove queued events according to the filter.
  *

--- a/src/seq/user-client.h
+++ b/src/seq/user-client.h
@@ -39,6 +39,10 @@ G_BEGIN_DECLS
                                ALSASEQ_TYPE_USER_CLIENT,    \
                                ALSASeqUserClientClass))
 
+#define ALSASEQ_USER_CLIENT_ERROR   alsaseq_user_client_error_quark()
+
+GQuark alsaseq_user_client_error_quark();
+
 typedef struct _ALSASeqUserClient           ALSASeqUserClient;
 typedef struct _ALSASeqUserClientClass      ALSASeqUserClientClass;
 typedef struct _ALSASeqUserClientPrivate    ALSASeqUserClientPrivate;

--- a/tests/alsaseq-enums
+++ b/tests/alsaseq-enums
@@ -167,6 +167,7 @@ remove_filter_flags = (
 user_client_error_types = (
     'FAILED',
     'PORT_PERMISSION',
+    'QUEUE_PERMISSION',
 )
 
 types = {

--- a/tests/alsaseq-enums
+++ b/tests/alsaseq-enums
@@ -166,6 +166,7 @@ remove_filter_flags = (
 
 user_client_error_types = (
     'FAILED',
+    'PORT_PERMISSION',
 )
 
 types = {

--- a/tests/alsaseq-enums
+++ b/tests/alsaseq-enums
@@ -164,6 +164,10 @@ remove_filter_flags = (
     'OUTPUT',
 )
 
+user_client_error_types = (
+    'FAILED',
+)
+
 types = {
     ALSASeq.SpecificAddress:    specific_address_types,
     ALSASeq.SpecificClientId:   specific_client_id_types,
@@ -182,6 +186,7 @@ types = {
     ALSASeq.QuerySubscribeType: query_subscribe_types,
     ALSASeq.QueueTimerType:     queue_timer_types,
     ALSASeq.RemoveFilterFlag:   remove_filter_flags,
+    ALSASeq.UserClientError:    user_client_error_types,
 }
 
 for obj, types in types.items():


### PR DESCRIPTION
The patchset is the part of work about #47.

Current implementation uses library-wide error domain to report error. this
is partly against rule of GError usage. Furthermore, the error delivers
information just about errno and hard to know the cause of error.

This patchset enhances error reporting. The library-wide error domain is
obsoleted. A new error domain is added just for ALSASeq.UserClient.
The error domain delivers information about the cause of error.

```
Takashi Sakamoto (15):
  seq: skip check of return value from g_malloc()
  seq: check whether method argument for GError is available
  seq: add checks for method arguments
  seq: user_client: just return when character device is not opened
  seq: add GLib enumeration to report type of error for ALSASeq.UserClient
  seq: user_client: add GQuark to report error for ALSASeq.UserClient
  seq: user_client: report error for ioctl
  seq: user_client: report open/write error
  seq: user_client: report error for port access permission
  seq: user_client: report error for queue access permission
  seq: user_client: update function comment for error reporting
  seq: query: use GFileError to report error
  seq: query: code refactoring to unify code to open file descriptor
  seq: query: code refactoring for error path
  seq: obsolete library-wide error quark

 src/seq/alsaseq-enum-types.h |  14 ++
 src/seq/alsaseq.map          |   5 +
 src/seq/client-info.c        |  20 +-
 src/seq/event-cntr.c         | 341 +++++++++++++++++----------------
 src/seq/privates.h           |   6 -
 src/seq/query.c              | 356 +++++++++++++++--------------------
 src/seq/queue-status.c       |   4 +
 src/seq/queue-tempo.c        |   4 +
 src/seq/queue-timer.c        |   4 +
 src/seq/remove-filter.c      |  42 ++---
 src/seq/user-client.c        | 275 ++++++++++++++++++---------
 src/seq/user-client.h        |   4 +
 tests/alsaseq-enums          |   7 +
 13 files changed, 566 insertions(+), 516 deletions(-)
```