### PR TITLE
[PATCH 0/2] rawmidi/meson: fix miscellaneous bugs

### DIFF
--- a/src/rawmidi/query.c
+++ b/src/rawmidi/query.c
@@ -363,8 +363,8 @@ err_sysname:
 
 /**
  * alsarawmidi_get_subdevice_id_list:
- * @card: The numberical value for sound card to query.
- * @device: The numerical value of rawmidi device to query.
+ * @card_id: The numberical value for sound card to query.
+ * @device_id: The numerical value of rawmidi device to query.
  * @direction: The direction of stream to query, one of
  *             ALSARawmidiStreamDirection.
  * @entries: (array length=entry_count)(out): The list of card.
@@ -377,14 +377,14 @@ err_sysname:
  * The call of function executes open(2), close(2), and ioctl(2) system call
  * with SNDRV_CTL_IOCTL_RAWMIDI_INFO command for ALSA control character device.
  */
-void alsarawmidi_get_subdevice_id_list(guint card, guint device,
+void alsarawmidi_get_subdevice_id_list(guint card_id, guint device_id,
                                        ALSARawmidiStreamDirection direction,
                                        guint **entries, gsize *entry_count,
                                        GError **error)
 {
     struct snd_rawmidi_info info = {
-        .card = card,
-        .device = device,
+        .card = card_id,
+        .device = device_id,
         .stream = direction,
         .subdevice = 0,
     };
@@ -394,7 +394,7 @@ void alsarawmidi_get_subdevice_id_list(guint card, guint device,
     g_return_if_fail(entry_count != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
-    rawmidi_perform_ctl_ioctl(card, SNDRV_CTL_IOCTL_RAWMIDI_INFO, &info, "RAWMIDI_INFO", NULL, error);
+    rawmidi_perform_ctl_ioctl(card_id, SNDRV_CTL_IOCTL_RAWMIDI_INFO, &info, "RAWMIDI_INFO", NULL, error);
     if (*error != NULL)
         return;
 

--- a/src/rawmidi/query.h
+++ b/src/rawmidi/query.h
@@ -16,7 +16,7 @@ void alsarawmidi_get_rawmidi_sysname(guint card_id, guint device_id,
 void alsarawmidi_get_rawmidi_devnode(guint card_id, guint device_id,
                                      char **devnode, GError **error);
 
-void alsarawmidi_get_subdevice_id_list(guint card, guint device,
+void alsarawmidi_get_subdevice_id_list(guint card_id, guint device_id,
                                        ALSARawmidiStreamDirection direction,
                                        guint **entries, gsize *entry_count,
                                        GError **error);

--- a/src/seq/meson.build
+++ b/src/seq/meson.build
@@ -96,8 +96,7 @@ if has_enumerations
     header_prefix: '#include <alsaseq.h>',
   )
 else
-  enum
-  s = []
+  enums = []
 endif
 
 # Generate marshallers for GObject signals.


### PR DESCRIPTION
This patchset fixes unintended two items below.

 * argument name against convention in this project
 * line break inner identifier in meson.build

```
Takashi Sakamoto (2):
  rawmidi: fix argument names with suffix '_id'
  meson: fix unintended line break for identifier

 src/rawmidi/query.c | 12 ++++++------
 src/rawmidi/query.h |  2 +-
 src/seq/meson.build |  3 +--
 3 files changed, 8 insertions(+), 9 deletions(-)
```