### PR TITLE
[PATCH 00/15] alsa-gobject: rawmidi: enhancement for error reporting

### DIFF
--- a/src/rawmidi/alsarawmidi-enum-types.h
+++ b/src/rawmidi/alsarawmidi-enum-types.h
@@ -31,4 +31,14 @@ typedef enum /*< flags >*/
     ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_DUPLEX = SNDRV_RAWMIDI_INFO_DUPLEX,
 } ALSARawmidiStreamPairInfoFlag;
 
+/**
+ * ALSARawmidiStreamPairError:
+ * @ALSARAWMIDI_STREAM_PAIR_ERROR_FAILED:       The system call failed.
+ *
+ * A set of error code for GError with domain which equals to #alsarawmidi_stream_pair_error_quark()
+ */
+typedef enum {
+    ALSARAWMIDI_STREAM_PAIR_ERROR_FAILED,
+} ALSARawmidiStreamPairError;
+
 #endif

--- a/src/rawmidi/alsarawmidi-enum-types.h
+++ b/src/rawmidi/alsarawmidi-enum-types.h
@@ -35,12 +35,14 @@ typedef enum /*< flags >*/
  * ALSARawmidiStreamPairError:
  * @ALSARAWMIDI_STREAM_PAIR_ERROR_FAILED:       The system call failed.
  * @ALSARAWMIDI_STREAM_PAIR_ERROR_DISCONNECTED: The card associated to the instance is in disconnect state.
+ * @ALSARAWMIDI_STREAM_PAIR_ERROR_UNREADABLE:   The instance is not for read operation.
  *
  * A set of error code for GError with domain which equals to #alsarawmidi_stream_pair_error_quark()
  */
 typedef enum {
     ALSARAWMIDI_STREAM_PAIR_ERROR_FAILED,
     ALSARAWMIDI_STREAM_PAIR_ERROR_DISCONNECTED,
+    ALSARAWMIDI_STREAM_PAIR_ERROR_UNREADABLE,
 } ALSARawmidiStreamPairError;
 
 #endif

--- a/src/rawmidi/alsarawmidi-enum-types.h
+++ b/src/rawmidi/alsarawmidi-enum-types.h
@@ -34,11 +34,13 @@ typedef enum /*< flags >*/
 /**
  * ALSARawmidiStreamPairError:
  * @ALSARAWMIDI_STREAM_PAIR_ERROR_FAILED:       The system call failed.
+ * @ALSARAWMIDI_STREAM_PAIR_ERROR_DISCONNECTED: The card associated to the instance is in disconnect state.
  *
  * A set of error code for GError with domain which equals to #alsarawmidi_stream_pair_error_quark()
  */
 typedef enum {
     ALSARAWMIDI_STREAM_PAIR_ERROR_FAILED,
+    ALSARAWMIDI_STREAM_PAIR_ERROR_DISCONNECTED,
 } ALSARawmidiStreamPairError;
 
 #endif

--- a/src/rawmidi/alsarawmidi.map
+++ b/src/rawmidi/alsarawmidi.map
@@ -32,3 +32,7 @@ ALSA_GOBJECT_0_0_0 {
   local:
     *;
 };
+
+ALSA_GOBJECT_0_2_0 {
+    "alsarawmidi_stream_pair_error_get_type";
+} ALSA_GOBJECT_0_0_0;

