### PR TITLE
[PATCH 0/2] ctl/rawmidi/hwdep: fix trivial bugs

### DIFF
--- a/src/ctl/query.c
+++ b/src/ctl/query.c
@@ -118,7 +118,7 @@ static int compare_guint(const void *l, const void *r)
 void alsactl_get_card_id_list(guint **entries, gsize *entry_count,
                               GError **error)
 {
-    struct udev_enumerate *enumerator;
+    struct udev_enumerate *enumerator = NULL;
     struct udev_list_entry *entry, *entry_list;
     unsigned int count;
     unsigned int index;
@@ -128,7 +128,7 @@ void alsactl_get_card_id_list(guint **entries, gsize *entry_count,
     g_return_if_fail(error == NULL || *error == NULL);
 
     prepare_udev_enum(&enumerator, error);
-    if (enumerator == NULL)
+    if (*error == NULL)
         return;
 
     entry_list = udev_enumerate_get_list_entry(enumerator);

--- a/src/hwdep/query.c
+++ b/src/hwdep/query.c
@@ -141,7 +141,7 @@ static unsigned int calculate_digits(unsigned int number)
 void alsahwdep_get_device_id_list(guint card_id, guint **entries,
                                   gsize *entry_count, GError **error)
 {
-    struct udev_enumerate *enumerator;
+    struct udev_enumerate *enumerator = NULL;
     unsigned int length;
     char *prefix;
     struct udev_list_entry *entry, *entry_list;
@@ -154,7 +154,7 @@ void alsahwdep_get_device_id_list(guint card_id, guint **entries,
 
     prepare_udev_enum(&enumerator, error);
     if (*error != NULL)
-        goto end;
+        return;
 
     length = strlen(PREFIX_SYSNAME_TEMPLATE) + calculate_digits(card_id) + 1;
     prefix = g_malloc0(length);

--- a/src/rawmidi/query.c
+++ b/src/rawmidi/query.c
@@ -141,7 +141,7 @@ static unsigned int calculate_digits(unsigned int number)
 void alsarawmidi_get_device_id_list(guint card_id, guint **entries,
                                     gsize *entry_count, GError **error)
 {
-    struct udev_enumerate *enumerator;
+    struct udev_enumerate *enumerator = NULL;
     unsigned int length;
     char *prefix;
     struct udev_list_entry *entry, *entry_list;
@@ -154,7 +154,7 @@ void alsarawmidi_get_device_id_list(guint card_id, guint **entries,
 
     prepare_udev_enum(&enumerator, error);
     if (*error != NULL)
-        goto end;
+        return;
 
     length = strlen(PREFIX_SYSNAME_TEMPLATE) + calculate_digits(card_id) + 1;
     prefix = g_malloc0(length);

--- a/src/seq/client-info.c
+++ b/src/seq/client-info.c
@@ -51,7 +51,7 @@ static void seq_client_info_set_property(GObject *obj, guint id,
         priv->info.type = (snd_seq_client_type_t)g_value_get_enum(val);
         break;
     case SEQ_CLIENT_INFO_PROP_NAME:
-        strncpy(priv->info.name, g_value_get_string(val), sizeof(priv->info.name));
+        g_strlcpy(priv->info.name, g_value_get_string(val), sizeof(priv->info.name));
         break;
     case SEQ_CLIENT_INFO_PROP_FILTER_ATTR_FLAGS:
         priv->info.filter &= SNDRV_SEQ_FILTER_USE_EVENT;

--- a/src/seq/port-info.c
+++ b/src/seq/port-info.c
@@ -50,7 +50,7 @@ static void seq_port_info_set_property(GObject *obj, guint id,
         break;
     }
     case SEQ_PORT_INFO_PROP_NAME:
-        strncpy(priv->info.name, g_value_get_string(val), sizeof(priv->info.name));
+        g_strlcpy(priv->info.name, g_value_get_string(val), sizeof(priv->info.name));
         break;
     case SEQ_PORT_INFO_PROP_CAPS:
         priv->info.capability = (unsigned int)g_value_get_flags(val);

--- a/src/seq/query.c
+++ b/src/seq/query.c
@@ -667,7 +667,7 @@ void alsaseq_get_queue_info_by_name(const gchar *name,
     *queue_info = g_object_new(ALSASEQ_TYPE_QUEUE_INFO, NULL);
     seq_queue_info_refer_private(*queue_info, &info);
 
-    strncpy(info->name, name, sizeof(info->name));
+    g_strlcpy(info->name, name, sizeof(info->name));
     if (ioctl(fd, SNDRV_SEQ_IOCTL_GET_NAMED_QUEUE, info) < 0) {
         generate_file_error(error, errno, "ioctl(GET_NAMED_QUEUE)");
         g_object_unref(*queue_info);

--- a/src/seq/queue-info.c
+++ b/src/seq/queue-info.c
@@ -47,7 +47,7 @@ static void seq_queue_info_set_property(GObject *obj, guint id,
         priv->info.locked = g_value_get_boolean(val);
         break;
     case SEQ_QUEUE_INFO_PROP_NAME:
-        strncpy(priv->info.name, g_value_get_string(val), sizeof(priv->info.name));
+        g_strlcpy(priv->info.name, g_value_get_string(val), sizeof(priv->info.name));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(obj, id, spec);


### PR DESCRIPTION
Current implementation of libalsactl0, libalsarawmidi0, and libalsahwdep0 includes trivial bugs such as usage of uninitialized local variable. This patchset fixes the bugs.

```
Takashi Sakamoto (2):
  ctl/rawmidi/hwdep: fix compiler warning due to uninitialized variables
  seq: use safer way to copy strings

 src/ctl/query.c       | 4 ++--
 src/hwdep/query.c     | 4 ++--
 src/rawmidi/query.c   | 4 ++--
 src/seq/client-info.c | 2 +-
 src/seq/port-info.c   | 2 +-
 src/seq/query.c       | 2 +-
 src/seq/queue-info.c  | 2 +-
 7 files changed, 10 insertions(+), 10 deletions(-)
```