### PR TITLE
alsa-gobject: various fixes

### DIFF
--- a/src/ctl/query.c
+++ b/src/ctl/query.c
@@ -109,7 +109,7 @@ static int compare_guint(const void *l, const void *r)
  * @entries: (array length=entry_count)(out): The list of numerical ID for sound
  *           cards.
  * @entry_count: The number of entries.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Get the list of numerical ID for available sound cards.
  *
@@ -225,7 +225,7 @@ static bool check_existence(char *sysname, GError **error)
  * alsactl_get_card_sysname:
  * @card_id: The numeridcal ID of sound card.
  * @sysname: (out): The string for sysname of the sound card.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Allocate sysname for the sound card and return it when it exists.
  *
@@ -254,7 +254,7 @@ void alsactl_get_card_sysname(guint card_id, char **sysname, GError **error)
  * alsactl_get_control_sysname:
  * @card_id: The numeridcal ID of sound card.
  * @sysname: (out): The string for sysname of control device for the sound card.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Allocate sysname of control device for the sound card and return it when
  * it exists.
@@ -284,7 +284,7 @@ void alsactl_get_control_sysname(guint card_id, char **sysname, GError **error)
  * alsactl_get_control_devnode:
  * @card_id: The numerical ID of sound card.
  * @devnode: (out): The string for devnode of control device for the sound card.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Allocate string of devnode for control device of the sound card and return it
  * if exists.

--- a/src/hwdep/query.c
+++ b/src/hwdep/query.c
@@ -132,7 +132,7 @@ static unsigned int calculate_digits(unsigned int number)
  * @entries: (array length=entry_count)(out): The list of numerical ID for
  *           hwdep device.
  * @entry_count: The number of entries.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Get the list of numerical ID for available hwdep devices of sound card.
  *
@@ -211,7 +211,7 @@ end:
  * @card_id: The numeridcal ID of sound card.
  * @device_id: The numerical ID of hwdep device for the sound card.
  * @sysname: (out): The string for sysname of hwdep device.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Allocate sysname for hwdep device and return it when it exists.
  *
