### PR TITLE
[PATCH 0/3] alsa-gobject: misc fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
   build_in_fedora_for_amd64_on_docker:
     runs-on: ubuntu-latest
     container:
-      image: fedora:33
+      image: fedora:34
     steps:
     - name: Checkout repository.
       uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,46 +36,47 @@ jobs:
         cd build
         meson install
 
-  build_in_ubuntu_for_i386_on_lxd:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Install and initialize LXD
-      run: |
-        sudo snap install lxd
-        sudo lxd init --auto
-    - name: Launch container
-      run: |
-        sudo lxc launch ubuntu:19.10/i386 builder
-        sudo lxc exec builder -- bash -c 'while [ "$(systemctl is-system-running 2>/dev/null)" != "running" ] && [ "$(systemctl is-system-running 2>/dev/null)" != "degraded" ]; do :; done'
-    - name: Prepare build environment.
-      run: |
-        sudo lxc exec builder -- su ubuntu -c 'sudo apt-get update'
-        sudo lxc exec builder -- su ubuntu -c 'sudo apt-get -y full-upgrade'
-        sudo lxc exec builder -- su ubuntu -c 'sudo apt-get install -y git build-essential'
-        sudo lxc exec builder -- su ubuntu -c 'sudo apt-get install -y meson ninja-build libglib2.0-dev libudev-dev gobject-introspection libgirepository1.0-dev'
-        sudo lxc exec builder -- su ubuntu -c 'sudo apt-get install -y gtk-doc-tools python3-gi'
-    - name: Checkout repository.
-      uses: actions/checkout@v2
-    - name: Generate archive and expand it inner the container.
-      run: |
-        git archive --format=tar --prefix=dist/ HEAD | xz > archive.tar.xz
-        sudo lxc file push archive.tar.xz builder/home/ubuntu/
-        sudo lxc exec builder -- su ubuntu -c 'cd; tar xf archive.tar.xz'
-    - name: Initialization for build
-      run: |
-        sudo lxc exec builder -- su ubuntu -c 'cd; cd dist; meson --prefix=/home/ubuntu/install -Dgtk_doc=true -Dwarning_level=3 . build'
-    - name: Display configuration.
-      run: |
-        sudo lxc exec builder -- su ubuntu -c 'cd; cd dist/build; meson configure'
-    - name: Build library.
-      run: |
-        sudo lxc exec builder -- su ubuntu -c 'cd; cd dist/build; ninja'
-    - name: Test interfaces exposed by g-i.
-      run: |
-        sudo lxc exec builder -- su ubuntu -c 'cd; cd dist/build; meson test'
-    - name: Test install.
-      run: |
-        sudo lxc exec builder -- su ubuntu -c 'cd; cd dist/build; meson install'
+# MEMO: my backup.
+#  build_in_ubuntu_for_i386_on_lxd:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - name: Install and initialize LXD
+#      run: |
+#        sudo snap install lxd
+#        sudo lxd init --auto
+#    - name: Launch container
+#      run: |
+#        sudo lxc launch ubuntu:19.10/i386 builder
+#        sudo lxc exec builder -- bash -c 'while [ "$(systemctl is-system-running 2>/dev/null)" != "running" ] && [ "$(systemctl is-system-running 2>/dev/null)" != "degraded" ]; do :; done'
+#    - name: Prepare build environment.
+#      run: |
+#        sudo lxc exec builder -- su ubuntu -c 'sudo apt-get update'
+#        sudo lxc exec builder -- su ubuntu -c 'sudo apt-get -y full-upgrade'
+#        sudo lxc exec builder -- su ubuntu -c 'sudo apt-get install -y git build-essential'
+#        sudo lxc exec builder -- su ubuntu -c 'sudo apt-get install -y meson ninja-build libglib2.0-dev libudev-dev gobject-introspection libgirepository1.0-dev'
+#        sudo lxc exec builder -- su ubuntu -c 'sudo apt-get install -y gtk-doc-tools python3-gi'
+#    - name: Checkout repository.
+#      uses: actions/checkout@v2
+#    - name: Generate archive and expand it inner the container.
+#      run: |
+#        git archive --format=tar --prefix=dist/ HEAD | xz > archive.tar.xz
+#        sudo lxc file push archive.tar.xz builder/home/ubuntu/
+#        sudo lxc exec builder -- su ubuntu -c 'cd; tar xf archive.tar.xz'
+#    - name: Initialization for build
+#      run: |
+#        sudo lxc exec builder -- su ubuntu -c 'cd; cd dist; meson --prefix=/home/ubuntu/install -Dgtk_doc=true -Dwarning_level=3 . build'
+#    - name: Display configuration.
+#      run: |
+#        sudo lxc exec builder -- su ubuntu -c 'cd; cd dist/build; meson configure'
+#    - name: Build library.
+#      run: |
+#        sudo lxc exec builder -- su ubuntu -c 'cd; cd dist/build; ninja'
+#    - name: Test interfaces exposed by g-i.
+#      run: |
+#        sudo lxc exec builder -- su ubuntu -c 'cd; cd dist/build; meson test'
+#    - name: Test install.
+#      run: |
+#        sudo lxc exec builder -- su ubuntu -c 'cd; cd dist/build; meson install'
 
   build_in_ubuntu_for_amd64_on_lxd:
     runs-on: ubuntu-latest

--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ Preparation ::
 
 Build ::
 
-    $ meson build
+    $ ninja
 
 Test ::
 


### PR DESCRIPTION
This patchset fixes some bugs below:

 * Ubuntu 19.10/i386 is EOL and no release is available for i386 architecture in Ubuntu project
 * Update Fedora version for CI environment
 * Wrong command is in install section of README

```
Takashi Sakamoto (3):
  correct install section in README
  fix workflow according to EOF of i386 ubuntu distribution
  update Fedora release for CI environment

 .github/workflows/build.yml | 83 +++++++++++++++++++------------------
 README.rst                  |  2 +-
 2 files changed, 43 insertions(+), 42 deletions(-)
```