### PR TITLE
[PATCH 0/3] fix v0.2.1

### DIFF
--- a/src/ctl/elem-id.c
+++ b/src/ctl/elem-id.c
@@ -15,7 +15,15 @@
  */
 ALSACtlElemId *ctl_elem_id_copy(const ALSACtlElemId *self)
 {
-    return g_memdup(self, sizeof(*self));
+#ifdef g_memdup2
+    return g_memdup2(self, sizeof(*self));
+#else
+    // GLib v2.68 deprecated g_memdup() with concern about overflow by narrow conversion from size_t to
+    // unsigned int however it's safe in the local case.
+    gpointer ptr = g_malloc(sizeof(*self));
+    memcpy(ptr, self, sizeof(*self));
+    return ptr;
+#endif
 }
 
 G_DEFINE_BOXED_TYPE(ALSACtlElemId, alsactl_elem_id, ctl_elem_id_copy, g_free);

--- a/src/ctl/query.c
+++ b/src/ctl/query.c
@@ -128,7 +128,7 @@ void alsactl_get_card_id_list(guint **entries, gsize *entry_count,
     g_return_if_fail(error == NULL || *error == NULL);
 
     prepare_udev_enum(&enumerator, error);
-    if (*error == NULL)
+    if (*error != NULL)
         return;
 
     entry_list = udev_enumerate_get_list_entry(enumerator);

--- a/src/hwdep/query.c
+++ b/src/hwdep/query.c
@@ -143,7 +143,7 @@ void alsahwdep_get_device_id_list(guint card_id, guint **entries,
 {
     struct udev_enumerate *enumerator = NULL;
     unsigned int length;
-    char *prefix;
+    char *prefix = NULL;
     struct udev_list_entry *entry, *entry_list;
     unsigned int count;
     unsigned int index;

--- a/src/rawmidi/query.c
+++ b/src/rawmidi/query.c
@@ -143,7 +143,7 @@ void alsarawmidi_get_device_id_list(guint card_id, guint **entries,
 {
     struct udev_enumerate *enumerator = NULL;
     unsigned int length;
-    char *prefix;
+    char *prefix = NULL;
     struct udev_list_entry *entry, *entry_list;
     unsigned int count;
     unsigned int index;

--- a/src/seq/addr.c
+++ b/src/seq/addr.c
@@ -13,7 +13,15 @@
  */
 ALSASeqAddr *seq_addr_copy(const ALSASeqAddr *self)
 {
-    return g_memdup(self, sizeof(*self));
+#ifdef g_memdup2
+    return g_memdup2(self, sizeof(*self));
+#else
+    // GLib v2.68 deprecated g_memdup() with concern about overflow by narrow conversion from size_t to
+    // unsigned int however it's safe in the local case.
+    gpointer ptr = g_malloc(sizeof(*self));
+    memcpy(ptr, self, sizeof(*self));
+    return ptr;
+#endif
 }
 
 G_DEFINE_BOXED_TYPE(ALSASeqAddr, alsaseq_addr, seq_addr_copy, g_free)

--- a/src/seq/event-data-connect.c
+++ b/src/seq/event-data-connect.c
@@ -13,7 +13,15 @@
  */
 ALSASeqEventDataConnect *seq_event_data_connect_copy(const ALSASeqEventDataConnect *self)
 {
-    return g_memdup(self, sizeof(*self));
+#ifdef g_memdup2
+    return g_memdup2(self, sizeof(*self));
+#else
+    // GLib v2.68 deprecated g_memdup() with concern about overflow by narrow conversion from size_t to
+    // unsigned int however it's safe in the local case.
+    gpointer ptr = g_malloc(sizeof(*self));
+    memcpy(ptr, self, sizeof(*self));
+    return ptr;
+#endif
 }
 
 G_DEFINE_BOXED_TYPE(ALSASeqEventDataConnect, alsaseq_event_data_connect, seq_event_data_connect_copy, g_free)

--- a/src/seq/event-data-ctl.c
+++ b/src/seq/event-data-ctl.c
@@ -13,7 +13,15 @@
  */
 ALSASeqEventDataCtl *seq_event_data_ctl_copy(const ALSASeqEventDataCtl *self)
 {
-    return g_memdup(self, sizeof(*self));
+#ifdef g_memdup2
+    return g_memdup2(self, sizeof(*self));
+#else
+    // GLib v2.68 deprecated g_memdup() with concern about overflow by narrow conversion from size_t to
+    // unsigned int however it's safe in the local case.
+    gpointer ptr = g_malloc(sizeof(*self));
+    memcpy(ptr, self, sizeof(*self));
+    return ptr;
+#endif
 }
 
 G_DEFINE_BOXED_TYPE(ALSASeqEventDataCtl, alsaseq_event_data_ctl, seq_event_data_ctl_copy, g_free)

--- a/src/seq/event-data-note.c
+++ b/src/seq/event-data-note.c
@@ -13,7 +13,15 @@
  */
 ALSASeqEventDataNote *seq_event_data_note_copy(const ALSASeqEventDataNote *self)
 {
-    return g_memdup(self, sizeof(*self));
+#ifdef g_memdup2
+    return g_memdup2(self, sizeof(*self));
+#else
+    // GLib v2.68 deprecated g_memdup() with concern about overflow by narrow conversion from size_t to
+    // unsigned int however it's safe in the local case.
+    gpointer ptr = g_malloc(sizeof(*self));
+    memcpy(ptr, self, sizeof(*self));
+    return ptr;
+#endif
 }
 
 G_DEFINE_BOXED_TYPE(ALSASeqEventDataNote, alsaseq_event_data_note, seq_event_data_note_copy, g_free)

--- a/src/seq/event-data-queue.c
+++ b/src/seq/event-data-queue.c
@@ -14,7 +14,15 @@
  */
 ALSASeqEventDataQueue *seq_event_data_queue_copy(const ALSASeqEventDataQueue *self)
 {
-    return g_memdup(self, sizeof(*self));
+#ifdef g_memdup2
+    return g_memdup2(self, sizeof(*self));
+#else
+    // GLib v2.68 deprecated g_memdup() with concern about overflow by narrow conversion from size_t to
+    // unsigned int however it's safe in the local case.
+    gpointer ptr = g_malloc(sizeof(*self));
+    memcpy(ptr, self, sizeof(*self));
+    return ptr;
+#endif
 }
 
 G_DEFINE_BOXED_TYPE(ALSASeqEventDataQueue, alsaseq_event_data_queue, seq_event_data_queue_copy, g_free)

--- a/src/seq/event-data-result.c
+++ b/src/seq/event-data-result.c
@@ -13,7 +13,15 @@
  */
 ALSASeqEventDataResult *seq_event_data_result_copy(const ALSASeqEventDataResult *self)
 {
-    return g_memdup(self, sizeof(*self));
+#ifdef g_memdup2
+    return g_memdup2(self, sizeof(*self));
+#else
+    // GLib v2.68 deprecated g_memdup() with concern about overflow by narrow conversion from size_t to
+    // unsigned int however it's safe in the local case.
+    gpointer ptr = g_malloc(sizeof(*self));
+    memcpy(ptr, self, sizeof(*self));
+    return ptr;
+#endif
 }
 
 G_DEFINE_BOXED_TYPE(ALSASeqEventDataResult, alsaseq_event_data_result, seq_event_data_result_copy, g_free)

--- a/src/seq/queue-timer-data-alsa.c
+++ b/src/seq/queue-timer-data-alsa.c
@@ -13,7 +13,15 @@
  */
 ALSASeqQueueTimerDataAlsa *seq_queue_timer_data_alsa_copy(const ALSASeqQueueTimerDataAlsa *self)
 {
-    return g_memdup(self, sizeof(*self));
+#ifdef g_memdup2
+    return g_memdup2(self, sizeof(*self));
+#else
+    // GLib v2.68 deprecated g_memdup() with concern about overflow by narrow conversion from size_t to
+    // unsigned int however it's safe in the local case.
+    gpointer ptr = g_malloc(sizeof(*self));
+    memcpy(ptr, self, sizeof(*self));
+    return ptr;
+#endif
 }
 
 G_DEFINE_BOXED_TYPE(ALSASeqQueueTimerDataAlsa, alsaseq_queue_timer_data_alsa, seq_queue_timer_data_alsa_copy, g_free)

--- a/src/seq/remove-filter.c
+++ b/src/seq/remove-filter.c
@@ -20,7 +20,15 @@
  */
 ALSASeqRemoveFilter *seq_remove_filter_copy(const ALSASeqRemoveFilter *self)
 {
-    return g_memdup(self, sizeof(*self));
+#ifdef g_memdup2
+    return g_memdup2(self, sizeof(*self));
+#else
+    // GLib v2.68 deprecated g_memdup() with concern about overflow by narrow conversion from size_t to
+    // unsigned int however it's safe in the local case.
+    gpointer ptr = g_malloc(sizeof(*self));
+    memcpy(ptr, self, sizeof(*self));
+    return ptr;
+#endif
 }
 
 G_DEFINE_BOXED_TYPE(ALSASeqRemoveFilter, alsaseq_remove_filter, seq_remove_filter_copy, g_free)

--- a/src/seq/tstamp.c
+++ b/src/seq/tstamp.c
@@ -13,7 +13,15 @@
  */
 ALSASeqTstamp *seq_tstamp_copy(const ALSASeqTstamp *self)
 {
-    return g_memdup(self, sizeof(*self));
+#ifdef g_memdup2
+    return g_memdup2(self, sizeof(*self));
+#else
+    // GLib v2.68 deprecated g_memdup() with concern about overflow by narrow conversion from size_t to
+    // unsigned int however it's safe in the local case.
+    gpointer ptr = g_malloc(sizeof(*self));
+    memcpy(ptr, self, sizeof(*self));
+    return ptr;
+#endif
 }
 
 G_DEFINE_BOXED_TYPE(ALSASeqTstamp, alsaseq_tstamp, seq_tstamp_copy, g_free)

--- a/src/timer/device-id.c
+++ b/src/timer/device-id.c
@@ -16,7 +16,15 @@
  */
 ALSATimerDeviceId *timer_device_id_copy(const ALSATimerDeviceId *self)
 {
-    return g_memdup(self, sizeof(*self));
+#ifdef g_memdup2
+    return g_memdup2(self, sizeof(*self));
+#else
+    // GLib v2.68 deprecated g_memdup() with concern about overflow by narrow conversion from size_t to
+    // unsigned int however it's safe in the local case.
+    gpointer ptr = g_malloc(sizeof(*self));
+    memcpy(ptr, self, sizeof(*self));
+    return ptr;
+#endif
 }
 
 G_DEFINE_BOXED_TYPE(ALSATimerDeviceId, alsatimer_device_id, timer_device_id_copy, g_free)

--- a/src/timer/event-data-tick.c
+++ b/src/timer/event-data-tick.c
@@ -15,7 +15,15 @@
  */
 ALSATimerEventDataTick *timer_event_data_tick_copy(const ALSATimerEventDataTick *self)
 {
-    return g_memdup(self, sizeof(*self));
+#ifdef g_memdup2
+    return g_memdup2(self, sizeof(*self));
+#else
+    // GLib v2.68 deprecated g_memdup() with concern about overflow by narrow conversion from size_t to
+    // unsigned int however it's safe in the local case.
+    gpointer ptr = g_malloc(sizeof(*self));
+    memcpy(ptr, self, sizeof(*self));
+    return ptr;
+#endif
 }
 
 G_DEFINE_BOXED_TYPE(ALSATimerEventDataTick, alsatimer_event_data_tick, timer_event_data_tick_copy, g_free)

--- a/src/timer/event-data-tstamp.c
+++ b/src/timer/event-data-tstamp.c
@@ -15,7 +15,15 @@
  */
 ALSATimerEventDataTstamp *timer_event_data_tstamp_copy(const ALSATimerEventDataTstamp *self)
 {
-    return g_memdup(self, sizeof(*self));
+#ifdef g_memdup2
+    return g_memdup2(self, sizeof(*self));
+#else
+    // GLib v2.68 deprecated g_memdup() with concern about overflow by narrow conversion from size_t to
+    // unsigned int however it's safe in the local case.
+    gpointer ptr = g_malloc(sizeof(*self));
+    memcpy(ptr, self, sizeof(*self));
+    return ptr;
+#endif
 }
 
 G_DEFINE_BOXED_TYPE(ALSATimerEventDataTstamp, alsatimer_event_data_tstamp, timer_event_data_tstamp_copy, g_free)

--- a/src/timer/event.c
+++ b/src/timer/event.c
@@ -14,7 +14,15 @@
  */
 ALSATimerEvent *timer_event_copy(const ALSATimerEvent *self)
 {
-    return g_memdup(self, sizeof(*self));
+#ifdef g_memdup2
+    return g_memdup2(self, sizeof(*self));
+#else
+    // GLib v2.68 deprecated g_memdup() with concern about overflow by narrow conversion from size_t to
+    // unsigned int however it's safe in the local case.
+    gpointer ptr = g_malloc(sizeof(*self));
+    memcpy(ptr, self, sizeof(*self));
+    return ptr;
+#endif
 }
 
 G_DEFINE_BOXED_TYPE(ALSATimerEvent, alsatimer_event, timer_event_copy, g_free)


### PR DESCRIPTION
The v0.2.1 release includes misfunction of ALSACtl.Card.get_elem_id_list(). This patchset includes fix for it as well as arrangement for GLib 2.0 v2.68.

```
Takashi Sakamoto (3):
  ctl/hwdep/rawmidi: fix uninitialized warning
  ctl/timer/seq: optimization for GLib v2.68
  ctl: fix misfunction of alsactl_get_card_id_list()

 src/ctl/elem-id.c               | 10 +++++++++-
 src/ctl/query.c                 |  2 +-
 src/hwdep/query.c               |  2 +-
 src/rawmidi/query.c             |  2 +-
 src/seq/addr.c                  | 10 +++++++++-
 src/seq/event-data-connect.c    | 10 +++++++++-
 src/seq/event-data-ctl.c        | 10 +++++++++-
 src/seq/event-data-note.c       | 10 +++++++++-
 src/seq/event-data-queue.c      | 10 +++++++++-
 src/seq/event-data-result.c     | 10 +++++++++-
 src/seq/queue-timer-data-alsa.c | 10 +++++++++-
 src/seq/remove-filter.c         | 10 +++++++++-
 src/seq/tstamp.c                | 10 +++++++++-
 src/timer/device-id.c           | 10 +++++++++-
 src/timer/event-data-tick.c     | 10 +++++++++-
 src/timer/event-data-tstamp.c   | 10 +++++++++-
 src/timer/event.c               | 10 +++++++++-
 17 files changed, 129 insertions(+), 17 deletions(-)
```