@@ -258,7 +258,7 @@ void alsahwdep_get_hwdep_sysname(guint card_id, guint device_id,
  * @card_id: The numeridcal ID of sound card.
  * @device_id: The numerical ID of hwdep device for the sound card.
  * @devnode: (out): The string for devnode of hwdep device.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Allocate devnode string for hwdep device and return it when exists.
  *
@@ -363,7 +363,7 @@ err_sysname:
  * @card_id: The numberical value for sound card to query.
  * @device_id: The numerical value of hwdep device to query.
  * @device_info: (out): The information of the device.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Get the information according to given numerical IDs for card and device.
  *

--- a/src/hwdep/query.c
+++ b/src/hwdep/query.c
@@ -114,7 +114,7 @@ static int compare_guint(const void *l, const void *r)
 
 static unsigned int calculate_digits(unsigned int number)
 {
-    unsigned int digits;
+    unsigned int digits = 0;
 
     while (true) {
         number /= 10;

--- a/src/rawmidi/query.c
+++ b/src/rawmidi/query.c
@@ -114,7 +114,7 @@ static int compare_guint(const void *l, const void *r)
 
 static unsigned int calculate_digits(unsigned int number)
 {
-    unsigned int digits;
+    unsigned int digits = 0;
 
     while (true) {
         number /= 10;

--- a/src/rawmidi/query.c
+++ b/src/rawmidi/query.c
@@ -132,7 +132,7 @@ static unsigned int calculate_digits(unsigned int number)
  * @entries: (array length=entry_count)(out): The list of numerical ID for
  *           rawmidi device.
  * @entry_count: The number of entries.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Get the list of numerical ID for available rawmidi devices of sound card.
  *
@@ -211,7 +211,7 @@ end:
  * @card_id: The numeridcal ID of sound card.
  * @device_id: The numerical ID of rawmidi device for the sound card.
  * @sysname: (out): The string for sysname of rawmidi device.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Allocate sysname for rawmidi device and return it when it exists.
  *
@@ -258,7 +258,7 @@ void alsarawmidi_get_rawmidi_sysname(guint card_id, guint device_id,
  * @card_id: The numeridcal ID of sound card.
  * @device_id: The numerical ID of rawmidi device for the sound card.
  * @devnode: (out): The string for devnode of rawmidi device.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Allocate devnode string for rawmidi device and return it when exists.
  *
@@ -370,7 +370,7 @@ err_sysname:
  *             ALSARawmidiStreamDirection.
  * @entries: (array length=entry_count)(out): The list of card.
  * @entry_count: The number of entries.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Get the list of numerical IDs for subdevices belongs to the numerical ID of
  * card, device, and the direction.
@@ -413,7 +413,7 @@ void alsarawmidi_get_subdevice_id_list(guint card, guint device,
  * @direction: The direction of stream, one of ALSARawmidiStreamDirection.
  * @subdevice_id: The numerical value of subdevice in rawmidi device.
  * @substream_info: (out): The information of substream for the subdevice.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Get the information of substream pointed by the numerical ID of card, device,
  * subdevice, and the direction.

--- a/src/rawmidi/stream-pair.c
+++ b/src/rawmidi/stream-pair.c
@@ -193,7 +193,8 @@ ALSARawmidiStreamPair *alsarawmidi_stream_pair_new()
  * @access_modes: Access flags for stream direction.
  * @open_flag: The flag of open(2) system call. O_RDWR, O_WRONLY and O_RDONLY
  *             are forced to fulfil internally according to the access_modes.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with two domains; #g_file_error_quark()
+ *         and #alsarawmidi_stream_pair_error_quark().
  *
  * Open file descriptor for a pair of streams to attach input/output substreams
  * corresponding to the given subdevice.
@@ -278,6 +279,7 @@ void alsarawmidi_stream_pair_open(ALSARawmidiStreamPair *self, guint card_id,
  * @self: A #ALSARawmidiStreamPair.
  * @proto_ver_triplet: (array fixed-size=3)(out)(transfer none): The version of
  *                     protocol currently used.
+ * @error: A #GError.
  *
  * Get the version of rawmidi protocol currently used. The version is
  * represented as the array with three elements; major, minor, and micro version
@@ -305,7 +307,7 @@ void alsarawmidi_stream_pair_get_protocol_version(ALSARawmidiStreamPair *self,
  * @self: A #ALSARawmidiStreamPair.
  * @direction: The direction of substream attached to the stream pair.
  * @substream_info: (out): The information for requested substream.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsarawmidi_stream_pair_error_quark.
  *
  * Get information of substream attached to the stream pair.
  *
@@ -345,7 +347,7 @@ void alsarawmidi_stream_pair_get_substream_info(ALSARawmidiStreamPair *self,
  * @self: A #ALSARawmidiStreamPair.
  * @direction: The direction of substream attached to the stream pair.
  * @substream_params: The parameters of substream.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsarawmidi_stream_pair_error_quark.
  *
  * Set parameters of substream for given direction, which is attached to the
  * pair of streams.
@@ -383,7 +385,7 @@ void alsarawmidi_stream_pair_set_substream_params(ALSARawmidiStreamPair *self,
  * @self: A #ALSARawmidiStreamPair.
  * @direction: The direction of substream attached to the stream pair.
  * @substream_status: (inout): The status of substream.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsarawmidi_stream_pair_error_quark.
  *
  * Retrieve status of substream for given direction, which is attached to the
  * pair of streams.
@@ -421,7 +423,8 @@ void alsarawmidi_stream_pair_get_substream_status(ALSARawmidiStreamPair *self,
  * @self: A #ALSARawmidiStreamPair.
  * @buf: (array length=buf_size)(inout): The buffer to copy data.
  * @buf_size: The size of buffer.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with two domains; #g_file_error_quark() and
+ *         #alsarawmidi_stream_pair_error_quark().
  *
  * Copy data from intermediate buffer to given buffer for substream attached to
  * the pair of streams. In a case that the instance is opened without
@@ -469,7 +472,8 @@ void alsarawmidi_stream_pair_read_from_substream(ALSARawmidiStreamPair *self,
  * @self: A #ALSARawmidiStreamPair.
  * @buf: (array length=buf_size): The buffer to copy data.
  * @buf_size: The size of buffer.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with two domains; #g_file_error_quark() and
+ *         #alsarawmidi_stream_pair_error_quark().
  *
  * Copy data from given buffer to intermediate buffer for substream attached to
  * the pair of streams. In a case that the instance is opened without
@@ -513,7 +517,7 @@ void alsarawmidi_stream_pair_write_to_substream(ALSARawmidiStreamPair *self,
  * alsarawmidi_stream_pair_drain:
  * @self: A #ALSARawmidiStreamPair.
  * @direction: The direction of substream attached to the stream pair.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsarawmidi_stream_pair_error_quark.
  *
  * Drain queued data in intermediate buffer for substream attached to the pair
  * of streams. In a case that the instance is opened without O_NONBLOCK and the
@@ -546,7 +550,7 @@ void alsarawmidi_stream_pair_drain_substream(ALSARawmidiStreamPair *self,
  * alsarawmidi_stream_pair_drop:
  * @self: A #ALSARawmidiStreamPair.
  * @direction: The direction of substream attached to the stream pair.
- * @err: A #GError.
+ * @error: A #GError. Error is generated with domain of #alsarawmidi_stream_pair_error_quark.
  *
  * Drop queued data in intermediate buffer immediately for substream attached
  * to the pair of streams. In implementation of ALSA rawmidi core, the
@@ -626,7 +630,8 @@ static void rawmidi_stream_pair_finalize_src(GSource *gsrc)
  * alsarawmidi_stream_pair_create_source:
  * @self: A #ALSARawmidiStreamPair.
  * @gsrc: (out): A #GSource to handle events from ALSA rawmidi character device.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with two domains; #g_file_error_quark() and
+ *         #alsarawmidi_stream_pair_error_quark().
  *
  * Allocate GSource structure to handle events from ALSA rawmidi character
  * device for input substream. In each iteration of GManContext, the read(2)

--- a/src/seq/query.c
+++ b/src/seq/query.c
@@ -30,7 +30,7 @@
 /**
  * alsaseq_get_seq_sysname:
  * @sysname: (out): The sysname of ALSA Sequencer.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Allocate sysname string for ALSA sequencer and return it when exists.
  *
@@ -75,7 +75,7 @@ void alsaseq_get_seq_sysname(gchar **sysname, GError **error)
 /**
  * alsaseq_get_seq_devnode:
  * @devnode: (out): The devnode of ALSA Sequencer.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Allocate devnode string for ALSA Sequencer and return it when exists.
  *
@@ -140,7 +140,7 @@ static int open_fd(GError **error)
 /**
  * alsaseq_get_system_info:
  * @system_info: (out): The information of ALSA Sequencer.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Get information of ALSA Sequencer.
  *
@@ -181,7 +181,7 @@ end:
  *           numerical ID of client. One of ALSASeqSpecificClientId can be
  *           included in result as well as any numerical value.
  * @entry_count: The number of entries.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Get the list of clients as the numerical ID.
  *
@@ -263,7 +263,7 @@ end:
  *             ALSASeqSpecificClientId is available as well as any numerical
  *             value.
  * @client_info: (out): A #ALSASeqClientInfo for the client.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Get the information of client according to the numerical ID.
  *
@@ -306,7 +306,7 @@ void alsaseq_get_client_info(guint8 client_id, ALSASeqClientInfo **client_info,
  *           numerical ID of port. One of ALSASeqSpecificPortId is available as
  *           well as any numerical value.
  * @entry_count: The number of entries in the array.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Get the list of numerical IDs for port added by the client.
  *
@@ -378,7 +378,7 @@ end:
  * @port_id: The numerical ID of port in the client. One of
  *           ALSASeqSpecificPortId is available as well as any numerical value.
  * @port_info: (out): A #ALSASeqPortInfo for the port.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Get the information of port in client.
  *
@@ -419,7 +419,7 @@ void alsaseq_get_port_info(guint8 client_id, guint8 port_id,
  *             ALSASeqSpecificClientId is available as well as any numerical
  *             value.
  * @client_pool: (out): The information of memory pool for the client.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Get statistical information of memory pool for the given client.
  *
@@ -472,7 +472,7 @@ static void fill_data_with_result(struct snd_seq_port_subscribe *data,
  * @query_type: The type of query, one of #ALSASeqQuerySubscribeType.
  * @entries: (element-type ALSASeq.SubscribeData)(out): The array with element
  *           for subscription data.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Get the list of subscription for given address and query type.
  *
@@ -540,7 +540,7 @@ end:
  * @entries: (array length=entry_count)(out): The array of elements for
  *           numerical ID of queue.
  * @entry_count: The number of entries.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Get the list of queue in ALSA Sequencer.
  *
@@ -605,7 +605,7 @@ end:
  * @queue_id: The numerical ID of queue, except for one of
  *            ALSASeqSpecificQueueId.
  * @queue_info: (out): The information of queue.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Get the information of queue, according to the numerical ID.
  *
@@ -642,7 +642,7 @@ void alsaseq_get_queue_info_by_id(guint8 queue_id, ALSASeqQueueInfo **queue_info
  * alsaseq_get_queue_info_by_name:
  * @name: The name string of queue to query.
  * @queue_info: (out): The information of queue.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Get the information of queue, according to the name string.
  *
@@ -681,7 +681,7 @@ void alsaseq_get_queue_info_by_name(const gchar *name,
  * @queue_id: The numerical ID of queue, except for entries in
  *            ALSASeqSpecificQueueId.
  * @queue_status: (inout): The current status of queue.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Get current status of queue.
  *

--- a/src/timer/device-id.c
+++ b/src/timer/device-id.c
@@ -23,7 +23,7 @@ G_DEFINE_BOXED_TYPE(ALSATimerDeviceId, alsatimer_device_id, timer_device_id_copy
 
 /**
  * alsatimer_device_id_new:
- * @class: The class of device, one of #ALSATImerClass.
+ * @class: The class of device, one of #ALSATimerClass.
  * @card_id: The numerical ID of relevant sound card.
  * @device_id: The numerical ID of relevant device.
  * @subdevice_id: The numerical ID of relevant subdevice.

--- a/src/timer/query.c
+++ b/src/timer/query.c
@@ -62,7 +62,7 @@ static bool check_existence(char *sysname, GError **error)
 /**
  * alsatimer_get_sysname:
  * @sysname: (out): The string for sysname of ALSA Timer.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Allocate sysname for ALSA Timer and return it when it exists.
  *
@@ -88,7 +88,7 @@ void alsatimer_get_sysname(char **sysname, GError **error)
 /**
  * alsatimer_get_devnode:
  * @devnode: (out): The string for devnode of ALSA Timer.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Allocate string of devnode for ALSA Timer and return it if exists.
  *
@@ -152,7 +152,7 @@ static int open_fd(GError **error)
  * alsatimer_get_device_id_list:
  * @entries: (element-type ALSATimer.DeviceId)(out): The array with
  *           entries of ALSATimerId.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Get the list of existent timer device.
  *
@@ -194,7 +194,7 @@ void alsatimer_get_device_id_list(GList **entries, GError **error)
  * alsatimer_get_device_info:
  * @device_id: A #ALSATimerDeviceId to identify the timer device.
  * @device_info: (out): The information of timer device.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Get the information of timer device.
  *
@@ -232,7 +232,7 @@ void alsatimer_get_device_info(ALSATimerDeviceId *device_id,
  * alsatimer_get_device_status:
  * @device_id: A #ALSATimerDeviceId to identify the timer device.
  * @device_status: (inout): The status of timer device.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Get the status of timer device.
  *
@@ -269,7 +269,7 @@ void alsatimer_get_device_status(ALSATimerDeviceId *device_id,
  * alsatimer_set_device_params:
  * @device_id: A #ALSATimerDeviceId to identify the timer device.
  * @device_params: The parameters of timer device.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Set the given parameters to the timer indicated by the identifier.
  *
@@ -339,7 +339,7 @@ end:
  * alsatimer_get_tstamp_source:
  * @clock_id: (out): The clock source for timestamp. The value of CLOCK_XXX in
  *                   UAPI of Linux kernel.
- * @error: A #GError.
+ * @error: A #GError. Error is generated with domain of #g_file_error_quark().
  *
  * Get the clock source for timestamp when #ALSATimerUserInstance is configured
  * to receive event with timestamp. The source is selected according to

--- a/src/timer/user-instance.c
+++ b/src/timer/user-instance.c
@@ -136,7 +136,7 @@ static void alsatimer_user_instance_init(ALSATimerUserInstance *self)
  * @self: A #ALSATimerUserInstance.
  * @open_flag: The flag of open(2) system call. O_RDONLY is forced to fulfil internally.
  * @error: A #GError. Error is generated with two domains; #g_file_error_quark() and
- *         #alsaseq_user_client_error_quark().
+ *         #alsatimer_user_instance_error_quark().
  *
  * Open ALSA Timer character device to allocate queue.
  *
@@ -224,7 +224,7 @@ void alsatimer_user_instance_get_protocol_version(ALSATimerUserInstance *self,
  * alsatimer_user_instance_choose_event_data_type:
  * @self: A #ALSATimerUserInstance.
  * @event_data_type: The type of event data, one of ALSATimerEventDataType.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark.
+ * @error: A #GError. Error is generated with domain of #alsatimer_user_instance_error_quark().
  *
  * Choose the type of event data to receive.
  *
@@ -262,7 +262,7 @@ void alsatimer_user_instance_choose_event_data_type(ALSATimerUserInstance *self,
  * alsatimer_user_instance_attach:
  * @self: A #ALSATimerUserInstance.
  * @device_id: A #ALSATimerDeviceId to which the instance is attached.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark.
+ * @error: A #GError. Error is generated with domain of #alsatimer_user_instance_error_quark.
  *
  * Attach the instance to the timer device. If the given device_id is for
  * absent timer device, the instance can be detached with error.
@@ -298,7 +298,7 @@ void alsatimer_user_instance_attach(ALSATimerUserInstance *self,
  * @slave_class: The class identifier of master instance, one of
  *               #ALSATimerSlaveClass.
  * @slave_id: The numerical identifier of master instance.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark.
+ * @error: A #GError. Error is generated with domain of #alsatimer_user_instance_error_quark.
  *
  * Attach the instance as an slave to another instance indicated by a pair of
  * slave_class and slave_id. If the slave_class is for application
@@ -334,7 +334,7 @@ void alsatimer_user_instance_attach_as_slave(ALSATimerUserInstance *self,
  * alsatimer_user_instance_get_info:
  * @self: A #ALSATimerUserInstance.
  * @instance_info: (out): A #ALSATimerInstanceInfo.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark.
+ * @error: A #GError. Error is generated with domain of #alsatimer_user_instance_error_quark.
  *
  * Return the information of device if attached to the instance.
  *
@@ -370,7 +370,7 @@ void alsatimer_user_instance_get_info(ALSATimerUserInstance *self,
  * alsatimer_user_instance_set_params:
  * @self: A #ALSATimerUserInstance.
  * @instance_params: (inout): A #ALSATimerInstanceParams.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark.
+ * @error: A #GError. Error is generated with domain of #alsatimer_user_instance_error_quark.
  *
  * Configure the instance with the parameters and return the latest parameters.
  *
@@ -404,7 +404,7 @@ void alsatimer_user_instance_set_params(ALSATimerUserInstance *self,
  * alsatimer_user_instance_get_status:
  * @self: A #ALSATimerUserInstance.
  * @instance_status: (inout): A #ALSATimerInstanceStatus.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark.
+ * @error: A #GError. Error is generated with domain of #alsatimer_user_instance_error_quark.
  *
  * Get the latest status of instance.
  *
@@ -561,7 +561,7 @@ void alsatimer_user_instance_create_source(ALSATimerUserInstance *self,
 /**
  * alsatimer_user_instance_start:
  * @self: A #ALSATimerUserInstance.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark.
+ * @error: A #GError. Error is generated with domain of #alsatimer_user_instance_error_quark.
  *
  * Start timer event emission.
  *
@@ -588,7 +588,7 @@ void alsatimer_user_instance_start(ALSATimerUserInstance *self, GError **error)
 /**
  * alsatimer_user_instance_stop:
  * @self: A #ALSATimerUserInstance.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark.
+ * @error: A #GError. Error is generated with domain of #alsatimer_user_instance_error_quark.
  *
  * Stop timer event emission.
  *
@@ -615,7 +615,7 @@ void alsatimer_user_instance_stop(ALSATimerUserInstance *self, GError **error)
 /**
  * alsatimer_user_instance_pause:
  * @self: A #ALSATimerUserInstance.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark.
+ * @error: A #GError. Error is generated with domain of #alsatimer_user_instance_error_quark.
  *
  * Pause timer event emission.
  *
@@ -642,7 +642,7 @@ void alsatimer_user_instance_pause(ALSATimerUserInstance *self, GError **error)
 /**
  * alsatimer_user_instance_continue:
  * @self: A #ALSATimerUserInstance.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark.
+ * @error: A #GError. Error is generated with domain of #alsatimer_user_instance_error_quark.
  *
  * Continue timer event emission paused by alsatimer_user_instance_pause().
  *


### PR DESCRIPTION
This patchset includes various fixes toward v0.2.0 release.

```
Takashi Sakamoto (10):
  timer: device_id: fix function comment
  timer: user_instance: fix function comment
  rawmidi: stream_pair: update function comment for error reporting
  hwdep: query: fix usage of uninitialized value
  rawmidi: query: fix usage of uninitialized value
  ctl: query: fulfil comment about GError
  timer: query: fulfil comment about GError
  seq: query: fulfil comment about GError
  hwdep: query: fulfil comment about GError
  rawmidi: query: fulfil comment about GError

 src/ctl/query.c           |  8 ++++----
 src/hwdep/query.c         | 10 +++++-----
 src/rawmidi/query.c       | 12 ++++++------
 src/rawmidi/stream-pair.c | 23 ++++++++++++++---------
 src/seq/query.c           | 26 +++++++++++++-------------
 src/timer/device-id.c     |  2 +-
 src/timer/query.c         | 14 +++++++-------
 src/timer/user-instance.c | 22 +++++++++++-----------
 8 files changed, 61 insertions(+), 56 deletions(-)
```