### PR TITLE
[PATCH 0/9] alsa-gobject: hwdep: enhancement for error reporting

### DIFF
--- a/src/ctl/query.c
+++ b/src/ctl/query.c
@@ -165,12 +165,9 @@ void alsactl_get_card_id_list(guint **entries, gsize *entry_count,
             udev_device_unref(dev);
         }
     }
-    if (index != count) {
-        g_warn_if_reached();
-        g_free(*entries);
-        *entries = NULL;
-        goto end;
-    }
+
+    g_warn_if_fail(index == count);
+
     *entry_count = count;
 
     qsort(*entries, count, sizeof(guint), compare_guint);

--- a/src/hwdep/privates.h
+++ b/src/hwdep/privates.h
@@ -8,12 +8,6 @@
 
 G_BEGIN_DECLS
 
-GQuark alsahwdep_error_quark(void);
-
-#define generate_error(err, errno)                              \
-    g_set_error(err, alsahwdep_error_quark(), errno,            \
-                __FILE__ ":%d: %s", __LINE__, strerror(errno))
-
 void hwdep_device_info_refer_private(ALSAHwdepDeviceInfo *self,
                                      struct snd_hwdep_info **info);
 

--- a/src/hwdep/query.c
+++ b/src/hwdep/query.c
@@ -153,11 +153,8 @@ void alsahwdep_get_device_id_list(guint card_id, guint **entries,
         goto end;
 
     length = strlen(PREFIX_SYSNAME_TEMPLATE) + calculate_digits(card_id) + 1;
-    prefix = g_try_malloc0(length);
-    if (prefix == NULL) {
-        generate_error(error, ENOMEM);
-        goto end;
-    }
+    prefix = g_malloc0(length);
+
     snprintf(prefix, length, PREFIX_SYSNAME_TEMPLATE, card_id);
 
     entry_list = udev_enumerate_get_list_entry(enumerator);
@@ -175,11 +172,7 @@ void alsahwdep_get_device_id_list(guint card_id, guint **entries,
     if (count == 0)
         goto end;
 
-    *entries = g_try_malloc0_n(count, sizeof(**entries));
-    if (*entries == NULL) {
-        generate_error(error, ENOMEM);
-        goto end;
-    }
+    *entries = g_malloc0_n(count, sizeof(**entries));
 
     index = 0;
     udev_list_entry_foreach(entry, entry_list) {
@@ -233,11 +226,8 @@ void alsahwdep_get_hwdep_sysname(guint card_id, guint device_id,
 
     length = strlen(HWDEP_SYSNAME_TEMPLATE) + calculate_digits(card_id) +
              calculate_digits(device_id) + 1;
-    name = g_try_malloc0(length);
-    if (name == NULL) {
-        generate_error(error, ENOMEM);
-        return;
-    }
+    name = g_malloc0(length);
+
     snprintf(name, length, HWDEP_SYSNAME_TEMPLATE, card_id, device_id);
 
     ctx = udev_new();
@@ -281,11 +271,8 @@ void alsahwdep_get_hwdep_devnode(guint card_id, guint device_id,
 
     length = strlen(HWDEP_SYSNAME_TEMPLATE) + calculate_digits(card_id) +
              calculate_digits(device_id) + 1;
-    name = g_try_malloc0(length);
-    if (name == NULL) {
-        generate_error(error, ENOMEM);
-        return;
-    }
+    name = g_malloc0(length);
+
     snprintf(name, length, HWDEP_SYSNAME_TEMPLATE, card_id, device_id);
 
     ctx = udev_new();
@@ -304,13 +291,10 @@ void alsahwdep_get_hwdep_devnode(guint card_id, guint device_id,
     }
 
     node = udev_device_get_devnode(dev);
-    if (node == NULL) {
+    if (node == NULL)
         generate_error(error, ENOENT);
-    } else {
-        *devnode = strdup(node);
-        if (*devnode == NULL)
-            generate_error(error, ENOMEM);
-    }
+    else
+        *devnode = g_strdup(node);
 
     udev_device_unref(dev);
     udev_unref(ctx);
@@ -327,11 +311,8 @@ static void hwdep_perform_ctl_ioctl(guint card_id, long request, void *data,
     int fd;
 
     length = strlen(CTL_SYSNAME_TEMPLATE) + calculate_digits(card_id) + 1;
-    sysname = g_try_malloc0(length);
-    if (sysname == NULL) {
-        generate_error(error, ENOMEM);
-        return;
-    }
+    sysname = g_malloc0(length);
+
     snprintf(sysname, length, CTL_SYSNAME_TEMPLATE, card_id);
 
     ctx = udev_new();

--- a/src/hwdep/query.c
+++ b/src/hwdep/query.c
@@ -192,12 +192,9 @@ void alsahwdep_get_device_id_list(guint card_id, guint **entries,
             udev_device_unref(dev);
         }
     }
-    if (index != count) {
-        g_warn_if_reached();
-        g_free(*entries);
-        *entries = NULL;
-        goto end;
-    }
+
+    g_warn_if_fail(index == count);
+
     *entry_count = count;
 
     qsort(*entries, count, sizeof(guint), compare_guint);

--- a/src/hwdep/query.c
+++ b/src/hwdep/query.c
@@ -147,6 +147,7 @@ void alsahwdep_get_device_id_list(guint card_id, guint **entries,
 
     g_return_if_fail(entries != NULL);
     g_return_if_fail(entry_count != NULL);
+    g_return_if_fail(error == NULL || *error == NULL);
 
     prepare_udev_enum(&enumerator, error);
     if (*error != NULL)
@@ -224,6 +225,8 @@ void alsahwdep_get_hwdep_sysname(guint card_id, guint device_id,
     struct udev *ctx;
     struct udev_device *dev;
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     length = strlen(HWDEP_SYSNAME_TEMPLATE) + calculate_digits(card_id) +
              calculate_digits(device_id) + 1;
     name = g_malloc0(length);
@@ -268,6 +271,8 @@ void alsahwdep_get_hwdep_devnode(guint card_id, guint device_id,
     struct udev *ctx;
     struct udev_device *dev;
     const char *node;
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     length = strlen(HWDEP_SYSNAME_TEMPLATE) + calculate_digits(card_id) +
              calculate_digits(device_id) + 1;
@@ -370,6 +375,7 @@ void alsahwdep_get_device_info(guint card_id, guint device_id,
     struct snd_hwdep_info *info;
 
     g_return_if_fail(device_info != NULL);
+    g_return_if_fail(error == NULL || *error == NULL);
 
     *device_info = g_object_new(ALSAHWDEP_TYPE_DEVICE_INFO, NULL);
     hwdep_device_info_refer_private(*device_info, &info);

--- a/src/hwdep/query.c
+++ b/src/hwdep/query.c
@@ -193,7 +193,7 @@ void alsahwdep_get_device_id_list(guint card_id, guint **entries,
         }
     }
     if (index != count) {
-        generate_error(error, ENOENT);
+        g_warn_if_reached();
         g_free(*entries);
         *entries = NULL;
         goto end;
@@ -225,6 +225,7 @@ void alsahwdep_get_hwdep_sysname(guint card_id, guint device_id,
     struct udev *ctx;
     struct udev_device *dev;
 
+    g_return_if_fail(sysname != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     length = strlen(HWDEP_SYSNAME_TEMPLATE) + calculate_digits(card_id) +
@@ -272,6 +273,7 @@ void alsahwdep_get_hwdep_devnode(guint card_id, guint device_id,
     struct udev_device *dev;
     const char *node;
 
+    g_return_if_fail(devnode != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     length = strlen(HWDEP_SYSNAME_TEMPLATE) + calculate_digits(card_id) +

--- a/src/hwdep/query.c
+++ b/src/hwdep/query.c
@@ -20,9 +20,6 @@
  *                     descriptor
  */
 
-// For error handling.
-G_DEFINE_QUARK("alsahwdep-error", alsahwdep_error)
-
 // 'C' is required apart from emulation of Open Sound System.
 #define PREFIX_SYSNAME_TEMPLATE     "hwC%u"
 #define HWDEP_SYSNAME_TEMPLATE      "hwC%uD%u"

--- a/src/seq/query.c
+++ b/src/seq/query.c
@@ -246,7 +246,7 @@ void alsaseq_get_client_id_list(guint8 **entries, gsize *entry_count,
 
     if (*error != NULL) {
         g_free(list);
-        goto end;;
+        goto end;
     }
 
     g_warn_if_fail(index == count);

--- a/src/timer/instance-params.c
+++ b/src/timer/instance-params.c
@@ -223,10 +223,7 @@ void alsatimer_instance_params_get_event_filter(ALSATimerInstanceParams *self,
         }
     }
 
-    if (index != count) {
-        g_free(list);
-        g_return_if_reached();
-    }
+    g_warn_if_fail(index == count);
 
     *entries = list;
     *entry_count = count;


### PR DESCRIPTION
The patchset is the part of work about #47.

Current implementation uses library-wide error domain to report error. this
is partly against rule of GError usage. Furthermore, the error delivers
information just about errno and hard to know the cause of error.

This patchset enhances error reporting. The library-wide error domain is
obsoleted. ALSAHwdep library is small and includes global functions.
GFileError is used for the functions to report error since It has no
specific error domain in current design.

```
Takashi Sakamoto (9):
  seq: query: remove duplicated semicolon
  ctl: query: simplify count check
  timer: instance_param: simplify count check
  hwdep: skip check of return value from g_malloc()
  hwdep: check whether method argument for GError is available
  hwdep: add checks for method arguments
  hwdep: query: simplify count check
  hwdep: query: use GFileError to report error
  hwdep; obsolete library-wide GQuark for error reporting

 src/ctl/query.c             |   9 ++--
 src/hwdep/privates.h        |   6 ---
 src/hwdep/query.c           | 101 ++++++++++++++++--------------------
 src/seq/query.c             |   2 +-
 src/timer/instance-params.c |   5 +-
 5 files changed, 50 insertions(+), 73 deletions(-)
```