### PR TITLE
[PATCH 0/3] alsa-gobject: buildable in kernel 4.5 or later

### DIFF
--- a/src/hwdep/alsahwdep-enum-types.h
+++ b/src/hwdep/alsahwdep-enum-types.h
@@ -32,8 +32,8 @@
  * @ALSAHWDEP_IFACE_TYPE_FW_DIGI00X:        For Digidesign Digi 002/003 family.
  * @ALSAHWDEP_IFACE_TYPE_FW_TASCAM:         For TASCAM FireWire series.
  * @ALSAHWDEP_IFACE_TYPE_LINE6:             For Line6 USB processors. Available in Linux kernel 4.9.0 or later.
- * @ALSAHWDEP_IFACE_TYPE_FW_MOTU:           For MOTU FireWire series.
- * @ALSAHWDEP_IFACE_TYPE_FW_FIREFACE:       For RME Fireface series.
+ * @ALSAHWDEP_IFACE_TYPE_FW_MOTU:           For MOTU FireWire series. Available in Linux kernel 4.12.0 or later.
+ * @ALSAHWDEP_IFACE_TYPE_FW_FIREFACE:       For RME Fireface series. Available in Linux kernel 4.12.0 or later.
  *
  * A set of enumerators for the interface of hwdep device.
  */
@@ -67,8 +67,13 @@ typedef enum {
 #else
     ALSAHWDEP_IFACE_TYPE_LINE6,
 #endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
     ALSAHWDEP_IFACE_TYPE_FW_MOTU        = SNDRV_HWDEP_IFACE_FW_MOTU,
     ALSAHWDEP_IFACE_TYPE_FW_FIREFACE    = SNDRV_HWDEP_IFACE_FW_FIREFACE,
+#else
+    ALSAHWDEP_IFACE_TYPE_FW_MOTU,
+    ALSAHWDEP_IFACE_TYPE_FW_FIREFACE,
+#endif
 } ALSAHwdepIfaceType;
 
 #endif

--- a/src/hwdep/alsahwdep-enum-types.h
+++ b/src/hwdep/alsahwdep-enum-types.h
@@ -3,6 +3,7 @@
 #define __ALSA_GOBJECT_ALSAHWDEP_ENUM_TYPES__H__
 
 #include <sound/asound.h>
+#include <linux/version.h>
 
 /**
  *ALSAHwdepIfaceType:
@@ -30,7 +31,7 @@
  * @ALSAHWDEP_IFACE_TYPE_FW_OXFW:           For Oxford OXFW970/971 based devices.
  * @ALSAHWDEP_IFACE_TYPE_FW_DIGI00X:        For Digidesign Digi 002/003 family.
  * @ALSAHWDEP_IFACE_TYPE_FW_TASCAM:         For TASCAM FireWire series.
- * @ALSAHWDEP_IFACE_TYPE_LINE6:             For Line6 USB processors.
+ * @ALSAHWDEP_IFACE_TYPE_LINE6:             For Line6 USB processors. Available in Linux kernel 4.9.0 or later.
  * @ALSAHWDEP_IFACE_TYPE_FW_MOTU:           For MOTU FireWire series.
  * @ALSAHWDEP_IFACE_TYPE_FW_FIREFACE:       For RME Fireface series.
  *
@@ -61,7 +62,11 @@ typedef enum {
     ALSAHWDEP_IFACE_TYPE_FW_OXFW        = SNDRV_HWDEP_IFACE_FW_OXFW,
     ALSAHWDEP_IFACE_TYPE_FW_DIGI00X     = SNDRV_HWDEP_IFACE_FW_DIGI00X,
     ALSAHWDEP_IFACE_TYPE_FW_TASCAM      = SNDRV_HWDEP_IFACE_FW_TASCAM,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,9,0)
     ALSAHWDEP_IFACE_TYPE_LINE6          = SNDRV_HWDEP_IFACE_LINE6,
+#else
+    ALSAHWDEP_IFACE_TYPE_LINE6,
+#endif
     ALSAHWDEP_IFACE_TYPE_FW_MOTU        = SNDRV_HWDEP_IFACE_FW_MOTU,
     ALSAHWDEP_IFACE_TYPE_FW_FIREFACE    = SNDRV_HWDEP_IFACE_FW_FIREFACE,
 } ALSAHwdepIfaceType;

--- a/src/seq/client-info.c
+++ b/src/seq/client-info.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "privates.h"
+#include <linux/version.h>
 
 #include <errno.h>
 
@@ -101,12 +102,14 @@ static void seq_client_info_get_property(GObject *obj, guint id, GValue *val,
     case SEQ_CLIENT_INFO_PROP_LOST_COUNT:
         g_value_set_int(val, priv->info.event_lost);
         break;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0)
     case SEQ_CLIENT_INFO_PROP_CARD_ID:
         g_value_set_int(val, priv->info.card);
         break;
     case SEQ_CLIENT_INFO_PROP_PROCESS_ID:
         g_value_set_int64(val, (gint64)priv->info.pid);
         break;
+#endif
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(obj, id, spec);
         break;
@@ -171,14 +174,16 @@ static void alsaseq_client_info_class_init(ALSASeqClientInfoClass *klass)
 
     seq_client_info_props[SEQ_CLIENT_INFO_PROP_CARD_ID] =
         g_param_spec_int("card-id", "card-id",
-                         "The numerical ID of sound card.",
+                         "The numerical ID of sound card. "
+                         "Available in Linux kernel 4.6.0 or later.",
                          G_MININT, G_MAXINT,
                          -1,
                          G_PARAM_READWRITE);
 
     seq_client_info_props[SEQ_CLIENT_INFO_PROP_PROCESS_ID] =
         g_param_spec_int64("process-id", "process-id",
-                           "The process ID for user client, otherwise -1.",
+                           "The process ID for user client, otherwise -1. "
+                           "Available in Linux kernel 4.6.0 or later",
                            G_MININT64, G_MAXINT64,
                            -1,
                            G_PARAM_READABLE);


### PR DESCRIPTION
Some users would like to build alsa-gobject in former versions of Linux kernel.

https://sourceforge.net/p/alsa/mailman/alsa-user/thread/d95fce3f-5244-0e5f-4a5f-fece9b853307%40sakamocchi.jp/#msg35839069

This patchset use some macro from Linux kernel for conditional build

```
Takashi Sakamoto (3):
  seq: client_info: conditional build for Linux kernel v4.6 or later
  hwdep: conditional build for Linux kernel v4.9 or later
  hwdep: conditional build for Linux kernel 4.12 or later

 src/hwdep/alsahwdep-enum-types.h | 16 +++++++++++++---
 src/seq/client-info.c            |  9 +++++++--
 2 files changed, 20 insertions(+), 5 deletions(-)
```