### PR TITLE
[PATCH 0/7] meson: refactor common part of configuration 

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,8 +4,6 @@ project('alsa-gobject', 'c',
   meson_version: '>= 0.48.0',
 )
 
-gnome = import('gnome')
-
 subdir('src')
 subdir('tests')
 

--- a/src/ctl/meson.build
+++ b/src/ctl/meson.build
@@ -36,6 +36,8 @@ dependencies = [
   libudev_dependency,
 ]
 
+pc_desc = 'GObject instrospection library for control interface in asound.h'
+
 # For test.
 build_dirs += {'alsactl': meson.current_build_dir()}
 
@@ -96,7 +98,7 @@ install_headers(headers,
 
 # Generate pkg-config file for development.
 pkg.generate(library,
-  description: 'GObject instrospection library for control interface in asound.h',
+  description: pc_desc,
   subdirs: inc_dir,
 )
 

--- a/src/ctl/meson.build
+++ b/src/ctl/meson.build
@@ -38,6 +38,8 @@ dependencies = [
 
 pc_desc = 'GObject instrospection library for control interface in asound.h'
 
+gir_includes = common_gir_includes
+
 # For test.
 build_dirs += {'alsactl': meson.current_build_dir()}
 
@@ -111,10 +113,7 @@ alsactl_gir = gnome.generate_gir(library,
   identifier_prefix: namespace,
   export_packages: name,
   dependencies: dependencies,
-  includes: [
-    'GLib-2.0',
-    'GObject-2.0',
-  ],
+  includes: gir_includes,
   header: 'alsactl.h',
   install: true,
 )

--- a/src/ctl/meson.build
+++ b/src/ctl/meson.build
@@ -95,7 +95,6 @@ install_headers(headers,
 )
 
 # Generate pkg-config file for development.
-pkg = import('pkgconfig')
 pkg.generate(library,
   description: 'GObject instrospection library for control interface in asound.h',
   subdirs: inc_dir,

--- a/src/ctl/meson.build
+++ b/src/ctl/meson.build
@@ -18,7 +18,6 @@ sources = files(
 )
 
 headers = files(
-  'alsactl.h',
   'query.h',
   'card.h',
   'card-info.h',
@@ -49,6 +48,9 @@ build_dirs += {'alsactl': meson.current_build_dir()}
 
 inc_dir = join_paths(meson.project_name(), path)
 
+top_header = '@0@.h'.format(name)
+headers += top_header
+
 # Generate enumerations for GObject fashion.
 if has_enumerations
   enum_header = '@0@-enum-types.h'.format(name)
@@ -59,7 +61,7 @@ if has_enumerations
     identifier_prefix: namespace,
     install_header: true,
     install_dir: join_paths(get_option('includedir'), inc_dir),
-    header_prefix: '#include <alsactl.h>',
+    header_prefix: '#include <@0@>'.format(top_header),
   )
 else
   enums = []
@@ -114,6 +116,6 @@ alsactl_gir = gnome.generate_gir(library,
   export_packages: name,
   dependencies: dependencies,
   includes: gir_includes,
-  header: 'alsactl.h',
+  header: top_header,
   install: true,
 )

--- a/src/ctl/meson.build
+++ b/src/ctl/meson.build
@@ -31,24 +31,17 @@ privates = files(
   'privates.h',
 )
 
+dependencies = [
+  gobject_dependency,
+  libudev_dependency,
+]
+
 # For test.
 build_dirs += {'alsactl': meson.current_build_dir()}
 
 #
 # Common part except for identifier of dependency.
 #
-
-# Depends on glib-2.0 and gobject-2.0
-gobject = dependency('gobject-2.0',
-  version: '>=2.34.0'
-)
-
-libudev = dependency('libudev')
-
-dependencies = [
-  gobject,
-  libudev,
-]
 
 inc_dir = join_paths(meson.project_name(), path)
 

--- a/src/hwdep/meson.build
+++ b/src/hwdep/meson.build
@@ -94,7 +94,7 @@ pkg.generate(library,
 
 # Generate metadata for gobject introspection.
 alsahwdep_gir = gnome.generate_gir(library,
-  sources: enums + headers + sources,
+  sources: enums + marshallers + headers + sources,
   nsversion: '0.0',
   namespace: namespace,
   symbol_prefix: '@0@_'.format(name),

--- a/src/hwdep/meson.build
+++ b/src/hwdep/meson.build
@@ -23,24 +23,17 @@ privates = files(
   'privates.h',
 )
 
+dependencies = [
+  gobject_dependency,
+  libudev_dependency,
+]
+
 # For test.
 build_dirs += {'alsahwdep': meson.current_build_dir()}
 
 #
 # Common part except for identifier of dependency.
 #
-
-# Depends on glib-2.0 and gobject-2.0
-gobject = dependency('gobject-2.0',
-  version: '>=2.34.0'
-)
-
-libudev = dependency('libudev')
-
-dependencies = [
-  gobject,
-  libudev,
-]
 
 inc_dir = join_paths(meson.project_name(), path)
 

--- a/src/hwdep/meson.build
+++ b/src/hwdep/meson.build
@@ -14,7 +14,6 @@ sources = files(
 )
 
 headers = files(
-  'alsahwdep.h',
   'query.h',
   'device-info.h',
 )
@@ -41,6 +40,9 @@ build_dirs += {'alsahwdep': meson.current_build_dir()}
 
 inc_dir = join_paths(meson.project_name(), path)
 
+top_header = '@0@.h'.format(name)
+headers += top_header
+
 # Generate enumerations for GObject fashion.
 if has_enumerations
   enum_header = '@0@-enum-types.h'.format(name)
@@ -51,7 +53,7 @@ if has_enumerations
     identifier_prefix: namespace,
     install_header: true,
     install_dir: join_paths(get_option('includedir'), inc_dir),
-    header_prefix: '#include <alsahwdep.h>',
+    header_prefix: '#include <@0@>'.format(top_header),
   )
 else
   enums = []
@@ -106,6 +108,6 @@ alsahwdep_gir = gnome.generate_gir(library,
   export_packages: name,
   dependencies: dependencies,
   includes: gir_includes,
-  header: 'alsahwdep.h',
+  header: top_header,
   install: true,
 )

--- a/src/hwdep/meson.build
+++ b/src/hwdep/meson.build
@@ -87,7 +87,6 @@ install_headers(headers,
 )
 
 # Generate pkg-config file for development.
-pkg = import('pkgconfig')
 pkg.generate(library,
   description: 'GObject instrospection library for HwDep interface in asound.h',
   subdirs: inc_dir,

--- a/src/hwdep/meson.build
+++ b/src/hwdep/meson.build
@@ -28,6 +28,8 @@ dependencies = [
   libudev_dependency,
 ]
 
+pc_desc = 'GObject instrospection library for HwDep interface in asound.h'
+
 # For test.
 build_dirs += {'alsahwdep': meson.current_build_dir()}
 
@@ -88,7 +90,7 @@ install_headers(headers,
 
 # Generate pkg-config file for development.
 pkg.generate(library,
-  description: 'GObject instrospection library for HwDep interface in asound.h',
+  description: pc_desc,
   subdirs: inc_dir,
 )
 

--- a/src/hwdep/meson.build
+++ b/src/hwdep/meson.build
@@ -30,6 +30,8 @@ dependencies = [
 
 pc_desc = 'GObject instrospection library for HwDep interface in asound.h'
 
+gir_includes = common_gir_includes
+
 # For test.
 build_dirs += {'alsahwdep': meson.current_build_dir()}
 
@@ -103,10 +105,7 @@ alsahwdep_gir = gnome.generate_gir(library,
   identifier_prefix: namespace,
   export_packages: name,
   dependencies: dependencies,
-  includes: [
-    'GLib-2.0',
-    'GObject-2.0',
-  ],
+  includes: gir_includes,
   header: 'alsahwdep.h',
   install: true,
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -8,6 +8,11 @@ libudev_dependency = dependency('libudev')
 gnome = import('gnome')
 pkg = import('pkgconfig')
 
+common_gir_includes = [
+    'GLib-2.0',
+    'GObject-2.0',
+]
+
 build_dirs = {}
 
 subdir('ctl')

--- a/src/meson.build
+++ b/src/meson.build
@@ -5,6 +5,9 @@ gobject_dependency = dependency('gobject-2.0',
 
 libudev_dependency = dependency('libudev')
 
+gnome = import('gnome')
+pkg = import('pkgconfig')
+
 build_dirs = {}
 
 subdir('ctl')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,3 +1,10 @@
+# Depends on glib-2.0 and gobject-2.0
+gobject_dependency = dependency('gobject-2.0',
+  version: '>=2.34.0'
+)
+
+libudev_dependency = dependency('libudev')
+
 build_dirs = {}
 
 subdir('ctl')

--- a/src/rawmidi/meson.build
+++ b/src/rawmidi/meson.build
@@ -99,7 +99,7 @@ pkg.generate(library,
 
 # Generate metadata for gobject introspection.
 alsarawmidi_gir = gnome.generate_gir(library,
-  sources: enums + headers + sources,
+  sources: enums + marshallers + headers + sources,
   nsversion: '0.0',
   namespace: namespace,
   symbol_prefix: '@0@_'.format(name),

--- a/src/rawmidi/meson.build
+++ b/src/rawmidi/meson.build
@@ -92,7 +92,6 @@ install_headers(headers,
 )
 
 # Generate pkg-config file for development.
-pkg = import('pkgconfig')
 pkg.generate(library,
   description: 'GObject instrospection library for RawMidi interface in asound.h',
   subdirs: inc_dir,

--- a/src/rawmidi/meson.build
+++ b/src/rawmidi/meson.build
@@ -35,6 +35,8 @@ dependencies = [
 
 pc_desc = 'GObject instrospection library for RawMidi interface in asound.h'
 
+gir_includes = common_gir_includes
+
 # For test.
 build_dirs += {'alsarawmidi': meson.current_build_dir()}
 
@@ -108,10 +110,7 @@ alsarawmidi_gir = gnome.generate_gir(library,
   identifier_prefix: namespace,
   export_packages: name,
   dependencies: dependencies,
-  includes: [
-    'GLib-2.0',
-    'GObject-2.0',
-  ],
+  includes: gir_includes,
   header: 'alsarawmidi.h',
   install: true,
 )

--- a/src/rawmidi/meson.build
+++ b/src/rawmidi/meson.build
@@ -46,6 +46,9 @@ build_dirs += {'alsarawmidi': meson.current_build_dir()}
 
 inc_dir = join_paths(meson.project_name(), path)
 
+top_header = '@0@.h'.format(name)
+headers += top_header
+
 # Generate enumerations for GObject fashion.
 if has_enumerations
   enum_header = '@0@-enum-types.h'.format(name)
@@ -56,7 +59,7 @@ if has_enumerations
     identifier_prefix: namespace,
     install_header: true,
     install_dir: join_paths(get_option('includedir'), inc_dir),
-    header_prefix: '#include <alsarawmidi.h>',
+    header_prefix: '#include <@0@>'.format(top_header),
   )
 else
   enums = []
@@ -111,6 +114,6 @@ alsarawmidi_gir = gnome.generate_gir(library,
   export_packages: name,
   dependencies: dependencies,
   includes: gir_includes,
-  header: 'alsarawmidi.h',
+  header: top_header,
   install: true,
 )

--- a/src/rawmidi/meson.build
+++ b/src/rawmidi/meson.build
@@ -33,6 +33,8 @@ dependencies = [
   libudev_dependency,
 ]
 
+pc_desc = 'GObject instrospection library for RawMidi interface in asound.h'
+
 # For test.
 build_dirs += {'alsarawmidi': meson.current_build_dir()}
 
@@ -93,7 +95,7 @@ install_headers(headers,
 
 # Generate pkg-config file for development.
 pkg.generate(library,
-  description: 'GObject instrospection library for RawMidi interface in asound.h',
+  description: pc_desc,
   subdirs: inc_dir,
 )
 

--- a/src/rawmidi/meson.build
+++ b/src/rawmidi/meson.build
@@ -28,24 +28,17 @@ privates = files(
   'privates.h',
 )
 
+dependencies = [
+  gobject_dependency,
+  libudev_dependency,
+]
+
 # For test.
 build_dirs += {'alsarawmidi': meson.current_build_dir()}
 
 #
 # Common part except for identifier of dependency.
 #
-
-# Depends on glib-2.0 and gobject-2.0
-gobject = dependency('gobject-2.0',
-  version: '>=2.34.0'
-)
-
-libudev = dependency('libudev')
-
-dependencies = [
-  gobject,
-  libudev,
-]
 
 inc_dir = join_paths(meson.project_name(), path)
 

--- a/src/seq/meson.build
+++ b/src/seq/meson.build
@@ -69,6 +69,8 @@ dependencies = [
 
 pc_desc = 'GObject instrospection library for sequencer interface in asequencer.h'
 
+gir_includes = [common_gir_includes, alsatimer_gir[0]]
+
 # For test.
 build_dirs += {'alsaseq': meson.current_build_dir()}
 
@@ -142,11 +144,7 @@ alsaseq_gir = gnome.generate_gir(library,
   identifier_prefix: namespace,
   export_packages: name,
   dependencies: dependencies,
-  includes: [
-    'GLib-2.0',
-    'GObject-2.0',
-    alsatimer_gir[0],
-  ],
+  includes: gir_includes,
   header: 'alsaseq.h',
   install: true,
 )

--- a/src/seq/meson.build
+++ b/src/seq/meson.build
@@ -67,6 +67,8 @@ dependencies = [
   alsatimer_dependency,
 ]
 
+pc_desc = 'GObject instrospection library for sequencer interface in asequencer.h'
+
 # For test.
 build_dirs += {'alsaseq': meson.current_build_dir()}
 
@@ -127,7 +129,7 @@ install_headers(headers,
 
 # Generate pkg-config file for development.
 pkg.generate(library,
-  description: 'GObject instrospection library for sequencer interface in asequencer.h',
+  description: pc_desc,
   subdirs: inc_dir,
 )
 

--- a/src/seq/meson.build
+++ b/src/seq/meson.build
@@ -126,7 +126,6 @@ install_headers(headers,
 )
 
 # Generate pkg-config file for development.
-pkg = import('pkgconfig')
 pkg.generate(library,
   description: 'GObject instrospection library for sequencer interface in asequencer.h',
   subdirs: inc_dir,

--- a/src/seq/meson.build
+++ b/src/seq/meson.build
@@ -33,7 +33,6 @@ sources = files(
 )
 
 headers = files(
-  'alsaseq.h',
   'query.h',
   'system-info.h',
   'client-info.h',
@@ -80,6 +79,9 @@ build_dirs += {'alsaseq': meson.current_build_dir()}
 
 inc_dir = join_paths(meson.project_name(), path)
 
+top_header = '@0@.h'.format(name)
+headers += top_header
+
 # Generate enumerations for GObject fashion.
 if has_enumerations
   enum_header = '@0@-enum-types.h'.format(name)
@@ -90,7 +92,7 @@ if has_enumerations
     identifier_prefix: namespace,
     install_header: true,
     install_dir: join_paths(get_option('includedir'), inc_dir),
-    header_prefix: '#include <alsaseq.h>',
+    header_prefix: '#include <@0@>'.format(top_header),
   )
 else
   enums = []
@@ -145,6 +147,6 @@ alsaseq_gir = gnome.generate_gir(library,
   export_packages: name,
   dependencies: dependencies,
   includes: gir_includes,
-  header: 'alsaseq.h',
+  header: top_header,
   install: true,
 )

--- a/src/seq/meson.build
+++ b/src/seq/meson.build
@@ -133,7 +133,7 @@ pkg.generate(library,
 
 # Generate metadata for gobject introspection.
 alsaseq_gir = gnome.generate_gir(library,
-  sources: enums + headers + sources,
+  sources: enums + marshallers + headers + sources,
   nsversion: '0.0',
   namespace: namespace,
   symbol_prefix: '@0@_'.format(name),

--- a/src/seq/meson.build
+++ b/src/seq/meson.build
@@ -61,25 +61,18 @@ privates = files(
   'privates.h',
 )
 
+dependencies = [
+  gobject_dependency,
+  libudev_dependency,
+  alsatimer_dependency,
+]
+
 # For test.
 build_dirs += {'alsaseq': meson.current_build_dir()}
 
 #
 # Common part except for identifier of dependency.
 #
-
-# Depends on glib-2.0 and gobject-2.0
-gobject = dependency('gobject-2.0',
-  version: '>=2.34.0'
-)
-
-libudev = dependency('libudev')
-
-dependencies = [
-  gobject,
-  libudev,
-  alsatimer_dependency,
-]
 
 inc_dir = join_paths(meson.project_name(), path)
 

--- a/src/seq/meson.build
+++ b/src/seq/meson.build
@@ -125,7 +125,7 @@ library = library(name,
   dependencies: dependencies,
   link_args : linker_flag,
   link_depends : mapfile_name,
-  include_directories: include_directories('.', '../timer'),
+  include_directories: include_directories('.'),
 )
 
 install_headers(headers,

--- a/src/timer/meson.build
+++ b/src/timer/meson.build
@@ -140,4 +140,5 @@ alsatimer_gir = gnome.generate_gir(library,
 alsatimer_dependency = declare_dependency(
   link_with: library,
   dependencies: dependencies,
+  include_directories: include_directories('.'),
 )

--- a/src/timer/meson.build
+++ b/src/timer/meson.build
@@ -43,24 +43,17 @@ privates = files(
   'privates.h',
 )
 
+dependencies = [
+  gobject_dependency,
+  libudev_dependency,
+]
+
 # For test.
 build_dirs += {'alsatimer': meson.current_build_dir()}
 
 #
 # Common part except for identifier of dependency.
 #
-
-# Depends on glib-2.0 and gobject-2.0
-gobject = dependency('gobject-2.0',
-  version: '>=2.34.0'
-)
-
-libudev = dependency('libudev')
-
-dependencies = [
-  gobject,
-  libudev,
-]
 
 inc_dir = join_paths(meson.project_name(), path)
 

--- a/src/timer/meson.build
+++ b/src/timer/meson.build
@@ -50,6 +50,8 @@ dependencies = [
 
 pc_desc = 'GObject instrospection library for timer interface in asound.h'
 
+gir_includes = common_gir_includes
+
 # For test.
 build_dirs += {'alsatimer': meson.current_build_dir()}
 
@@ -123,10 +125,7 @@ alsatimer_gir = gnome.generate_gir(library,
   identifier_prefix: namespace,
   export_packages: name,
   dependencies: dependencies,
-  includes: [
-    'GLib-2.0',
-    'GObject-2.0',
-  ],
+  includes: gir_includes,
   header: 'alsatimer.h',
   install: true,
 )

--- a/src/timer/meson.build
+++ b/src/timer/meson.build
@@ -107,7 +107,6 @@ install_headers(headers,
 )
 
 # Generate pkg-config file for development.
-pkg = import('pkgconfig')
 pkg.generate(library,
   description: 'GObject instrospection library for timer interface in asound.h',
   subdirs: inc_dir,

--- a/src/timer/meson.build
+++ b/src/timer/meson.build
@@ -24,7 +24,6 @@ sources = files(
 )
 
 headers = files(
-  'alsatimer.h',
   'query.h',
   'device-id.h',
   'device-info.h',
@@ -61,6 +60,9 @@ build_dirs += {'alsatimer': meson.current_build_dir()}
 
 inc_dir = join_paths(meson.project_name(), path)
 
+top_header = '@0@.h'.format(name)
+headers += top_header
+
 # Generate enumerations for GObject fashion.
 if has_enumerations
   enum_header = '@0@-enum-types.h'.format(name)
@@ -71,7 +73,7 @@ if has_enumerations
     identifier_prefix: namespace,
     install_header: true,
     install_dir: join_paths(get_option('includedir'), inc_dir),
-    header_prefix: '#include <alsatimer.h>',
+    header_prefix: '#include <@0@>'.format(top_header),
   )
 else
   enums = []
@@ -126,7 +128,7 @@ alsatimer_gir = gnome.generate_gir(library,
   export_packages: name,
   dependencies: dependencies,
   includes: gir_includes,
-  header: 'alsatimer.h',
+  header: top_header,
   install: true,
 )
 

--- a/src/timer/meson.build
+++ b/src/timer/meson.build
@@ -114,7 +114,7 @@ pkg.generate(library,
 
 # Generate metadata for gobject introspection.
 alsatimer_gir = gnome.generate_gir(library,
-  sources: enums + headers + sources,
+  sources: enums + marshallers + headers + sources,
   nsversion: '0.0',
   namespace: namespace,
   symbol_prefix: '@0@_'.format(name),

--- a/src/timer/meson.build
+++ b/src/timer/meson.build
@@ -48,6 +48,8 @@ dependencies = [
   libudev_dependency,
 ]
 
+pc_desc = 'GObject instrospection library for timer interface in asound.h'
+
 # For test.
 build_dirs += {'alsatimer': meson.current_build_dir()}
 
@@ -108,7 +110,7 @@ install_headers(headers,
 
 # Generate pkg-config file for development.
 pkg.generate(library,
-  description: 'GObject instrospection library for timer interface in asound.h',
+  description: pc_desc,
   subdirs: inc_dir,
 )
 


### PR DESCRIPTION
In this project, meson configuration for included libraries consists of
two parts; common and specific. During development, the common part
gains differences between libraries. This patchset refactors meson
configuration to increase the same expression in the common part.

```
Takashi Sakamoto (7):
  timer: code refactoring for search path of alsatimer header
  meson: aggregate dependency declaration on glib/gobject and libudev
  meson: aggregate module imports
  meson: fulfill missing sources for gir scanner which are blank
  meson: move pkg-config description to metadata part
  meson: aggregate and move extra gir to metadata part
  meson: move path to top header to metadata part

 meson.build             |  2 --
 src/ctl/meson.build     | 37 +++++++++++++++-------------------
 src/hwdep/meson.build   | 39 ++++++++++++++++--------------------
 src/meson.build         | 15 ++++++++++++++
 src/rawmidi/meson.build | 38 ++++++++++++++++-------------------
 src/seq/meson.build     | 44 ++++++++++++++++++-----------------------
 src/timer/meson.build   | 40 +++++++++++++++++--------------------
 7 files changed, 102 insertions(+), 113 deletions(-)
```