### PR TITLE
[PATCH] alsa-gobject: ctl: change prototype of function relevant to TLV

### DIFF
--- a/src/ctl/alsactl.map
+++ b/src/ctl/alsactl.map
@@ -19,9 +19,6 @@ ALSA_GOBJECT_0_0_0 {
     "alsactl_card_get_elem_id_list";
     "alsactl_card_lock_elem";
     "alsactl_card_get_elem_info";
-    "alsactl_card_write_elem_tlv";
-    "alsactl_card_read_elem_tlv";
-    "alsactl_card_command_elem_tlv";
     "alsactl_card_add_elems";
     "alsactl_card_replace_elems";
     "alsactl_card_remove_elems";
@@ -94,4 +91,7 @@ ALSA_GOBJECT_0_0_0 {
 ALSA_GOBJECT_0_2_0 {
     "alsactl_card_error_get_type";
     "alsactl_card_error_quark";
+    "alsactl_card_write_elem_tlv";
+    "alsactl_card_read_elem_tlv";
+    "alsactl_card_command_elem_tlv";
 } ALSA_GOBJECT_0_0_0;

--- a/src/ctl/card.c
+++ b/src/ctl/card.c
@@ -576,7 +576,7 @@ void alsactl_card_get_elem_info(ALSACtlCard *self, const ALSACtlElemId *elem_id,
  */
 void alsactl_card_write_elem_tlv(ALSACtlCard *self,
                             const ALSACtlElemId *elem_id,
-                            const gint32 *container, gsize container_count,
+                            const guint32 *container, gsize container_count,
                             GError **error)
 {
     ALSACtlCardPrivate *priv;
@@ -630,7 +630,7 @@ void alsactl_card_write_elem_tlv(ALSACtlCard *self,
  * SNDRV_CTL_IOCTL_TLV_READ command for ALSA control character device.
  */
 void alsactl_card_read_elem_tlv(ALSACtlCard *self, const ALSACtlElemId *elem_id,
-                            gint32 *const *container, gsize *container_count,
+                            guint32 *const *container, gsize *container_count,
                             GError **error)
 {
     ALSACtlCardPrivate *priv;
@@ -685,7 +685,7 @@ void alsactl_card_read_elem_tlv(ALSACtlCard *self, const ALSACtlElemId *elem_id,
  */
 void alsactl_card_command_elem_tlv(ALSACtlCard *self,
                             const ALSACtlElemId *elem_id,
-                            gint32 *const *container, gsize *container_count,
+                            guint32 *const *container, gsize *container_count,
                             GError **error)
 {
     ALSACtlCardPrivate *priv;

--- a/src/ctl/card.h
+++ b/src/ctl/card.h
@@ -101,14 +101,14 @@ void alsactl_card_get_elem_info(ALSACtlCard *self, const ALSACtlElemId *elem_id,
 
 void alsactl_card_write_elem_tlv(ALSACtlCard *self,
                             const ALSACtlElemId *elem_id,
-                            const gint32 *container, gsize container_count,
+                            const guint32 *container, gsize container_count,
                             GError **error);
 void alsactl_card_read_elem_tlv(ALSACtlCard *self, const ALSACtlElemId *elem_id,
-                            gint32 *const *container, gsize *container_count,
+                            guint32 *const *container, gsize *container_count,
                             GError **error);
 void alsactl_card_command_elem_tlv(ALSACtlCard *self,
                             const ALSACtlElemId *elem_id,
-                            gint32 *const *container, gsize *container_count,
+                            guint32 *const *container, gsize *container_count,
                             GError **error);
 
 void alsactl_card_add_elems(ALSACtlCard *self, const ALSACtlElemId *elem_id,


### PR DESCRIPTION
In ALSA control interface, the data of TLV (Type-Length-Value) style is
defined as array with unsigned int type of element. However, current
implementation of ALSACtl.Card handles them as signed int type.

This commit fixes the bug. This loses backward compatibility to v0.1.0
in a point of type of function argument.