### PR TITLE
[PATCH] seq: event_data_ctl: fix getter API for value parameter

### DIFF
--- a/src/seq/event-data-ctl.c
+++ b/src/seq/event-data-ctl.c
@@ -79,7 +79,7 @@ void alsaseq_event_data_ctl_set_param(ALSASeqEventDataCtl *self, guint param)
 void alsaseq_event_data_ctl_get_value(const ALSASeqEventDataCtl *self,
                                       gint *value)
 {
-    *value = self->param;
+    *value = self->value;
 }
 
 /**


### PR DESCRIPTION
ALSASeq.EventDataCtl.get_value() is programmed carelessly to return the value in parameter field instead of value field.

This commit fixes the bug.