### PR TITLE
[PATCH 0/6] add internal static library to include common utilities

### DIFF
--- a/src/ctl/card.c
+++ b/src/ctl/card.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "privates.h"
 
+#include <utils.h>
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -51,9 +53,6 @@ static const char *const err_msgs[] = {
 #define generate_syscall_error(exception, errno, fmt, arg)                  \
     g_set_error(exception, ALSACTL_CARD_ERROR, ALSACTL_CARD_ERROR_FAILED,   \
                 fmt" %d(%s)", arg, errno, strerror(errno))
-
-#define generate_file_error(exception, code, format, arg) \
-    g_set_error(exception, G_FILE_ERROR, code, format, arg)
 
 typedef struct {
     GSource src;

--- a/src/ctl/meson.build
+++ b/src/ctl/meson.build
@@ -32,7 +32,6 @@ privates = files(
 
 dependencies = [
   gobject_dependency,
-  libudev_dependency,
   utils_dependencies,
 ]
 

--- a/src/ctl/meson.build
+++ b/src/ctl/meson.build
@@ -33,6 +33,7 @@ privates = files(
 dependencies = [
   gobject_dependency,
   libudev_dependency,
+  utils_dependencies,
 ]
 
 pc_desc = 'GObject instrospection library for control interface in asound.h'

--- a/src/ctl/query.c
+++ b/src/ctl/query.c
@@ -3,13 +3,6 @@
 
 #include <utils.h>
 
-#include <string.h>
-#include <errno.h>
-#include <stdio.h>
-#include <stdbool.h>
-
-#include <libudev.h>
-
 /**
  * SECTION: query
  * @Title: Global functions in ALSACtl
@@ -19,88 +12,6 @@
 
 #define generate_file_error(exception, errno, msg) \
         g_set_error_literal(exception, G_FILE_ERROR, g_file_error_from_errno(errno), msg)
-
-static void prepare_udev_enum(struct udev_enumerate **enumerator,
-                              GError **error)
-{
-    struct udev *ctx;
-    int err;
-
-    ctx = udev_new();
-    if (ctx == NULL) {
-        generate_file_error(error, errno, "udev_new()");
-        return;
-    }
-
-    *enumerator = udev_enumerate_new(ctx);
-    if (*enumerator == NULL) {
-        generate_file_error(error, errno, "udev_enumerate_new()");
-        udev_unref(ctx);
-        return;
-    }
-
-    err = udev_enumerate_add_match_subsystem(*enumerator, "sound");
-    if (err < 0) {
-        generate_file_error(error, -err, "udev_enumerate_add_match_subsystem()");
-        udev_enumerate_unref(*enumerator);
-        udev_unref(ctx);
-        return;
-    }
-
-    err = udev_enumerate_scan_devices(*enumerator);
-    if (err < 0) {
-        generate_file_error(error, -err, "udev_enumerate_scan_devices()");
-        udev_enumerate_unref(*enumerator);
-        udev_unref(ctx);
-    }
-}
-
-static struct udev_device *detect_dev(struct udev_enumerate *enumerator,
-                                      struct udev_list_entry *entry,
-                                      const char *prefix)
-{
-    struct udev *ctx = udev_enumerate_get_udev(enumerator);
-    const char *syspath;
-    struct udev_device *dev;
-    const char *sysname;
-
-    syspath = udev_list_entry_get_name(entry);
-    if (syspath == NULL)
-        return NULL;
-
-    dev = udev_device_new_from_syspath(ctx, syspath);
-    if (dev == NULL)
-        return NULL;
-
-    sysname = udev_device_get_sysname(dev);
-    if (sysname == NULL) {
-        udev_device_unref(dev);
-        return NULL;
-    }
-
-    if (strstr(sysname, prefix) != sysname) {
-        udev_device_unref(dev);
-        return NULL;
-    }
-
-    return dev;
-}
-
-static void release_udev_enum(struct udev_enumerate *enumerator)
-{
-    struct udev *ctx = udev_enumerate_get_udev(enumerator);
-
-    udev_enumerate_unref(enumerator);
-    udev_unref(ctx);
-}
-
-static int compare_guint(const void *l, const void *r)
-{
-    const guint *x = l;
-    const guint *y = r;
-
-    return *x > *y;
-}
 
 /**
  * alsactl_get_card_id_list:
@@ -116,58 +27,15 @@ static int compare_guint(const void *l, const void *r)
 void alsactl_get_card_id_list(guint **entries, gsize *entry_count,
                               GError **error)
 {
-    struct udev_enumerate *enumerator = NULL;
-    struct udev_list_entry *entry, *entry_list;
-    unsigned int count;
-    unsigned int index;
+    int err;
 
     g_return_if_fail(entries != NULL);
     g_return_if_fail(entry_count != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
-    prepare_udev_enum(&enumerator, error);
-    if (*error != NULL)
-        return;
-
-    entry_list = udev_enumerate_get_list_entry(enumerator);
-
-    count = 0;
-    udev_list_entry_foreach(entry, entry_list) {
-        struct udev_device *dev = detect_dev(enumerator, entry, "card");
-        if (dev != NULL) {
-            ++count;
-            udev_device_unref(dev);
-        }
-    }
-
-    // Nothing available.
-    if (count == 0)
-        goto end;
-
-    *entries = g_malloc0_n(count, sizeof(**entries));
-
-    index = 0;
-    udev_list_entry_foreach(entry, entry_list) {
-        struct udev_device *dev = detect_dev(enumerator, entry, "card");
-        if (dev != NULL) {
-            const char *sysnum = udev_device_get_sysnum(dev);
-            long val;
-
-            if (!long_from_string(sysnum, &val)) {
-                (*entries)[index] = val;
-                ++index;
-            }
-            udev_device_unref(dev);
-        }
-    }
-
-    g_warn_if_fail(index == count);
-
-    *entry_count = count;
-
-    qsort(*entries, count, sizeof(guint), compare_guint);
-end:
-    release_udev_enum(enumerator);
+    err = generate_card_sysnum_list(entries, entry_count);
+    if (err < 0)
+        generate_file_error(error, -err, "Fail to generate list of card sysnum");
 }
 
 /**

--- a/src/ctl/query.c
+++ b/src/ctl/query.c
@@ -10,9 +10,6 @@
  *                     descriptor
  */
 
-#define generate_file_error(exception, errno, msg) \
-        g_set_error_literal(exception, G_FILE_ERROR, g_file_error_from_errno(errno), msg)
-
 /**
  * alsactl_get_card_id_list:
  * @entries: (array length=entry_count)(out): The list of numerical ID for sound

--- a/src/ctl/query.c
+++ b/src/ctl/query.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "privates.h"
 
+#include <utils.h>
+
 #include <string.h>
 #include <errno.h>
 #include <stdio.h>
@@ -153,12 +155,9 @@ void alsactl_get_card_id_list(guint **entries, gsize *entry_count,
         if (dev != NULL) {
             const char *sysnum = udev_device_get_sysnum(dev);
             long val;
-            char *endptr;
 
-            errno = 0;
-            val = strtol(sysnum, &endptr, 10);
-            if (errno == 0 && *endptr == '\0' && val >= 0) {
-                (*entries)[index] = (guint)val;
+            if (!long_from_string(sysnum, &val)) {
+                (*entries)[index] = val;
                 ++index;
             }
             udev_device_unref(dev);

--- a/src/hwdep/meson.build
+++ b/src/hwdep/meson.build
@@ -25,6 +25,7 @@ privates = files(
 dependencies = [
   gobject_dependency,
   libudev_dependency,
+  utils_dependencies,
 ]
 
 pc_desc = 'GObject instrospection library for HwDep interface in asound.h'

--- a/src/hwdep/meson.build
+++ b/src/hwdep/meson.build
@@ -24,7 +24,6 @@ privates = files(
 
 dependencies = [
   gobject_dependency,
-  libudev_dependency,
   utils_dependencies,
 ]
 

--- a/src/hwdep/query.c
+++ b/src/hwdep/query.c
@@ -3,16 +3,11 @@
 
 #include <utils.h>
 
-#include <stdio.h>
-#include <errno.h>
-#include <stdbool.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
-
-#include <libudev.h>
 
 /**
  * SECTION: query
@@ -21,109 +16,11 @@
  *                     descriptor
  */
 
-// 'C' is required apart from emulation of Open Sound System.
-#define PREFIX_SYSNAME_TEMPLATE     "hwC%u"
-
 #define generate_file_error(error, errno, msg) \
         g_set_error_literal(error, G_FILE_ERROR, g_file_error_from_errno(errno), msg)
 
 #define generate_file_error_fmt(error, errno, fmt, msg) \
         g_set_error(error, G_FILE_ERROR, g_file_error_from_errno(errno), fmt, msg)
-
-static void prepare_udev_enum(struct udev_enumerate **enumerator, GError **error)
-{
-    struct udev *ctx;
-    int err;
-
-    ctx = udev_new();
-    if (ctx == NULL) {
-        generate_file_error(error, errno, "udev_new()");
-        return;
-    }
-
-    *enumerator = udev_enumerate_new(ctx);
-    if (*enumerator == NULL) {
-        generate_file_error(error, errno, "udev_enumerate_new()");
-        udev_unref(ctx);
-        return;
-    }
-
-    err = udev_enumerate_add_match_subsystem(*enumerator, "sound");
-    if (err < 0) {
-        generate_file_error(error, -err, "udev_enumerate_add_match_subsystem()");
-        udev_enumerate_unref(*enumerator);
-        udev_unref(ctx);
-        return;
-    }
-
-    err = udev_enumerate_scan_devices(*enumerator);
-    if (err < 0) {
-        generate_file_error(error, -err, "udev_enumerate_scan_devices()");
-        udev_enumerate_unref(*enumerator);
-        udev_unref(ctx);
-    }
-}
-
-static struct udev_device *detect_dev(struct udev_enumerate *enumerator,
-                                      struct udev_list_entry *entry,
-                                      const char *prefix)
-{
-    struct udev *ctx = udev_enumerate_get_udev(enumerator);
-    const char *syspath;
-    struct udev_device *dev;
-    const char *sysname;
-
-    syspath = udev_list_entry_get_name(entry);
-    if (syspath == NULL)
-        return NULL;
-
-    dev = udev_device_new_from_syspath(ctx, syspath);
-    if (dev == NULL)
-        return NULL;
-
-    sysname = udev_device_get_sysname(dev);
-    if (sysname == NULL) {
-        udev_device_unref(dev);
-        return NULL;
-    }
-
-    if (strstr(sysname, prefix) != sysname) {
-        udev_device_unref(dev);
-        return NULL;
-    }
-
-    return dev;
-}
-
-static void release_udev_enum(struct udev_enumerate *enumerator)
-{
-    struct udev *ctx = udev_enumerate_get_udev(enumerator);
-
-    udev_enumerate_unref(enumerator);
-    udev_unref(ctx);
-}
-
-static int compare_guint(const void *l, const void *r)
-{
-    const guint *x = l;
-    const guint *y = r;
-
-    return *x > *y;
-}
-
-static unsigned int calculate_digits(unsigned int number)
-{
-    unsigned int digits = 0;
-
-    while (true) {
-        number /= 10;
-        ++digits;
-        if (number == 0)
-            break;
-    }
-
-    return digits;
-}
 
 /**
  * alsahwdep_get_device_id_list:
@@ -140,66 +37,15 @@ static unsigned int calculate_digits(unsigned int number)
 void alsahwdep_get_device_id_list(guint card_id, guint **entries,
                                   gsize *entry_count, GError **error)
 {
-    struct udev_enumerate *enumerator = NULL;
-    unsigned int length;
-    char *prefix = NULL;
-    struct udev_list_entry *entry, *entry_list;
-    unsigned int count;
-    unsigned int index;
+    int err;
 
     g_return_if_fail(entries != NULL);
     g_return_if_fail(entry_count != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
-    prepare_udev_enum(&enumerator, error);
-    if (*error != NULL)
-        return;
-
-    length = strlen(PREFIX_SYSNAME_TEMPLATE) + calculate_digits(card_id) + 1;
-    prefix = g_malloc0(length);
-
-    snprintf(prefix, length, PREFIX_SYSNAME_TEMPLATE, card_id);
-
-    entry_list = udev_enumerate_get_list_entry(enumerator);
-
-    count = 0;
-    udev_list_entry_foreach(entry, entry_list) {
-        struct udev_device *dev = detect_dev(enumerator, entry, prefix);
-        if (dev != NULL) {
-            ++count;
-            udev_device_unref(dev);
-        }
-    }
-
-    // Nothing available.
-    if (count == 0)
-        goto end;
-
-    *entries = g_malloc0_n(count, sizeof(**entries));
-
-    index = 0;
-    udev_list_entry_foreach(entry, entry_list) {
-        struct udev_device *dev = detect_dev(enumerator, entry, prefix);
-        if (dev != NULL) {
-            const char *sysnum = udev_device_get_sysnum(dev);
-            long val;
-
-            if (!long_from_string(sysnum, &val)) {
-                (*entries)[index] = (guint)val;
-                ++index;
-            }
-            udev_device_unref(dev);
-        }
-    }
-
-    g_warn_if_fail(index == count);
-
-    *entry_count = count;
-
-    qsort(*entries, count, sizeof(guint), compare_guint);
-end:
-    g_free(prefix);
-    release_udev_enum(enumerator);
+    err = generate_hwdep_sysnum_list(entries, entry_count, card_id);
+    if (err < 0)
+        generate_file_error(error, -err, "Fail to generate list of hwdep sysnum");
 }
 
 /**

--- a/src/hwdep/query.c
+++ b/src/hwdep/query.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "privates.h"
 
+#include <utils.h>
+
 #include <stdio.h>
 #include <errno.h>
 #include <stdbool.h>
@@ -183,11 +185,8 @@ void alsahwdep_get_device_id_list(guint card_id, guint **entries,
         if (dev != NULL) {
             const char *sysnum = udev_device_get_sysnum(dev);
             long val;
-            char *endptr;
 
-            errno = 0;
-            val = strtol(sysnum, &endptr, 10);
-            if (errno == 0 && *endptr == '\0' && val >= 0) {
+            if (!long_from_string(sysnum, &val)) {
                 (*entries)[index] = (guint)val;
                 ++index;
             }

--- a/src/hwdep/query.c
+++ b/src/hwdep/query.c
@@ -12,12 +12,6 @@
  *                     descriptor
  */
 
-#define generate_file_error(error, errno, msg) \
-        g_set_error_literal(error, G_FILE_ERROR, g_file_error_from_errno(errno), msg)
-
-#define generate_file_error_fmt(error, errno, fmt, msg) \
-        g_set_error(error, G_FILE_ERROR, g_file_error_from_errno(errno), fmt, msg)
-
 /**
  * alsahwdep_get_device_id_list:
  * @card_id: The numerical ID of sound card.

--- a/src/hwdep/query.c
+++ b/src/hwdep/query.c
@@ -23,8 +23,6 @@
 
 // 'C' is required apart from emulation of Open Sound System.
 #define PREFIX_SYSNAME_TEMPLATE     "hwC%u"
-#define HWDEP_SYSNAME_TEMPLATE      "hwC%uD%u"
-#define CTL_SYSNAME_TEMPLATE        "controlC%u"
 
 #define generate_file_error(error, errno, msg) \
         g_set_error_literal(error, G_FILE_ERROR, g_file_error_from_errno(errno), msg)
@@ -218,37 +216,14 @@ end:
 void alsahwdep_get_hwdep_sysname(guint card_id, guint device_id,
                                  char **sysname, GError **error)
 {
-    unsigned int length;
-    char *name;
-    struct udev *ctx;
-    struct udev_device *dev;
+    int err;
 
     g_return_if_fail(sysname != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
-    length = strlen(HWDEP_SYSNAME_TEMPLATE) + calculate_digits(card_id) +
-             calculate_digits(device_id) + 1;
-    name = g_malloc0(length);
-
-    snprintf(name, length, HWDEP_SYSNAME_TEMPLATE, card_id, device_id);
-
-    ctx = udev_new();
-    if (ctx == NULL) {
-        generate_file_error(error, errno, "udev_new()");
-        g_free(name);
-        return;
-    }
-
-    dev = udev_device_new_from_subsystem_sysname(ctx, "sound", name);
-    if (dev == NULL) {
-        generate_file_error(error, ENODEV, "udev_device_new_from_subsystem_sysname()");
-        g_free(name);
-    } else {
-        *sysname = name;
-        udev_device_unref(dev);
-    }
-
-    udev_unref(ctx);
+    err = lookup_and_allocate_hwdep_sysname(sysname, card_id, device_id);
+    if (err < 0)
+        generate_file_error(error, -err, "Fail to generate hwdep sysname");
 }
 
 /**
@@ -265,95 +240,43 @@ void alsahwdep_get_hwdep_sysname(guint card_id, guint device_id,
 void alsahwdep_get_hwdep_devnode(guint card_id, guint device_id,
                                  char **devnode, GError **error)
 {
-    unsigned int length;
-    char *name;
-    struct udev *ctx;
-    struct udev_device *dev;
-    const char *node;
+    int err;
 
     g_return_if_fail(devnode != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
-    length = strlen(HWDEP_SYSNAME_TEMPLATE) + calculate_digits(card_id) +
-             calculate_digits(device_id) + 1;
-    name = g_malloc0(length);
-
-    snprintf(name, length, HWDEP_SYSNAME_TEMPLATE, card_id, device_id);
-
-    ctx = udev_new();
-    if (ctx == NULL) {
-        generate_file_error(error, errno, "udev_new()");
-        g_free(name);
-        return;
-    }
-
-    dev = udev_device_new_from_subsystem_sysname(ctx, "sound", name);
-    g_free(name);
-    if (dev == NULL) {
-        generate_file_error(error, ENODEV, "udev_device_new_from_subsystem_sysname()");
-        udev_unref(ctx);
-        return;
-    }
-
-    node = udev_device_get_devnode(dev);
-    if (node == NULL)
-        generate_file_error(error, ENOENT, "udev_device_get_devnode()");
-    else
-        *devnode = g_strdup(node);
-
-    udev_device_unref(dev);
-    udev_unref(ctx);
+    err = lookup_and_allocate_hwdep_devname(devnode, card_id, device_id);
+    if (err < 0)
+        generate_file_error(error, -err, "Fail to generate hwdep devname");
 }
 
 static void hwdep_perform_ctl_ioctl(guint card_id, long request, void *data,
                                     const char *req_label, GError **error)
 {
-    unsigned int length;
-    char *sysname;
-    struct udev *ctx;
-    struct udev_device *dev;
-    const char *devnode;
+    char *devname;
     int fd;
+    int err;
 
-    length = strlen(CTL_SYSNAME_TEMPLATE) + calculate_digits(card_id) + 1;
-    sysname = g_malloc0(length);
+    g_return_if_fail(error == NULL || *error == NULL);
 
-    snprintf(sysname, length, CTL_SYSNAME_TEMPLATE, card_id);
-
-    ctx = udev_new();
-    if (ctx == NULL) {
-        generate_file_error(error, errno, "udev_new()");
-        goto err_sysname;
+    err = lookup_and_allocate_control_devname(&devname, card_id);
+    if (err < 0) {
+        generate_file_error(error, -err, "Fail to generate control devname");
+        return;
     }
 
-    dev = udev_device_new_from_subsystem_sysname(ctx, "sound", sysname);
-    if (dev == NULL) {
-        generate_file_error(error, errno, "udev_device_new_from_subsystem_sysname()");
-        goto err_ctx;
-    }
-
-    devnode = udev_device_get_devnode(dev);
-    if (devnode == NULL) {
-        generate_file_error(error, ENODEV, "udev_device_get_devnode()");
-        goto err_device;
-    }
-
-    fd = open(devnode, O_RDONLY | O_NONBLOCK);
+    fd = open(devname, O_RDONLY | O_NONBLOCK);
     if (fd < 0) {
-        generate_file_error_fmt(error, errno, "open(%s)", devnode);
-        goto err_device;
+        generate_file_error_fmt(error, errno, "open(%s)", devname);
+        goto end;
     }
 
-    if (ioctl(fd, request, data) < 0)
-        generate_file_error_fmt(error, errno, "ioctl(%s)", req_label);
+	if (ioctl(fd, request, data) < 0)
+	    generate_file_error_fmt(error, errno, "ioctl(%s)", req_label);
 
-    close(fd);
-err_device:
-    udev_device_unref(dev);
-err_ctx:
-    udev_unref(ctx);
-err_sysname:
-    g_free(sysname);
+	close(fd);
+end:
+    free(devname);
 }
 
 /**

--- a/src/meson.build
+++ b/src/meson.build
@@ -15,6 +15,7 @@ common_gir_includes = [
 
 build_dirs = {}
 
+subdir('utils')
 subdir('ctl')
 subdir('timer')
 subdir('seq')

--- a/src/rawmidi/meson.build
+++ b/src/rawmidi/meson.build
@@ -31,6 +31,7 @@ privates = files(
 dependencies = [
   gobject_dependency,
   libudev_dependency,
+  utils_dependencies,
 ]
 
 pc_desc = 'GObject instrospection library for RawMidi interface in asound.h'

--- a/src/rawmidi/meson.build
+++ b/src/rawmidi/meson.build
@@ -30,7 +30,6 @@ privates = files(
 
 dependencies = [
   gobject_dependency,
-  libudev_dependency,
   utils_dependencies,
 ]
 

--- a/src/rawmidi/query.c
+++ b/src/rawmidi/query.c
@@ -12,12 +12,6 @@
  *                     descriptor
  */
 
-#define generate_file_error(error, errno, msg)    \
-    g_set_error_literal(error, G_FILE_ERROR, g_file_error_from_errno(errno), msg)
-
-#define generate_file_error_fmt(error, errno, fmt, msg) \
-    g_set_error(error, G_FILE_ERROR, g_file_error_from_errno(errno), fmt, msg)
-
 /**
  * alsarawmidi_get_device_id_list:
  * @card_id: The numerical ID of sound card.

--- a/src/rawmidi/query.c
+++ b/src/rawmidi/query.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "privates.h"
 
+#include <utils.h>
+
 #include <stdio.h>
 #include <errno.h>
 #include <stdbool.h>
@@ -183,11 +185,8 @@ void alsarawmidi_get_device_id_list(guint card_id, guint **entries,
         if (dev != NULL) {
             const char *sysnum = udev_device_get_sysnum(dev);
             long val;
-            char *endptr;
 
-            errno = 0;
-            val = strtol(sysnum, &endptr, 10);
-            if (errno == 0 && *endptr == '\0' && val >= 0) {
+            if (!long_from_string(sysnum, &val)) {
                 (*entries)[index] = (guint)val;
                 ++index;
             }

--- a/src/rawmidi/query.c
+++ b/src/rawmidi/query.c
@@ -3,16 +3,11 @@
 
 #include <utils.h>
 
-#include <stdio.h>
-#include <errno.h>
-#include <stdbool.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
-
-#include <libudev.h>
 
 /**
  * SECTION: query
@@ -21,109 +16,11 @@
  *                     descriptor
  */
 
-// 'C' is required apart from emulation of Open Sound System.
-#define PREFIX_SYSNAME_TEMPLATE     "midiC%u"
-
 #define generate_file_error(error, errno, msg)    \
     g_set_error_literal(error, G_FILE_ERROR, g_file_error_from_errno(errno), msg)
 
 #define generate_file_error_fmt(error, errno, fmt, msg) \
     g_set_error(error, G_FILE_ERROR, g_file_error_from_errno(errno), fmt, msg)
-
-static void prepare_udev_enum(struct udev_enumerate **enumerator, GError **error)
-{
-    struct udev *ctx;
-    int err;
-
-    ctx = udev_new();
-    if (ctx == NULL) {
-        generate_file_error(error, errno, "udev_new()");
-        return;
-    }
-
-    *enumerator = udev_enumerate_new(ctx);
-    if (*enumerator == NULL) {
-        generate_file_error(error, errno, "udev_enumerate_new()");
-        udev_unref(ctx);
-        return;
-    }
-
-    err = udev_enumerate_add_match_subsystem(*enumerator, "sound");
-    if (err < 0) {
-        generate_file_error(error, -err, "udev_enumerate_add_match_subsystem()");
-        udev_enumerate_unref(*enumerator);
-        udev_unref(ctx);
-        return;
-    }
-
-    err = udev_enumerate_scan_devices(*enumerator);
-    if (err < 0) {
-        generate_file_error(error, -err, "udev_enumerate_scan_devices()");
-        udev_enumerate_unref(*enumerator);
-        udev_unref(ctx);
-    }
-}
-
-static struct udev_device *detect_dev(struct udev_enumerate *enumerator,
-                                      struct udev_list_entry *entry,
-                                      const char *prefix)
-{
-    struct udev *ctx = udev_enumerate_get_udev(enumerator);
-    const char *syspath;
-    struct udev_device *dev;
-    const char *sysname;
-
-    syspath = udev_list_entry_get_name(entry);
-    if (syspath == NULL)
-        return NULL;
-
-    dev = udev_device_new_from_syspath(ctx, syspath);
-    if (dev == NULL)
-        return NULL;
-
-    sysname = udev_device_get_sysname(dev);
-    if (sysname == NULL) {
-        udev_device_unref(dev);
-        return NULL;
-    }
-
-    if (strstr(sysname, prefix) != sysname) {
-        udev_device_unref(dev);
-        return NULL;
-    }
-
-    return dev;
-}
-
-static void release_udev_enum(struct udev_enumerate *enumerator)
-{
-    struct udev *ctx = udev_enumerate_get_udev(enumerator);
-
-    udev_enumerate_unref(enumerator);
-    udev_unref(ctx);
-}
-
-static int compare_guint(const void *l, const void *r)
-{
-    const guint *x = l;
-    const guint *y = r;
-
-    return *x > *y;
-}
-
-static unsigned int calculate_digits(unsigned int number)
-{
-    unsigned int digits = 0;
-
-    while (true) {
-        number /= 10;
-        ++digits;
-        if (number == 0)
-            break;
-    }
-
-    return digits;
-}
 
 /**
  * alsarawmidi_get_device_id_list:
@@ -140,66 +37,15 @@ static unsigned int calculate_digits(unsigned int number)
 void alsarawmidi_get_device_id_list(guint card_id, guint **entries,
                                     gsize *entry_count, GError **error)
 {
-    struct udev_enumerate *enumerator = NULL;
-    unsigned int length;
-    char *prefix = NULL;
-    struct udev_list_entry *entry, *entry_list;
-    unsigned int count;
-    unsigned int index;
+    int err;
 
     g_return_if_fail(entries != NULL);
     g_return_if_fail(entry_count != NULL);
     g_return_if_fail(error == NULL || *error == NULL);
 
-    prepare_udev_enum(&enumerator, error);
-    if (*error != NULL)
-        return;
-
-    length = strlen(PREFIX_SYSNAME_TEMPLATE) + calculate_digits(card_id) + 1;
-    prefix = g_malloc0(length);
-
-    snprintf(prefix, length, PREFIX_SYSNAME_TEMPLATE, card_id);
-
-    entry_list = udev_enumerate_get_list_entry(enumerator);
-
-    count = 0;
-    udev_list_entry_foreach(entry, entry_list) {
-        struct udev_device *dev = detect_dev(enumerator, entry, prefix);
-        if (dev != NULL) {
-            ++count;
-            udev_device_unref(dev);
-        }
-    }
-
-    // Nothing available.
-    if (count == 0)
-        goto end;
-
-    *entries = g_malloc0_n(count, sizeof(**entries));
-
-    index = 0;
-    udev_list_entry_foreach(entry, entry_list) {
-        struct udev_device *dev = detect_dev(enumerator, entry, prefix);
-        if (dev != NULL) {
-            const char *sysnum = udev_device_get_sysnum(dev);
-            long val;
-
-            if (!long_from_string(sysnum, &val)) {
-                (*entries)[index] = (guint)val;
-                ++index;
-            }
-            udev_device_unref(dev);
-        }
-    }
-
-    g_warn_if_fail(index == count);
-
-    *entry_count = count;
-
-    qsort(*entries, count, sizeof(guint), compare_guint);
-end:
-    g_free(prefix);
-    release_udev_enum(enumerator);
+    err = generate_rawmidi_sysnum_list(entries, entry_count, card_id);
+    if (err < 0)
+        generate_file_error(error, -err, "Fail to generate list of rawmidi sysnum");
 }
 
 /**

--- a/src/rawmidi/stream-pair.c
+++ b/src/rawmidi/stream-pair.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "privates.h"
 
+#include <utils.h>
+
 #include <errno.h>
 #include <string.h>
 #include <sys/types.h>
@@ -55,9 +57,6 @@ static const char *const err_msgs[] = {
 
 #define generate_local_error(error, code) \
         g_set_error_literal(error, ALSARAWMIDI_STREAM_PAIR_ERROR, code, err_msgs[code])
-
-#define generate_file_error(exception, code, format, arg) \
-        g_set_error(exception, G_FILE_ERROR, code, format, arg)
 
 #define generate_syscall_error(error, errno, format, arg)           \
         g_set_error(error, ALSARAWMIDI_STREAM_PAIR_ERROR,           \

--- a/src/seq/meson.build
+++ b/src/seq/meson.build
@@ -62,7 +62,6 @@ privates = files(
 
 dependencies = [
   gobject_dependency,
-  libudev_dependency,
   utils_dependencies,
   alsatimer_dependency,
 ]

--- a/src/seq/meson.build
+++ b/src/seq/meson.build
@@ -63,6 +63,7 @@ privates = files(
 dependencies = [
   gobject_dependency,
   libudev_dependency,
+  utils_dependencies,
   alsatimer_dependency,
 ]
 

--- a/src/seq/query.c
+++ b/src/seq/query.c
@@ -16,12 +16,6 @@
  *                     descriptor
  */
 
-#define generate_file_error(exception, errno, msg) \
-        g_set_error_literal(exception, G_FILE_ERROR, g_file_error_from_errno(errno), msg)
-
-#define generate_file_error_fmt(exception, errno, fmt, msg) \
-        g_set_error(exception, G_FILE_ERROR, g_file_error_from_errno(errno), fmt, msg)
-
 /**
  * alsaseq_get_seq_sysname:
  * @sysname: (out): The sysname of ALSA Sequencer.
@@ -75,7 +69,7 @@ static int open_fd(GError **error)
 
     fd = open(devname, O_RDONLY);
     if (fd < 0)
-        generate_file_error_fmt(error, errno, "open(%s)", devname);
+        generate_file_error(error, errno, "open(%s)", devname);
     g_free(devname);
 
     return fd;

--- a/src/seq/query.c
+++ b/src/seq/query.c
@@ -1,16 +1,13 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "privates.h"
-#include "utils.h"
 
-#include <errno.h>
+#include <utils.h>
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
 #include <sys/ioctl.h>
-#include <stdbool.h>
-
-#include <libudev.h>
+#include <unistd.h>
 
 /**
  * SECTION: query

--- a/src/seq/user-client.c
+++ b/src/seq/user-client.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "privates.h"
 
+#include <utils.h>
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -52,9 +54,6 @@ static const char *const err_msgs[] = {
 #define generate_syscall_error(exception, errno, fmt, arg) \
         g_set_error(exception, ALSASEQ_USER_CLIENT_ERROR, ALSASEQ_USER_CLIENT_ERROR_FAILED, \
                     fmt" %d(%s)", arg, errno, strerror(errno))
-
-#define generate_file_error(exception, code, fmt, arg) \
-        g_set_error(exception, G_FILE_ERROR, code, fmt, arg)
 
 typedef struct {
     GSource src;

--- a/src/timer/meson.build
+++ b/src/timer/meson.build
@@ -44,7 +44,6 @@ privates = files(
 
 dependencies = [
   gobject_dependency,
-  libudev_dependency,
   utils_dependencies,
 ]
 

--- a/src/timer/meson.build
+++ b/src/timer/meson.build
@@ -45,6 +45,7 @@ privates = files(
 dependencies = [
   gobject_dependency,
   libudev_dependency,
+  utils_dependencies,
 ]
 
 pc_desc = 'GObject instrospection library for timer interface in asound.h'

--- a/src/timer/query.c
+++ b/src/timer/query.c
@@ -22,12 +22,6 @@
 
 #define SYSFS_SND_TIMER_NODE    "/sys/module/snd_timer/"
 
-#define generate_file_error(exception, errno, msg) \
-        g_set_error_literal(exception, G_FILE_ERROR, g_file_error_from_errno(errno), msg)
-
-#define generate_file_error_fmt(exception, errno, fmt, msg) \
-        g_set_error(exception, G_FILE_ERROR, g_file_error_from_errno(errno), fmt, msg)
-
 /**
  * alsatimer_get_sysname:
  * @sysname: (out): The string for sysname of ALSA Timer.
@@ -81,7 +75,7 @@ static int open_fd(GError **error)
 
     fd = open(devname, O_RDONLY);
     if (fd < 0)
-        generate_file_error_fmt(error, errno, "open(%s)", devname);
+        generate_file_error(error, errno, "open(%s)", devname);
     g_free(devname);
 
     return fd;
@@ -253,7 +247,7 @@ static void timer_get_node_param_value(const char *param_name, char *buf,
 
     fd = open(literal, O_RDONLY);
     if (fd < 0) {
-        generate_file_error_fmt(error, errno, "open(%s)", literal);
+        generate_file_error(error, errno, "open(%s)", literal);
         return;
     }
 

--- a/src/timer/query.c
+++ b/src/timer/query.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "privates.h"
 
+#include <utils.h>
+
 #include <stdio.h>
 #include <stdbool.h>
 #include <errno.h>
@@ -305,7 +307,7 @@ static void timer_get_node_param_value(const char *param_name, char *buf,
     int fd;
     ssize_t len;
     long v;
-    char *term;
+    int err;
 
     snprintf(literal, sizeof(literal), SYSFS_SND_TIMER_NODE "parameters/%s",
              param_name);
@@ -322,11 +324,9 @@ static void timer_get_node_param_value(const char *param_name, char *buf,
         goto end;
     }
 
-    v = strtol(buf, &term, 10);
-    if (errno > 0)
-        generate_file_error(error, errno, "strtol()");
-    else if (*term != '\n')
-        generate_file_error(error, EIO, "strtol()");
+    err = long_from_string(buf, &v);
+    if (err < 0)
+        generate_file_error(error, -err, "Fail to parse snd_timer module parameter as integer value");
     else
         *val = (int)v;
 end:

--- a/src/timer/query.c
+++ b/src/timer/query.c
@@ -3,19 +3,15 @@
 
 #include <utils.h>
 
-#include <stdio.h>
-#include <stdbool.h>
-#include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
 #include <sys/ioctl.h>
+#include <unistd.h>
+#include <stdio.h>
 #include <stdbool.h>
 
 #include <time.h>
-
-#include <libudev.h>
 
 /**
  * SECTION: query

--- a/src/timer/user-instance.c
+++ b/src/timer/user-instance.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "privates.h"
 
+#include <utils.h>
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -49,9 +51,6 @@ static const char *const err_msgs[] = {
 #define generate_syscall_error(exception, errno, fmt, arg)                                      \
     g_set_error(exception, ALSATIMER_USER_INSTANCE_ERROR, ALSATIMER_USER_INSTANCE_ERROR_FAILED, \
                 fmt" %d(%s)", arg, errno, strerror(errno))
-
-#define generate_file_error(exception, code, format, arg) \
-    g_set_error(exception, G_FILE_ERROR, code, format, arg)
 
 typedef struct {
     GSource src;

--- a/src/utils/ioctl.c
+++ b/src/utils/ioctl.c
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#include "utils.h"
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+int request_ctl_ioctl_opened(int *fd, unsigned int card_id, long request, void *data)
+{
+    char *devname;
+    int err;
+
+    if (fd == NULL)
+        return -EINVAL;
+
+    err = lookup_and_allocate_control_devname(&devname, card_id);
+    if (err < 0)
+        return err;
+
+    *fd = open(devname, O_RDONLY | O_NONBLOCK);
+    free(devname);
+    if (*fd < 0)
+        return -errno;
+
+    if (ioctl(*fd, request, data) < 0)
+        return -errno;
+
+    return 0;
+}
+
+int request_ctl_ioctl(unsigned int card_id, long request, void *data)
+{
+    int fd;
+    int err;
+
+    err = request_ctl_ioctl_opened(&fd, card_id, request, data);
+    close(fd);
+
+    return err;
+}

--- a/src/utils/meson.build
+++ b/src/utils/meson.build
@@ -1,0 +1,19 @@
+headers = [
+  'utils.h',
+]
+
+sources = [
+]
+
+dependencies = [
+]
+
+static_library = static_library('utils',
+  sources: sources + headers,
+)
+
+utils_dependencies = declare_dependency(
+  dependencies: dependencies,
+  include_directories: include_directories('.'),
+  link_with: static_library,
+)

--- a/src/utils/meson.build
+++ b/src/utils/meson.build
@@ -4,9 +4,11 @@ headers = [
 
 sources = [
   'string.c',
+  'sysfs.c',
 ]
 
 dependencies = [
+  dependency('libudev'),
 ]
 
 static_library = static_library('utils',

--- a/src/utils/meson.build
+++ b/src/utils/meson.build
@@ -5,6 +5,7 @@ headers = [
 sources = [
   'string.c',
   'sysfs.c',
+  'ioctl.c',
 ]
 
 dependencies = [

--- a/src/utils/meson.build
+++ b/src/utils/meson.build
@@ -3,6 +3,7 @@ headers = [
 ]
 
 sources = [
+  'string.c',
 ]
 
 dependencies = [

--- a/src/utils/string.c
+++ b/src/utils/string.c
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#include <stdlib.h>
+#include <errno.h>
+
+long long_from_string(const char *literal, long *number)
+{
+    long val;
+    char *endptr;
+
+    errno = 0;
+    val = strtol(literal, &endptr, 10);
+    if (errno > 0)
+        return -errno;
+    if (!endptr || endptr == literal || *endptr != 0)
+        return -EINVAL;
+    *number = val;
+    return 0;
+}

--- a/src/utils/string.c
+++ b/src/utils/string.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-#include <stdlib.h>
+#include "utils.h"
+
 #include <errno.h>
+#include <stdio.h>
 
 long long_from_string(const char *literal, long *number)
 {
@@ -14,5 +16,32 @@ long long_from_string(const char *literal, long *number)
     if (!endptr || endptr == literal || *endptr != 0)
         return -EINVAL;
     *number = val;
+    return 0;
+}
+
+int allocate_string(char **dst, const char *template, va_list ap)
+{
+    char *label;
+    int size;
+    va_list aq;
+
+    va_copy(aq, ap);
+    size = vsnprintf(NULL, 0, template, aq);
+    va_end(aq);
+
+    if (size < 0)
+        return -EINVAL;
+    size += 1;
+
+    label = malloc(size);
+    if (label == NULL)
+        return -ENOMEM;
+
+    va_copy(aq, ap);
+    vsnprintf(label, size, template, aq);
+    va_end(aq);
+
+    *dst = label;
+
     return 0;
 }

--- a/src/utils/sysfs.c
+++ b/src/utils/sysfs.c
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#include "utils.h"
+
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+
+#define SOUND_SUBSYSTEM     "sound"
+
+int lookup_and_allocate_string_by_sysname(char **name, const char *sysname,
+                                          const char *(*func)(struct udev_device *))
+{
+    struct udev *ctx;
+    struct udev_device *device;
+    const char *n;
+    int err = 0;
+
+    if (name == NULL || sysname == NULL || func == NULL)
+        return -EINVAL;
+
+    ctx = udev_new();
+    if (ctx == NULL)
+        return -errno;
+
+    device = udev_device_new_from_subsystem_sysname(ctx, SOUND_SUBSYSTEM, sysname);
+    if (device == NULL) {
+        err = -errno;
+        goto err_ctx;
+    }
+
+    n = func(device);
+    if (n == NULL) {
+        err = -errno;
+        goto err_dev;
+    }
+
+    *name = strdup(n);
+    if (*name == NULL)
+        err = -ENOMEM;
+err_dev:
+    udev_device_unref(device);
+err_ctx:
+    udev_unref(ctx);
+    return err;
+}

--- a/src/utils/sysfs.c
+++ b/src/utils/sysfs.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
+#include <stdlib.h>
 
 #define SOUND_SUBSYSTEM     "sound"
 
@@ -41,5 +42,133 @@ err_dev:
     udev_device_unref(device);
 err_ctx:
     udev_unref(ctx);
+    return err;
+}
+
+static int detect_device(struct udev_device **device, struct udev *ctx,
+                         struct udev_list_entry *entry, const char *prefix)
+{
+    const char *syspath;
+    struct udev_device *dev;
+    const char *sysname;
+
+    syspath = udev_list_entry_get_name(entry);
+    if (syspath == NULL)
+        return -errno;
+
+    dev = udev_device_new_from_syspath(ctx, syspath);
+    if (dev == NULL)
+        return -errno;
+
+    sysname = udev_device_get_sysname(dev);
+    if (sysname == NULL) {
+        udev_device_unref(dev);
+        return -errno;
+    }
+
+    if (strstr(sysname, prefix) != sysname) {
+        udev_device_unref(dev);
+        return -ENODEV;
+    }
+
+    *device = dev;
+
+    return 0;
+}
+
+static int compare_u32(const void *l, const void *r)
+{
+    const unsigned int *x = l;
+    const unsigned int *y = r;
+
+    return *x > *y;
+}
+
+int generate_sysnum_list_by_sysname_prefix(unsigned int **entries, unsigned long *entry_count,
+                                           const char *prefix)
+{
+    struct udev *ctx;
+    struct udev_enumerate *enumerator;
+    unsigned int count;
+    struct udev_list_entry *entry, *entry_list;
+    unsigned int index;
+    int err;
+
+    ctx = udev_new();
+    if (ctx == NULL)
+        return -errno;
+
+    enumerator = udev_enumerate_new(ctx);
+    if (enumerator == NULL) {
+        err = -errno;
+        goto err_ctx;
+    }
+
+    err = udev_enumerate_add_match_subsystem(enumerator, SOUND_SUBSYSTEM);
+    if (err < 0) {
+        goto err_enum;
+    }
+
+    err = udev_enumerate_scan_devices(enumerator);
+    if (err < 0)
+        goto err_enum;
+
+    count = 0;
+    entry_list = udev_enumerate_get_list_entry(enumerator);
+    udev_list_entry_foreach(entry, entry_list) {
+        struct udev_device *dev;
+        int err;
+
+        err = detect_device(&dev, ctx, entry, prefix);
+        if (err < 0)
+            continue;
+
+         ++count;
+         udev_device_unref(dev);
+    }
+
+    // Nothing available.
+    if (count == 0)
+        goto err_enum;
+
+    *entries = calloc(count, sizeof(**entries));
+    if (*entries == NULL) {
+        err = -ENOMEM;
+        goto err_enum;
+    }
+
+    index = 0;
+    udev_list_entry_foreach(entry, entry_list) {
+        struct udev_device *dev;
+        const char *sysnum;
+        long val;
+        int err;
+
+        err = detect_device(&dev, ctx, entry, prefix);
+        if (err < 0)
+            continue;
+
+        sysnum = udev_device_get_sysnum(dev);
+        if (sysnum != NULL && !long_from_string(sysnum, &val)) {
+            (*entries)[index] = (unsigned int)val;
+            ++index;
+        }
+
+        udev_device_unref(dev);
+    }
+
+    if (index != count) {
+        err = -ENODATA;
+        goto err_enum;
+    }
+
+    *entry_count = count;
+
+    qsort(*entries, count, sizeof(unsigned int), compare_u32);
+err_enum:
+    udev_enumerate_unref(enumerator);
+err_ctx:
+    udev_unref(ctx);
+
     return err;
 }

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -2,4 +2,6 @@
 #ifndef __ALSA_GOBJECT_UTILS_H__
 #define __ALSA_GOBJECT_UTILS_H__
 
+long long_from_string(const char *literal, long *number);
+
 #endif

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -6,6 +6,9 @@
 #include <stdarg.h>
 #include <libudev.h>
 
+#define generate_file_error(exception, errno, ...) \
+        g_set_error(exception, G_FILE_ERROR, g_file_error_from_errno(errno), __VA_ARGS__)
+
 #define CARD_SYSNAME_PREFIX             "card"
 #define CARD_SYSNAME_TEMPLATE           CARD_SYSNAME_PREFIX "%u"
 #define CONTROL_SYSNAME_TEMPLATE        "controlC%u"

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -28,6 +28,9 @@ int lookup_and_allocate_string_by_sysname(char **name, const char *sysname,
 int generate_sysnum_list_by_sysname_prefix(unsigned int **entries, unsigned long *entry_count,
                                            const char *prefix);
 
+int request_ctl_ioctl_opened(int *fd, unsigned int card_id, long request, void *data);
+int request_ctl_ioctl(unsigned int card_id, long request, void *data);
+
 static inline int lookup_and_allocate_name_by_sysname(char **name,
                                                       const char *(*func)(struct udev_device *),
                                                       const char *fmt, va_list ap)

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -2,6 +2,123 @@
 #ifndef __ALSA_GOBJECT_UTILS_H__
 #define __ALSA_GOBJECT_UTILS_H__
 
+#include <stdlib.h>
+#include <stdarg.h>
+#include <libudev.h>
+
+#define CARD_SYSNAME_TEMPLATE           "card%u"
+#define CONTROL_SYSNAME_TEMPLATE        "controlC%u"
+#define RAWMIDI_SYSNAME_TEMPLATE        "midiC%uD%u"
+#define HWDEP_SYSNAME_TEMPLATE          "hwC%uD%u"
+#define TIMER_SYSNAME                   "timer"
+#define SEQ_SYSNAME                     "seq"
+
 long long_from_string(const char *literal, long *number);
+
+int allocate_string(char **dst, const char *template, va_list ap);
+
+int lookup_and_allocate_string_by_sysname(char **name, const char *sysname,
+                                          const char *(*func)(struct udev_device *));
+
+static inline int lookup_and_allocate_name_by_sysname(char **name,
+                                                      const char *(*func)(struct udev_device *),
+                                                      const char *fmt, va_list ap)
+{
+    char *sysname;
+    int err;
+
+    err = allocate_string(&sysname, fmt, ap);
+    if (err >= 0)
+        err = lookup_and_allocate_string_by_sysname(name, sysname, func);
+    free(sysname);
+    return err;
+}
+
+static inline int lookup_and_allocate_sysname_by_sysname(char **sysname, const char *fmt, ...)
+{
+    va_list ap;
+    int err;
+
+    va_start(ap, fmt);
+    err = lookup_and_allocate_name_by_sysname(sysname, udev_device_get_sysname, fmt, ap);
+    va_end(ap);
+
+    return err;
+}
+
+static inline int lookup_and_allocate_devname_by_sysname(char **devname, const char *fmt, ...)
+{
+    va_list ap;
+    int err;
+
+    va_start(ap, fmt);
+    err = lookup_and_allocate_name_by_sysname(devname, udev_device_get_devnode, fmt, ap);
+    va_end(ap);
+
+    return err;
+}
+
+static inline int lookup_and_allocate_card_sysname(char **sysname, unsigned int card_id)
+{
+    return lookup_and_allocate_sysname_by_sysname(sysname, CARD_SYSNAME_TEMPLATE, card_id);
+}
+
+static inline int lookup_and_allocate_control_sysname(char **sysname, unsigned int card_id)
+{
+    return lookup_and_allocate_sysname_by_sysname(sysname, CONTROL_SYSNAME_TEMPLATE, card_id);
+}
+
+static inline int lookup_and_allocate_control_devname(char **devname, unsigned int card_id)
+{
+    return lookup_and_allocate_devname_by_sysname(devname, CONTROL_SYSNAME_TEMPLATE, card_id);
+}
+
+static inline int lookup_and_allocate_hwdep_sysname(char **sysname, unsigned int card_id,
+                                                    unsigned int device_id)
+{
+    return lookup_and_allocate_sysname_by_sysname(sysname, HWDEP_SYSNAME_TEMPLATE, card_id,
+                                                  device_id);
+}
+
+static inline int lookup_and_allocate_hwdep_devname(char **devname, unsigned int card_id,
+                                                    unsigned int device_id)
+{
+    return lookup_and_allocate_devname_by_sysname(devname, HWDEP_SYSNAME_TEMPLATE, card_id,
+                                                  device_id);
+}
+
+static inline int lookup_and_allocate_rawmidi_sysname(char **sysname, unsigned int card_id,
+                                                      unsigned int device_id)
+{
+    return lookup_and_allocate_sysname_by_sysname(sysname, RAWMIDI_SYSNAME_TEMPLATE, card_id,
+                                                  device_id);
+}
+
+static inline int lookup_and_allocate_rawmidi_devname(char **devname, unsigned int card_id,
+                                                      unsigned int device_id)
+{
+    return lookup_and_allocate_devname_by_sysname(devname, RAWMIDI_SYSNAME_TEMPLATE, card_id,
+                                                  device_id);
+}
+
+static inline int lookup_and_allocate_timer_sysname(char **sysname)
+{
+    return lookup_and_allocate_sysname_by_sysname(sysname, TIMER_SYSNAME);
+}
+
+static inline int lookup_and_allocate_timer_devname(char **devname)
+{
+    return lookup_and_allocate_devname_by_sysname(devname, TIMER_SYSNAME);
+}
+
+static inline int lookup_and_allocate_seq_sysname(char **sysname)
+{
+    return lookup_and_allocate_sysname_by_sysname(sysname, SEQ_SYSNAME);
+}
+
+static inline int lookup_and_allocate_seq_devname(char **devname)
+{
+    return lookup_and_allocate_devname_by_sysname(devname, SEQ_SYSNAME);
+}
 
 #endif

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#ifndef __ALSA_GOBJECT_UTILS_H__
+#define __ALSA_GOBJECT_UTILS_H__
+
+#endif


### PR DESCRIPTION
Current implementation of included libraries have duplicated codes
to operate over sysfs by libudev and so. It's inconvenient in a point of
maintenance.

This patchset adds internal static library to include such codes.

```
Takashi Sakamoto (6):
  utils: build internal static library including common utilities
  utils: add utility to compute integer value from string literal
  utils: add utilities to allocate string information for device
  utils: add utilitiy to generate list of sysnum by prefix of sysname
  utils: add utilities to request control ioctl
  utils: add utility macros to generate GError with file domain

 src/ctl/card.c            |   5 +-
 src/ctl/meson.build       |   2 +-
 src/ctl/query.c           | 261 ++----------------------------
 src/hwdep/meson.build     |   2 +-
 src/hwdep/query.c         | 306 +++--------------------------------
 src/meson.build           |   1 +
 src/rawmidi/meson.build   |   2 +-
 src/rawmidi/query.c       | 324 ++++----------------------------------
 src/rawmidi/stream-pair.c |   5 +-
 src/seq/meson.build       |   2 +-
 src/seq/query.c           |  87 ++--------
 src/seq/user-client.c     |   5 +-
 src/timer/meson.build     |   2 +-
 src/timer/query.c         | 105 +++---------
 src/timer/user-instance.c |   5 +-
 src/utils/ioctl.c         |  45 ++++++
 src/utils/meson.build     |  23 +++
 src/utils/string.c        |  47 ++++++
 src/utils/sysfs.c         | 176 +++++++++++++++++++++
 src/utils/utils.h         | 176 +++++++++++++++++++++
 20 files changed, 578 insertions(+), 1003 deletions(-)
 create mode 100644 src/utils/ioctl.c
 create mode 100644 src/utils/meson.build
 create mode 100644 src/utils/string.c
 create mode 100644 src/utils/sysfs.c
 create mode 100644 src/utils/utils.h
```