--- a/src/rawmidi/alsarawmidi.map
+++ b/src/rawmidi/alsarawmidi.map
@@ -35,4 +35,5 @@ ALSA_GOBJECT_0_0_0 {
 
 ALSA_GOBJECT_0_2_0 {
     "alsarawmidi_stream_pair_error_get_type";
+    "alsarawmidi_stream_pair_error_quark";
 } ALSA_GOBJECT_0_0_0;

--- a/src/rawmidi/privates.h
+++ b/src/rawmidi/privates.h
@@ -15,12 +15,6 @@
 
 G_BEGIN_DECLS
 
-GQuark alsarawmidi_error_quark(void);
-
-#define generate_error(err, errno)                              \
-    g_set_error(err, alsarawmidi_error_quark(), errno,          \
-                __FILE__ ":%d: %s", __LINE__, strerror(errno))
-
 void rawmidi_substream_info_refer_private(ALSARawmidiSubstreamInfo *self,
                                           struct snd_rawmidi_info **info);
 

--- a/src/rawmidi/query.c
+++ b/src/rawmidi/query.c
@@ -20,9 +20,6 @@
  *                     descriptor
  */
 
-// For error reporting.
-G_DEFINE_QUARK("alsarawmidi-error", alsarawmidi_error)
-
 // 'C' is required apart from emulation of Open Sound System.
 #define PREFIX_SYSNAME_TEMPLATE     "midiC%u"
 #define RAWMIDI_SYSNAME_TEMPLATE    "midiC%uD%u"

--- a/src/rawmidi/query.c
+++ b/src/rawmidi/query.c
@@ -147,6 +147,7 @@ void alsarawmidi_get_device_id_list(guint card_id, guint **entries,
 
     g_return_if_fail(entries != NULL);
     g_return_if_fail(entry_count != NULL);
+    g_return_if_fail(error == NULL || *error == NULL);
 
     prepare_udev_enum(&enumerator, error);
     if (*error != NULL)
@@ -224,6 +225,8 @@ void alsarawmidi_get_rawmidi_sysname(guint card_id, guint device_id,
     struct udev *ctx;
     struct udev_device *dev;
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     length = strlen(RAWMIDI_SYSNAME_TEMPLATE) + calculate_digits(card_id) +
              calculate_digits(device_id) + 1;
     name = g_malloc0(length);
@@ -268,6 +271,8 @@ void alsarawmidi_get_rawmidi_devnode(guint card_id, guint device_id,
     struct udev *ctx;
     struct udev_device *dev;
     const char *node;
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     length = strlen(RAWMIDI_SYSNAME_TEMPLATE) + calculate_digits(card_id) +
              calculate_digits(device_id) + 1;
@@ -382,6 +387,7 @@ void alsarawmidi_get_subdevice_id_list(guint card, guint device,
 
     g_return_if_fail(entries != NULL);
     g_return_if_fail(entry_count != NULL);
+    g_return_if_fail(error == NULL || *error == NULL);
 
     rawmidi_perform_ctl_ioctl(card, SNDRV_CTL_IOCTL_RAWMIDI_INFO, &info, error);
     if (*error != NULL)
@@ -416,6 +422,8 @@ void alsarawmidi_get_substream_info(guint card_id, guint device_id,
                                     GError **error)
 {
     struct snd_rawmidi_info *info;
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     if (substream_info == NULL) {
         generate_error(error, EINVAL);

--- a/src/rawmidi/query.c
+++ b/src/rawmidi/query.c
@@ -193,7 +193,7 @@ void alsarawmidi_get_device_id_list(guint card_id, guint **entries,
         }
     }
     if (index != count) {
-        generate_error(error, ENOENT);
+        g_warn_if_reached();
         g_free(*entries);
         *entries = NULL;
         goto end;
@@ -225,6 +225,7 @@ void alsarawmidi_get_rawmidi_sysname(guint card_id, guint device_id,
     struct udev *ctx;
     struct udev_device *dev;
 
+    g_return_if_fail(sysname != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     length = strlen(RAWMIDI_SYSNAME_TEMPLATE) + calculate_digits(card_id) +
@@ -272,6 +273,7 @@ void alsarawmidi_get_rawmidi_devnode(guint card_id, guint device_id,
     struct udev_device *dev;
     const char *node;
 
+    g_return_if_fail(devnode != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     length = strlen(RAWMIDI_SYSNAME_TEMPLATE) + calculate_digits(card_id) +
@@ -423,12 +425,8 @@ void alsarawmidi_get_substream_info(guint card_id, guint device_id,
 {
     struct snd_rawmidi_info *info;
 
+    g_return_if_fail(substream_info != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
-
-    if (substream_info == NULL) {
-        generate_error(error, EINVAL);
-        return;
-    }
 
     *substream_info = g_object_new(ALSARAWMIDI_TYPE_SUBSTREAM_INFO, NULL);
 

--- a/src/rawmidi/query.c
+++ b/src/rawmidi/query.c
@@ -153,11 +153,8 @@ void alsarawmidi_get_device_id_list(guint card_id, guint **entries,
         goto end;
 
     length = strlen(PREFIX_SYSNAME_TEMPLATE) + calculate_digits(card_id) + 1;
-    prefix = g_try_malloc0(length);
-    if (prefix == NULL) {
-        generate_error(error, ENOMEM);
-        goto end;
-    }
+    prefix = g_malloc0(length);
+
     snprintf(prefix, length, PREFIX_SYSNAME_TEMPLATE, card_id);
 
     entry_list = udev_enumerate_get_list_entry(enumerator);
@@ -175,11 +172,7 @@ void alsarawmidi_get_device_id_list(guint card_id, guint **entries,
     if (count == 0)
         goto end;
 
-    *entries = g_try_malloc0_n(count, sizeof(**entries));
-    if (*entries == NULL) {
-        generate_error(error, ENOMEM);
-        goto end;
-    }
+    *entries = g_malloc0_n(count, sizeof(**entries));
 
     index = 0;
     udev_list_entry_foreach(entry, entry_list) {
@@ -233,11 +226,8 @@ void alsarawmidi_get_rawmidi_sysname(guint card_id, guint device_id,
 
     length = strlen(RAWMIDI_SYSNAME_TEMPLATE) + calculate_digits(card_id) +
              calculate_digits(device_id) + 1;
-    name = g_try_malloc0(length);
-    if (name == NULL) {
-        generate_error(error, ENOMEM);
-        return;
-    }
+    name = g_malloc0(length);
+
     snprintf(name, length, RAWMIDI_SYSNAME_TEMPLATE, card_id, device_id);
 
     ctx = udev_new();
@@ -281,11 +271,8 @@ void alsarawmidi_get_rawmidi_devnode(guint card_id, guint device_id,
 
     length = strlen(RAWMIDI_SYSNAME_TEMPLATE) + calculate_digits(card_id) +
              calculate_digits(device_id) + 1;
-    name = g_try_malloc0(length);
-    if (name == NULL) {
-        generate_error(error, ENOMEM);
-        return;
-    }
+    name = g_malloc0(length);
+
     snprintf(name, length, RAWMIDI_SYSNAME_TEMPLATE, card_id, device_id);
 
     ctx = udev_new();
@@ -304,13 +291,10 @@ void alsarawmidi_get_rawmidi_devnode(guint card_id, guint device_id,
     }
 
     node = udev_device_get_devnode(dev);
-    if (node == NULL) {
+    if (node == NULL)
         generate_error(error, ENOENT);
-    } else {
-        *devnode = strdup(node);
-        if (*devnode == NULL)
-            generate_error(error, ENOMEM);
-    }
+    else
+        *devnode = g_strdup(node);
 
     udev_device_unref(dev);
     udev_unref(ctx);
@@ -327,11 +311,8 @@ static void rawmidi_perform_ctl_ioctl(guint card_id, long request, void *data,
     int fd;
 
     length = strlen(CTL_SYSNAME_TEMPLATE) + calculate_digits(card_id) + 1;
-    sysname = g_try_malloc0(length);
-    if (sysname == NULL) {
-        generate_error(error, ENOMEM);
-        return;
-    }
+    sysname = g_malloc0(length);
+
     snprintf(sysname, length, CTL_SYSNAME_TEMPLATE, card_id);
 
     ctx = udev_new();
@@ -406,11 +387,7 @@ void alsarawmidi_get_subdevice_id_list(guint card, guint device,
     if (*error != NULL)
         return;
 
-    *entries = g_try_malloc0_n(info.subdevices_count, sizeof(guint));
-    if (*entries == NULL) {
-        generate_error(error, ENOMEM);
-        return;
-    }
+    *entries = g_malloc0_n(info.subdevices_count, sizeof(guint));
 
     for (i = 0; i < info.subdevices_count; ++i)
         (*entries)[i] = i;

--- a/src/rawmidi/query.c
+++ b/src/rawmidi/query.c
@@ -192,12 +192,9 @@ void alsarawmidi_get_device_id_list(guint card_id, guint **entries,
             udev_device_unref(dev);
         }
     }
-    if (index != count) {
-        g_warn_if_reached();
-        g_free(*entries);
-        *entries = NULL;
-        goto end;
-    }
+
+    g_warn_if_fail(index == count);
+
     *entry_count = count;
 
     qsort(*entries, count, sizeof(guint), compare_guint);

--- a/src/rawmidi/stream-pair.c
+++ b/src/rawmidi/stream-pair.c
@@ -188,26 +188,20 @@ void alsarawmidi_stream_pair_open(ALSARawmidiStreamPair *self, guint card_id,
     g_return_if_fail(ALSARAWMIDI_IS_STREAM_PAIR(self));
     priv = alsarawmidi_stream_pair_get_instance_private(self);
 
+    // The flag is used to attach substreams for each direction.
+    g_return_if_fail((access_modes & ~(ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_OUTPUT |
+                     ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_INPUT)) == 0);
     g_return_if_fail(error == NULL || *error == NULL);
 
-    // The flag is used to attach substreams for each direction.
-    if (access_modes & ~(ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_OUTPUT |
-                         ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_INPUT)) {
-        generate_error(error, EINVAL);
-        return;
-    }
-
     if ((access_modes & ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_OUTPUT) &&
-        (access_modes & ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_INPUT)) {
+        (access_modes & ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_INPUT))
         open_flag = O_RDWR;
-    } else if (access_modes & ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_OUTPUT) {
+    else if (access_modes & ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_OUTPUT)
         open_flag = O_WRONLY;
-    } else if (access_modes & ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_INPUT) {
+    else if (access_modes & ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_INPUT)
         open_flag = O_RDONLY;
-    } else {
-        generate_error(error, EINVAL);
-        return;
-    }
+    else
+        g_return_if_reached();
 
     alsarawmidi_get_rawmidi_devnode(card_id, device_id, &devnode, error);
     if (*error != NULL)
@@ -261,6 +255,7 @@ void alsarawmidi_stream_pair_get_protocol_version(ALSARawmidiStreamPair *self,
     g_return_if_fail(ALSARAWMIDI_IS_STREAM_PAIR(self));
     priv = alsarawmidi_stream_pair_get_instance_private(self);
 
+    g_return_if_fail(proto_ver_triplet != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     if (priv->fd < 0) {
@@ -294,6 +289,7 @@ void alsarawmidi_stream_pair_get_substream_info(ALSARawmidiStreamPair *self,
     g_return_if_fail(ALSARAWMIDI_IS_STREAM_PAIR(self));
     priv = alsarawmidi_stream_pair_get_instance_private(self);
 
+    g_return_if_fail(substream_info != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     *substream_info = g_object_new(ALSARAWMIDI_TYPE_SUBSTREAM_INFO, NULL);
@@ -331,6 +327,7 @@ void alsarawmidi_stream_pair_set_substream_params(ALSARawmidiStreamPair *self,
     g_return_if_fail(ALSARAWMIDI_IS_STREAM_PAIR(self));
     priv = alsarawmidi_stream_pair_get_instance_private(self);
 
+    g_return_if_fail(substream_params != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     rawmidi_substream_params_refer_private(substream_params, &params);
@@ -362,9 +359,9 @@ void alsarawmidi_stream_pair_get_substream_status(ALSARawmidiStreamPair *self,
     struct snd_rawmidi_status *status;
 
     g_return_if_fail(ALSARAWMIDI_IS_STREAM_PAIR(self));
-    g_return_if_fail(substream_status != NULL);
     priv = alsarawmidi_stream_pair_get_instance_private(self);
 
+    g_return_if_fail(substream_status != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     rawmidi_substream_status_refer_private(*substream_status, &status);
@@ -399,6 +396,8 @@ void alsarawmidi_stream_pair_read_from_substream(ALSARawmidiStreamPair *self,
     g_return_if_fail(ALSARAWMIDI_IS_STREAM_PAIR(self));
     priv = alsarawmidi_stream_pair_get_instance_private(self);
 
+    g_return_if_fail(buf != NULL);
+    g_return_if_fail(buf_size != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     len = read(priv->fd, *buf, *buf_size);
@@ -435,6 +434,7 @@ void alsarawmidi_stream_pair_write_to_substream(ALSARawmidiStreamPair *self,
     g_return_if_fail(ALSARAWMIDI_IS_STREAM_PAIR(self));
     priv = alsarawmidi_stream_pair_get_instance_private(self);
 
+    g_return_if_fail(buf != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     len = write(priv->fd, buf, buf_size);
@@ -575,6 +575,7 @@ void alsarawmidi_stream_pair_create_source(ALSARawmidiStreamPair *self,
     g_return_if_fail(ALSARAWMIDI_IS_STREAM_PAIR(self));
     priv = alsarawmidi_stream_pair_get_instance_private(self);
 
+    g_return_if_fail(gsrc != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
     if (priv->fd < 0) {

--- a/src/rawmidi/stream-pair.c
+++ b/src/rawmidi/stream-pair.c
@@ -188,6 +188,8 @@ void alsarawmidi_stream_pair_open(ALSARawmidiStreamPair *self, guint card_id,
     g_return_if_fail(ALSARAWMIDI_IS_STREAM_PAIR(self));
     priv = alsarawmidi_stream_pair_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     // The flag is used to attach substreams for each direction.
     if (access_modes & ~(ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_OUTPUT |
                          ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_INPUT)) {
@@ -259,6 +261,8 @@ void alsarawmidi_stream_pair_get_protocol_version(ALSARawmidiStreamPair *self,
     g_return_if_fail(ALSARAWMIDI_IS_STREAM_PAIR(self));
     priv = alsarawmidi_stream_pair_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     if (priv->fd < 0) {
         generate_error(error, ENXIO);
         return;
@@ -289,6 +293,8 @@ void alsarawmidi_stream_pair_get_substream_info(ALSARawmidiStreamPair *self,
 
     g_return_if_fail(ALSARAWMIDI_IS_STREAM_PAIR(self));
     priv = alsarawmidi_stream_pair_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     *substream_info = g_object_new(ALSARAWMIDI_TYPE_SUBSTREAM_INFO, NULL);
 
@@ -325,6 +331,8 @@ void alsarawmidi_stream_pair_set_substream_params(ALSARawmidiStreamPair *self,
     g_return_if_fail(ALSARAWMIDI_IS_STREAM_PAIR(self));
     priv = alsarawmidi_stream_pair_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     rawmidi_substream_params_refer_private(substream_params, &params);
 
     params->stream = direction;
@@ -357,6 +365,8 @@ void alsarawmidi_stream_pair_get_substream_status(ALSARawmidiStreamPair *self,
     g_return_if_fail(substream_status != NULL);
     priv = alsarawmidi_stream_pair_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     rawmidi_substream_status_refer_private(*substream_status, &status);
 
     status->stream = direction;
@@ -388,6 +398,8 @@ void alsarawmidi_stream_pair_read_from_substream(ALSARawmidiStreamPair *self,
 
     g_return_if_fail(ALSARAWMIDI_IS_STREAM_PAIR(self));
     priv = alsarawmidi_stream_pair_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     len = read(priv->fd, *buf, *buf_size);
     if (len < 0) {
@@ -423,6 +435,8 @@ void alsarawmidi_stream_pair_write_to_substream(ALSARawmidiStreamPair *self,
     g_return_if_fail(ALSARAWMIDI_IS_STREAM_PAIR(self));
     priv = alsarawmidi_stream_pair_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     len = write(priv->fd, buf, buf_size);
     if (len < 0) {
         generate_error(error, errno);
@@ -453,6 +467,8 @@ void alsarawmidi_stream_pair_drain_substream(ALSARawmidiStreamPair *self,
     g_return_if_fail(ALSARAWMIDI_IS_STREAM_PAIR(self));
     priv = alsarawmidi_stream_pair_get_instance_private(self);
 
+    g_return_if_fail(error == NULL || *error == NULL);
+
     if (ioctl(priv->fd, SNDRV_RAWMIDI_IOCTL_DRAIN, &direction) < 0)
         generate_error(error, errno);
 }
@@ -478,6 +494,8 @@ void alsarawmidi_stream_pair_drop_substream(ALSARawmidiStreamPair *self,
 
     g_return_if_fail(ALSARAWMIDI_IS_STREAM_PAIR(self));
     priv = alsarawmidi_stream_pair_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     if (ioctl(priv->fd, SNDRV_RAWMIDI_IOCTL_DROP, &direction) < 0)
         generate_error(error, errno);
@@ -556,6 +574,8 @@ void alsarawmidi_stream_pair_create_source(ALSARawmidiStreamPair *self,
 
     g_return_if_fail(ALSARAWMIDI_IS_STREAM_PAIR(self));
     priv = alsarawmidi_stream_pair_get_instance_private(self);
+
+    g_return_if_fail(error == NULL || *error == NULL);
 
     if (priv->fd < 0) {
         generate_error(error, ENXIO);

--- a/src/rawmidi/stream-pair.c
+++ b/src/rawmidi/stream-pair.c
@@ -41,6 +41,15 @@ struct _ALSARawmidiStreamPairPrivate {
 };
 G_DEFINE_TYPE_WITH_PRIVATE(ALSARawmidiStreamPair, alsarawmidi_stream_pair, G_TYPE_OBJECT)
 
+/**
+ * alsarawmidi_stream_pair_error_quark:
+ *
+ * Return the GQuark for error domain of GError which has code in #ALSARawmidiStreamPairError.
+ *
+ * Returns: A #GQuark.
+ */
+G_DEFINE_QUARK(alsarawmidi-stream-pair-error-quark, alsarawmidi_stream_pair_error)
+
 typedef struct {
     GSource src;
     ALSARawmidiStreamPair *self;

--- a/src/rawmidi/stream-pair.c
+++ b/src/rawmidi/stream-pair.c
@@ -254,14 +254,10 @@ void alsarawmidi_stream_pair_get_protocol_version(ALSARawmidiStreamPair *self,
 
     g_return_if_fail(ALSARAWMIDI_IS_STREAM_PAIR(self));
     priv = alsarawmidi_stream_pair_get_instance_private(self);
+    g_return_if_fail(priv->fd >= 0);
 
     g_return_if_fail(proto_ver_triplet != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
-
-    if (priv->fd < 0) {
-        generate_error(error, ENXIO);
-        return;
-    }
 
     *proto_ver_triplet = (const guint16 *)priv->proto_ver_triplet;
 }
@@ -574,14 +570,10 @@ void alsarawmidi_stream_pair_create_source(ALSARawmidiStreamPair *self,
 
     g_return_if_fail(ALSARAWMIDI_IS_STREAM_PAIR(self));
     priv = alsarawmidi_stream_pair_get_instance_private(self);
+    g_return_if_fail(priv->fd >= 0);
 
     g_return_if_fail(gsrc != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
-
-    if (priv->fd < 0) {
-        generate_error(error, ENXIO);
-        return;
-    }
 
     access_modes = fcntl(priv->fd, F_GETFL);
     if (access_modes < 0) {

--- a/src/rawmidi/stream-pair.c
+++ b/src/rawmidi/stream-pair.c
@@ -52,6 +52,7 @@ G_DEFINE_QUARK(alsarawmidi-stream-pair-error-quark, alsarawmidi_stream_pair_erro
 
 static const char *const err_msgs[] = {
         [ALSARAWMIDI_STREAM_PAIR_ERROR_DISCONNECTED] = "The card is in disconnect state",
+        [ALSARAWMIDI_STREAM_PAIR_ERROR_UNREADABLE] = "The instance is not for read operation",
 };
 
 #define generate_local_error(error, code) \
@@ -662,7 +663,7 @@ void alsarawmidi_stream_pair_create_source(ALSARawmidiStreamPair *self,
     }
 
     if (!(access_modes & O_RDWR) && !(access_modes & O_WRONLY)) {
-        generate_error(error, ENOTSUP);
+        generate_local_error(error, ALSARAWMIDI_STREAM_PAIR_ERROR_UNREADABLE);
         return;
     }
 

--- a/src/rawmidi/stream-pair.h
+++ b/src/rawmidi/stream-pair.h
@@ -34,6 +34,10 @@ G_BEGIN_DECLS
                                ALSARAWMIDI_TYPE_STREAM_PAIR,    \
                                ALSARawmidiStreamPairClass))
 
+#define ALSARAWMIDI_STREAM_PAIR_ERROR           alsarawmidi_stream_pair_error_quark()
+
+GQuark alsarawmidi_stream_pair_error_quark();
+
 typedef struct _ALSARawmidiStreamPair           ALSARawmidiStreamPair;
 typedef struct _ALSARawmidiStreamPairClass      ALSARawmidiStreamPairClass;
 typedef struct _ALSARawmidiStreamPairPrivate    ALSARawmidiStreamPairPrivate;

--- a/src/seq/user-client.c
+++ b/src/seq/user-client.c
@@ -200,7 +200,7 @@ void alsaseq_user_client_open(ALSASeqUserClient *self, gint open_flag,
         GFileError code = g_file_error_from_errno(errno);
 
         if (code != G_FILE_ERROR_FAILED)
-            generate_file_error(error, errno, "open(%s)", devnode);
+            generate_file_error(error, code, "open(%s)", devnode);
         else
             generate_syscall_error(error, errno, "open(%s)", devnode);
 
@@ -541,9 +541,9 @@ void alsaseq_user_client_schedule_event(ALSASeqUserClient *self,
         GFileError code = g_file_error_from_errno(errno);
 
         if (code != G_FILE_ERROR_FAILED)
-            generate_file_error(error, errno, "open(%s)", priv->devnode);
+            generate_file_error(error, code, "write(%s)", priv->devnode);
         else
-            generate_syscall_error(error, errno, "open(%s)", priv->devnode);
+            generate_syscall_error(error, errno, "write(%s)", priv->devnode);
     }
 }
 

--- a/src/timer/user-instance.c
+++ b/src/timer/user-instance.c
@@ -165,7 +165,7 @@ void alsatimer_user_instance_open(ALSATimerUserInstance *self, gint open_flag,
         GFileError code = g_file_error_from_errno(errno);
 
         if (code != G_FILE_ERROR_FAILED)
-            generate_file_error(error, errno, "open(%s)", devnode);
+            generate_file_error(error, code, "open(%s)", devnode);
         else
             generate_syscall_error(error, errno, "open(%s)", devnode);
 

--- a/tests/alsarawmidi-enums
+++ b/tests/alsarawmidi-enums
@@ -16,9 +16,14 @@ stream_pair_info_flags = (
     'DUPLEX',
 )
 
+stream_pair_error_types = (
+    'FAILED',
+)
+
 types = {
     ALSARawmidi.StreamDirection:    stream_direction_types,
     ALSARawmidi.StreamPairInfoFlag: stream_pair_info_flags,
+    ALSARawmidi.StreamPairError:    stream_pair_error_types,
 }
 
 for obj, types in types.items():

--- a/tests/alsarawmidi-enums
+++ b/tests/alsarawmidi-enums
@@ -18,6 +18,7 @@ stream_pair_info_flags = (
 
 stream_pair_error_types = (
     'FAILED',
+    'DISCONNECTED',
 )
 
 types = {


### PR DESCRIPTION
The patchset is the part of work about #47.

Current implementation uses library-wide error domain to report error. this
is partly against rule of GError usage. Furthermore, the error delivers
information just about errno and hard to know the cause of error.

This patchset enhances error reporting. The library-wide error domain is
obsoleted. A new error domain is added just for ALSARawmidi.StreamPair.
The error domain delivers information about the cause of error

```
Takashi Sakamoto (15):
  timer: user_instance: fix code for GFileError
  seq: user_client: fix code for GFileError
  rawmidi: skip check of return value from g_malloc()
  rawmidi: check whether method argument for GError is available
  rawmidi: add checks for method arguments
  rawmidi: stream_pair: just return when character device is not opened
  rawmidi: query: simplify count check
  rawmidi: add GLib enumerations for error reporting
  rawmidi: stream-pair: add GQuark to report error for ALSARawmidi.StreamPair
  rawmidi: report error for ioctl
  rawmidi: report open/read/write/fcntl error
  rawmidi: report error for card disconnection state
  rawmidi: stream_pair: report error about write-only file descriptor
  rawmidi: query: use GFileError to report error
  rawmidi: obsolete library-wide GQuark for error reporting

 src/rawmidi/alsarawmidi-enum-types.h |  14 +++
 src/rawmidi/alsarawmidi.map          |   5 +
 src/rawmidi/privates.h               |   6 -
 src/rawmidi/query.c                  | 117 ++++++++----------
 src/rawmidi/stream-pair.c            | 172 +++++++++++++++++++++------
 src/rawmidi/stream-pair.h            |   4 +
 src/seq/user-client.c                |   6 +-
 src/timer/user-instance.c            |   2 +-
 tests/alsarawmidi-enums              |   6 +
 9 files changed, 216 insertions(+), 116 deletions(-)
```