### PR TITLE
[PATCH 00/55] optimization to gi-docgen

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 The alsa-gobject project
 ========================
 
-2022/03/16
+2022/04/03
 Takashi Sakamoto
 
 Introduction
@@ -98,7 +98,7 @@ Generate documentation ::
     $ meson --prefix=xxx -D doc=true . build
     $ cd build
     $ meson install
-    $ xdg-open xxx/share/doc/html/index.html
+    $ xdg-open xxx/share/doc/alsa-gobject/index.html
 
 Design note
 ===========

--- a/README.rst
+++ b/README.rst
@@ -60,11 +60,17 @@ Dependencies
 
 * GLib <https://gitlab.gnome.org/GNOME/glib>
 * GObject introspection <https://gi.readthedocs.io/>
-* UAPI of Linux kernel version 4.5 or later for sound subsystem
 * libudev1 <https://www.freedesktop.org/wiki/Software/systemd/>
-* Meson <https://mesonbuild.com/>
-* (optional) PyGObject <https://pygobject.readthedocs.io/> to execute tests
-* (optional) gi-docgen <https://gnome.pages.gitlab.gnome.org/gi-docgen/> to generate documentation
+* Linux kernel version 4.5 or later
+
+Requirements to build
+=====================
+
+* UAPI header of Linux kernel
+* Meson build system <https://mesonbuild.com/>
+* Ninja build system <https://ninja-build.org/>
+* PyGObject <https://pygobject.readthedocs.io/> (optional to run unit tests)
+* gi-docgen <https://gnome.pages.gitlab.gnome.org/gi-docgen/> (optional to generate API documentation)
 
 How to build
 ============

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ ALSARawmidi-0.0
 Documentation
 =============
 
-<https://alsa-project.github.io/alsa-gobject-docs/>
+`<https://alsa-project.github.io/alsa-gobject-docs/>`_
 
 Python 3 Samples
 ================
@@ -58,19 +58,19 @@ This software is licensed under GNU Lesser General Public License version 3 or l
 Dependencies
 ============
 
-* GLib <https://gitlab.gnome.org/GNOME/glib>
-* GObject introspection <https://gi.readthedocs.io/>
-* libudev1 <https://www.freedesktop.org/wiki/Software/systemd/>
+* GLib `<https://gitlab.gnome.org/GNOME/glib>`_
+* GObject introspection `<https://gi.readthedocs.io/>`_
+* libudev1 `<https://www.freedesktop.org/wiki/Software/systemd/>`_
 * Linux kernel version 4.5 or later
 
 Requirements to build
 =====================
 
 * UAPI header of Linux kernel
-* Meson build system <https://mesonbuild.com/>
-* Ninja build system <https://ninja-build.org/>
-* PyGObject <https://pygobject.readthedocs.io/> (optional to run unit tests)
-* gi-docgen <https://gnome.pages.gitlab.gnome.org/gi-docgen/> (optional to generate API documentation)
+* Meson build system `<https://mesonbuild.com/>`_
+* Ninja build system `<https://ninja-build.org/>`_
+* PyGObject `<https://pygobject.readthedocs.io/>`_ (optional to run unit tests)
+* gi-docgen `<https://gnome.pages.gitlab.gnome.org/gi-docgen/>`_ (optional to generate API documentation)
 
 How to build
 ============
@@ -123,9 +123,9 @@ Design note
 Supplemental information for language bindings
 ==============================================
 
-* PyGObject <https://pygobject.readthedocs.io/> is a dynamic loader for
+* PyGObject `<https://pygobject.readthedocs.io/>`_ is a dynamic loader for
   libraries compatible with g-i.
-* alsa-gobject-rs <https://github.com/alsa-project/alsa-gobject-rs/> includes
+* alsa-gobject-rs `<https://github.com/alsa-project/alsa-gobject-rs/>`_ includes
   creates to use these libraries.
 
 Valgrind suppression file for leak detected in glib

--- a/src/ctl/alsactl-enum-types.h
+++ b/src/ctl/alsactl-enum-types.h
@@ -116,7 +116,7 @@ typedef enum /*< flags >*/
  * @ALSACTL_CARD_ERROR_ELEM_OWNED:          The control element is owned by the other process.
  * @ALSACTL_CARD_ERROR_ELEM_EXIST:          The control element already exists.
  *
- * A set of error code for GError with domain which equals to #alsactl_card_error_quark()
+ * A set of error code for [struct@GLib.Error] with `ALSACtl.CardError` domain.
  */
 typedef enum {
     ALSACTL_CARD_ERROR_FAILED,

--- a/src/ctl/card-info.c
+++ b/src/ctl/card-info.c
@@ -2,16 +2,13 @@
 #include "privates.h"
 
 /**
- * SECTION: card-info
- * @Title: ALSACtlCardInfo
- * @Short_description: A GObject-derived object to represent information of
- *                     sound card
+ * ALSACtlCardInfo:
+ * A GObject-derived object to represent information of sound card.
  *
- * A #ALSACtlCardInfo is a GObject-derived object to represent information of
- * sound card. The call of alsactl_card_get_info() returns an instance of the
- * object.
+ * A [class@CardInfo] is information of sound card. The call of [method@Card.get_info] returns an
+ * instance of the object.
  *
- * The object wraps 'struct snd_ctl_card_info' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_ctl_card_info` in UAPI of Linux sound subsystem.
  */
 typedef struct {
     struct snd_ctl_card_info info;

--- a/src/ctl/card.c
+++ b/src/ctl/card.c
@@ -12,15 +12,13 @@
 #include <unistd.h>
 
 /**
- * SECTION: card
- * @Title: ALSACtlCard
- * @Short_description: An GObject-derived object to represent sound card
+ * ALSACtlCard:
+ * An GObject-derived object to represent sound card.
  *
- * A #ALSACtlCard is a GObject-derived object to represent sound card.
- * Applications use the instance of object to manipulate functionalities on
- * sound card.
- * After the call of alsactl_card_open() for the numerical ID of sound card,
- * the object maintains file descriptor till object destruction.
+ * A [class@Card] is a GObject-derived object to represent sound card. Applications use the
+ * instance of object to manipulate functionalities on sound card. After the call of
+ * [method@Card.open] for the numeric ID of sound card, the object maintains file descriptor till
+ * object destruction.
  */
 typedef struct {
     int fd;
@@ -33,9 +31,9 @@ G_DEFINE_TYPE_WITH_PRIVATE(ALSACtlCard, alsactl_card, G_TYPE_OBJECT)
 /**
  * alsactl_card_error_quark:
  *
- * Return the GQuark for error domain of GError which has code in #ALSACtlCardError enumerations.
+ * Return the [alias@GLib.Quark] for [struct@GLib.Error] with code in [enum@CardError] enumerations.
  *
- * Returns: A #GQuark.
+ * Returns: A [alias@GLib.Quark].
  */
 G_DEFINE_QUARK(alsactl-card-error-quark, alsactl_card_error)
 
@@ -135,11 +133,11 @@ static void alsactl_card_class_init(ALSACtlCardClass *klass)
 
     /**
      * ALSACtlCard::handle-elem-event:
-     * @self: A #ALSACtlCard.
-     * @elem_id: (transfer none): A #ALSACtlElemId.
-     * @events: A set of #ALSACtlElemEventMask.
+     * @self: A [class@Card].
+     * @elem_id: (transfer none): A [struct@ElemId].
+     * @events: A set of [flags@ElemEventMask].
      *
-     * When event occurs for any element, this signal is emit.
+     * Emitted when event occurs for any element.
      */
     ctl_card_sigs[CTL_CARD_SIG_HANDLE_ELEM_EVENT] =
         g_signal_new("handle-elem-event",
@@ -153,12 +151,11 @@ static void alsactl_card_class_init(ALSACtlCardClass *klass)
 
     /**
      * ALSACtlCard::handle-disconnection:
-     * @self: A #ALSACtlCard.
+     * @self: A [class@Card].
      *
-     * When the sound card is not available anymore due to unbinding driver or
-     * hot unplugging, this signal is emit. The owner of this object should
-     * call g_object_unref() as quickly as possible to be going to release ALSA
-     * control character device.
+     * Emitted when the sound card is not available anymore due to unbinding driver or hot
+     * unplugging. The owner of this object should call [method@GObject.Object.unref] as quickly
+     * as possible to be going to release ALSA control character device.
      */
     ctl_card_sigs[CTL_CARD_SIG_HANDLE_DISCONNECTION] =
         g_signal_new("handle-disconnection",
@@ -180,7 +177,9 @@ static void alsactl_card_init(ALSACtlCard *self)
 /**
  * alsactl_card_new:
  *
- * Allocate and return an instance of ALSACtlCard class.
+ * Allocate and return an instance of [class@Card].
+ *
+ * Returns: An instance of [class@Card].
  */
 ALSACtlCard *alsactl_card_new()
 {
@@ -189,19 +188,17 @@ ALSACtlCard *alsactl_card_new()
 
 /**
  * alsactl_card_open:
- * @self: A #ALSACtlCard.
- * @card_id: The numerical ID of sound card.
- * @open_flag: The flag of open(2) system call. O_RDONLY is forced to fulfil internally.
- * @error: A #GError. Error is generated with two domains; #g_file_error_quark() and
- *         #alsactl_card_error_quark().
+ * @self: A [class@Card].
+ * @card_id: The numeric ID of sound card.
+ * @open_flag: The flag of `open(2)` system call. O_RDONLY is forced to fulfil internally.
+ * @error: A [struct@GLib.Error]. Error is generated with two domains; `GLib.FileError` and
+ *         `ALSACtl.CardError`.
  *
  * Open ALSA control character device for the sound card.
  *
- * The call of function executes open(2) system call for ALSA control character
- * device.
+ * The call of function executes `open(2)` system call for ALSA control character device.
  */
-void alsactl_card_open(ALSACtlCard *self, guint card_id, gint open_flag,
-                       GError **error)
+void alsactl_card_open(ALSACtlCard *self, guint card_id, gint open_flag, GError **error)
 {
     ALSACtlCardPrivate *priv;
     char *devnode;
@@ -254,18 +251,16 @@ void alsactl_card_open(ALSACtlCard *self, guint card_id, gint open_flag,
 
 /**
  * alsactl_card_get_protocol_version:
- * @self: A #ALSACtlCard.
- * @proto_ver_triplet: (array fixed-size=3)(out)(transfer none): The version of
- *                     protocol currently used.
- * @error: A #GError.
+ * @self: A [class@Card].
+ * @proto_ver_triplet: (array fixed-size=3)(out)(transfer none): The version of protocol currently
+ *                     used.
+ * @error: A [struct@GLib.Error].
  *
- * Get the version of control protocol currently used. The version is
- * represented as the array with three elements; major, minor, and micro version
- * in the order. The length of major version is 16 bit, the length of minor
- * and micro version is 8 bit each.
+ * Get the version of control protocol currently used. The version is represented as the array with
+ * three elements; major, minor, and micro version in the order. The length of major version is
+ * 16 bit, the length of minor and micro version is 8 bit each.
  */
-void alsactl_card_get_protocol_version(ALSACtlCard *self,
-                                       const guint16 *proto_ver_triplet[3],
+void alsactl_card_get_protocol_version(ALSACtlCard *self, const guint16 *proto_ver_triplet[3],
                                        GError **error)
 {
     ALSACtlCardPrivate *priv;
@@ -282,17 +277,16 @@ void alsactl_card_get_protocol_version(ALSACtlCard *self,
 
 /**
  * alsactl_card_get_info:
- * @self: A #ALSACtlCard.
- * @card_info: (out): A #ALSACtlCardInfo for the sound card.
- * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
+ * @self: A [class@Card].
+ * @card_info: (out): A [class@Card]Info for the sound card.
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSACtl.CardError`.
  *
  * Get the information of sound card.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_CTL_IOCTL_CARD_INFO command for ALSA control character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_CTL_IOCTL_CARD_INFO` command
+ * for ALSA control character device.
  */
-void alsactl_card_get_info(ALSACtlCard *self, ALSACtlCardInfo **card_info,
-                           GError **error)
+void alsactl_card_get_info(ALSACtlCard *self, ALSACtlCardInfo **card_info, GError **error)
 {
     ALSACtlCardPrivate *priv;
     struct snd_ctl_card_info *info;
@@ -371,16 +365,15 @@ static inline void deallocate_elem_ids(struct snd_ctl_elem_list *list)
 
 /**
  * alsactl_card_get_elem_id_list:
- * @self: A #ALSACtlCard.
- * @entries: (element-type ALSACtl.ElemId)(out): The list of entries for
- *           ALSACtlElemId.
- * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
+ * @self: A [class@Card].
+ * @entries: (element-type ALSACtl.ElemId)(out): The list of entries for [struct@ElemId].
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSACtl.CardError`.
  *
- * Generate a list of ALSACtlElemId for ALSA control character device
- * associated to the sound card.
+ * Generate a list of [struct@ElemId] for ALSA control character device associated to the sound
+ * card.
  *
- * The call of function executes several ioctl(2) system call with
- * SNDRV_CTL_IOCTL_ELEM_LIST command for ALSA control character device.
+ * The call of function executes several `ioctl(2)` system call with `SNDRV_CTL_IOCTL_ELEM_LIST`
+ * command for ALSA control character device.
  */
 void alsactl_card_get_elem_id_list(ALSACtlCard *self, GList **entries,
                                    GError **error)
@@ -410,19 +403,18 @@ void alsactl_card_get_elem_id_list(ALSACtlCard *self, GList **entries,
 
 /**
  * alsactl_card_lock_elem:
- * @self: A #ALSACtlCard.
- * @elem_id: A #ALSACtlElemId.
+ * @self: A [class@Card].
+ * @elem_id: A [struct@ElemId].
  * @lock: whether to lock or unlock the element.
- * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSACtl.CardError`.
  *
  * Lock/Unlock indicated element not to be written by the other processes.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_CTL_IOCTL_ELEM_LOCK and SNDRV_CTL_IOCTL_ELEM_UNLOCK commands for
- * ALSA control character device..
+ * The call of function executes `ioctl(2)` system call with `SNDRV_CTL_IOCTL_ELEM_LOCK` and
+ * `SNDRV_CTL_IOCTL_ELEM_UNLOCK` commands for ALSA control character device.
  */
-void alsactl_card_lock_elem(ALSACtlCard *self, const ALSACtlElemId *elem_id,
-                            gboolean lock, GError **error)
+void alsactl_card_lock_elem(ALSACtlCard *self, const ALSACtlElemId *elem_id, gboolean lock,
+                            GError **error)
 {
     ALSACtlCardPrivate *priv;
     unsigned long req;
@@ -486,17 +478,16 @@ error:
 
 /**
  * alsactl_card_get_elem_info:
- * @self: A #ALSACtlCard.
- * @elem_id: A #ALSACtlElemId.
- * @elem_info: (out): A %ALSACtlElemInfo.
- * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
+ * @self: A [class@Card].
+ * @elem_id: A [struct@ElemId].
+ * @elem_info: (out): A [class@ElemInfo].
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSACtl.CardError`.
  *
  * Get information of element corresponding to given id.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_CTL_IOCTL_ELEM_INFO command for ALSA control character device. For
- * enumerated element, it executes the system call for several times to
- * retrieve all of enumeration labels.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_CTL_IOCTL_ELEM_INFO` command
+ * for ALSA control character device. For enumerated element, it executes the system call for
+ * several times to retrieve all of enumeration labels.
  */
 void alsactl_card_get_elem_info(ALSACtlCard *self, const ALSACtlElemId *elem_id,
                                 ALSACtlElemInfo **elem_info, GError **error)
@@ -558,23 +549,19 @@ void alsactl_card_get_elem_info(ALSACtlCard *self, const ALSACtlElemId *elem_id,
 
 /**
  * alsactl_card_write_elem_tlv:
- * @self: A #ALSACtlCard.
- * @elem_id: A #ALSACtlElemId.
- * @container: (array length=container_count): The array with qudalets for
- *             Type-Length-Value data.
+ * @self: A [class@Card].
+ * @elem_id: A [struct@ElemId].
+ * @container: (array length=container_count): The array with qudalets for Type-Length-Value data.
  * @container_count: The number of quadlets in the container.
- * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSACtl.CardError`.
  *
- * Write the given array of bytes as Type/Length/Value data for element pointed
- * by the identifier.
+ * Write the given array of bytes as Type/Length/Value data for element pointed by the identifier.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_CTL_IOCTL_TLV_WRITE command for ALSA control character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_CTL_IOCTL_TLV_WRITE` command
+ * for ALSA control character device.
  */
-void alsactl_card_write_elem_tlv(ALSACtlCard *self,
-                            const ALSACtlElemId *elem_id,
-                            const guint32 *container, gsize container_count,
-                            GError **error)
+void alsactl_card_write_elem_tlv(ALSACtlCard *self, const ALSACtlElemId *elem_id,
+                                 const guint32 *container, gsize container_count, GError **error)
 {
     ALSACtlCardPrivate *priv;
     struct snd_ctl_tlv *packet;
@@ -613,22 +600,21 @@ void alsactl_card_write_elem_tlv(ALSACtlCard *self,
 
 /**
  * alsactl_card_read_elem_tlv:
- * @self: A #ALSACtlCard.
- * @elem_id: A #ALSACtlElemId.
- * @container: (array length=container_count)(inout): The array with qudalets
- *             for Type-Length-Value data.
+ * @self: A [class@Card].
+ * @elem_id: A [struct@ElemId].
+ * @container: (array length=container_count)(inout): The array with qudalets for Type-Length-Value
+ *             data.
  * @container_count: The number of quadlets in the container.
- * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSACtl.CardError`.
  *
- * Read Type/Length/Value data from element pointed by the identifier and fulfil
- * the given array of bytes with the data.
+ * Read Type/Length/Value data from element pointed by the identifier and fulfil the given array of
+ * bytes with the data.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_CTL_IOCTL_TLV_READ command for ALSA control character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_CTL_IOCTL_TLV_READ` command for
+ * ALSA control character device.
  */
 void alsactl_card_read_elem_tlv(ALSACtlCard *self, const ALSACtlElemId *elem_id,
-                            guint32 *const *container, gsize *container_count,
-                            GError **error)
+                            guint32 *const *container, gsize *container_count, GError **error)
 {
     ALSACtlCardPrivate *priv;
     struct snd_ctl_tlv *packet;
@@ -667,23 +653,20 @@ void alsactl_card_read_elem_tlv(ALSACtlCard *self, const ALSACtlElemId *elem_id,
 
 /**
  * alsactl_card_command_elem_tlv:
- * @self: A #ALSACtlCard.
- * @elem_id: A #ALSACtlElemId.
- * @container: (array length=container_count)(inout): The array with qudalets
- *             for Type-Length-Value data.
+ * @self: A [class@Card].
+ * @elem_id: A [struct@ElemId].
+ * @container: (array length=container_count)(inout): The array with qudalets for Type-Length-Value
+ *             data.
  * @container_count: The number of quadlets in the container.
- * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSACtl.CardError`.
  *
- * Command the given array of bytes as Type/Length/Value data for  element
- * pointed by the identifier.
+ * Command the given array of bytes as Type/Length/Value data for element pointed by the identifier.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_CTL_IOCTL_TLV_COMMAND command for ALSA control character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_CTL_IOCTL_TLV_COMMAND` command
+ * for ALSA control character device.
  */
-void alsactl_card_command_elem_tlv(ALSACtlCard *self,
-                            const ALSACtlElemId *elem_id,
-                            guint32 *const *container, gsize *container_count,
-                            GError **error)
+void alsactl_card_command_elem_tlv(ALSACtlCard *self, const ALSACtlElemId *elem_id,
+                            guint32 *const *container, gsize *container_count, GError **error)
 {
     ALSACtlCardPrivate *priv;
     struct snd_ctl_tlv *packet;
@@ -829,17 +812,17 @@ static void add_or_replace_elems(int fd, const ALSACtlElemId *elem_id,
 
 /**
  * alsactl_card_add_elems:
- * @self: A #ALSACtlCard.
- * @elem_id: A #ALSACtlElemId.
+ * @self: A [class@Card].
+ * @elem_id: A [struct@ElemId].
  * @elem_count: The number of elements going to be added.
- * @elem_info: A %ALSACtlElemInfo.
- * @entries: (element-type ALSACtl.ElemId)(out): The list of added element IDs.
- * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
+ * @elem_info: A [class@ElemInfo].
+ * @entries: (element-type ALSACtl.ElemId)(out): The list of added element identifiers.
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSACtl.CardError`.
  *
  * Add the user-defined elements and return the list of their identifier.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_CTL_IOCTL_ELEM_ADD command for ALSA control character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_CTL_IOCTL_ELEM_ADD` command
+ * for ALSA control character device.
  */
 void alsactl_card_add_elems(ALSACtlCard *self, const ALSACtlElemId *elem_id,
                             guint elem_count, ALSACtlElemInfo *elem_info,
@@ -861,17 +844,17 @@ void alsactl_card_add_elems(ALSACtlCard *self, const ALSACtlElemId *elem_id,
 
 /**
  * alsactl_card_replace_elems:
- * @self: A #ALSACtlCard.
- * @elem_id: A #ALSACtlElemId.
+ * @self: A [class@Card].
+ * @elem_id: A [struct@ElemId].
  * @elem_count: The number of elements going to be added.
- * @elem_info: A %ALSACtlElemInfo.
- * @entries: (element-type ALSACtl.ElemId)(out): The list of renewed element IDs.
- * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
+ * @elem_info: A [class@ElemInfo].
+ * @entries: (element-type ALSACtl.ElemId)(out): The list of renewed element identifiers.
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSACtl.CardError`.
  *
  * Add user-defined elements to replace the existent ones.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_CTL_IOCTL_ELEM_REPLACE command for ALSA control character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_CTL_IOCTL_ELEM_REPLACE` command
+ * for ALSA control character device.
  */
 void alsactl_card_replace_elems(ALSACtlCard *self, const ALSACtlElemId *elem_id,
                             guint elem_count, ALSACtlElemInfo *elem_info,
@@ -893,14 +876,14 @@ void alsactl_card_replace_elems(ALSACtlCard *self, const ALSACtlElemId *elem_id,
 
 /**
  * alsactl_card_remove_elems:
- * @self: A #ALSACtlCard.
- * @elem_id: A #ALSACtlElemId.
- * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
+ * @self: A [class@Card].
+ * @elem_id: A [struct@ElemId].
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSACtl.CardError`.
  *
  * Remove user-defined elements pointed by the identifier.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_CTL_IOCTL_ELEM_REMOVE command for ALSA control character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_CTL_IOCTL_ELEM_REMOVE` command
+ * for ALSA control character device.
  */
 void alsactl_card_remove_elems(ALSACtlCard *self, const ALSACtlElemId *elem_id,
                                GError **error)
@@ -927,15 +910,15 @@ void alsactl_card_remove_elems(ALSACtlCard *self, const ALSACtlElemId *elem_id,
 
 /**
  * alsactl_card_write_elem_value:
- * @self: A #ALSACtlCard.
- * @elem_id: A #ALSACtlElemId.
+ * @self: A [class@Card].
+ * @elem_id: A [struct@ElemId].
  * @elem_value: A derivative of #ALSACtlElemValue.
- * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSACtl.CardError`.
  *
- * Write given value to element indicated by given ID.
+ * Write given value to element indicated by the given identifier.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_CTL_IOCTL_ELEM_WRITE command for ALSA control character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_CTL_IOCTL_ELEM_WRITE` command
+ * for ALSA control character device.
  */
 void alsactl_card_write_elem_value(ALSACtlCard *self,
                                    const ALSACtlElemId *elem_id,
@@ -969,18 +952,17 @@ void alsactl_card_write_elem_value(ALSACtlCard *self,
 
 /**
  * alsactl_card_read_elem_value:
- * @self: A #ALSACtlCard.
- * @elem_id: A #ALSACtlElemId.
+ * @self: A [class@Card].
+ * @elem_id: A [struct@ElemId].
  * @elem_value: (inout): A derivative of #ALSACtlElemValue.
- * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSACtl.CardError`.
  *
- * Read given value from element indicated by given ID.
+ * Read given value from element indicated by the given identifier.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_CTL_IOCTL_ELEM_READ command for ALSA control character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_CTL_IOCTL_ELEM_READ` command
+ * for ALSA control character device.
  */
-void alsactl_card_read_elem_value(ALSACtlCard *self,
-                                  const ALSACtlElemId *elem_id,
+void alsactl_card_read_elem_value(ALSACtlCard *self, const ALSACtlElemId *elem_id,
                                   ALSACtlElemValue *const *elem_value,
                                   GError **error)
 {
@@ -1097,14 +1079,14 @@ static void ctl_card_finalize_src(GSource *gsrc)
 
 /**
  * alsactl_card_create_source:
- * @self: A #ALSACtlCard.
- * @gsrc: (out): A #GSource to handle events from ALSA control character device.
- * @error: A #GError. Error is generated with domain of #alsactl_card_error_quark().
+ * @self: A [class@Card].
+ * @gsrc: (out): A [struct@GLib.Source] to handle events from ALSA control character device.
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSACtl.CardError`.
  *
- * Allocate GSource structure to handle events from ALSA control character
- * device. In each iteration of GManContext, the read(2) system call is
- * executed to dispatch control event for 'handle-elem-event' signal,
- * according to the result of poll(2) system call.
+ * Allocate [struct@GLib.Source] structure to handle events from ALSA control character device. In
+ * each iteration of [struct@GLib.MainContext], the `read(2)` system call is executed to dispatch
+ * control event for [signal@Card::handle-elem-event] signal, according to the result of `poll(2)`
+ * system call.
  */
 void alsactl_card_create_source(ALSACtlCard *self, GSource **gsrc,
                                 GError **error)

--- a/src/ctl/card.h
+++ b/src/ctl/card.h
@@ -19,23 +19,20 @@ struct _ALSACtlCardClass {
 
     /**
      * ALSACtlCardClass::handle_elem_event:
-     * @self: A #ALSACtlCard.
-     * @elem_id: (transfer none): A #ALSACtlElemId.
-     * @events: A set of #ALSACtlElemEventMask.
+     * @self: A [class@Card].
+     * @elem_id: (transfer none): A [struct@ElemId].
+     * @events: A set of [flags@ElemEventMask].
      *
-     * When event occurs for any element, this signal is emit.
+     * Class closure for the [signal@Card::handle-elem-event] signal.
      */
     void (*handle_elem_event)(ALSACtlCard *self, const ALSACtlElemId *elem_id,
                               ALSACtlElemEventMask events);
 
     /**
      * ALSACtlCardClass::handle_disconnection:
-     * @self: A #ALSACtlCard.
+     * @self: A [class@Card].
      *
-     * When the sound card is not available anymore due to unbinding driver or
-     * hot unplugging, this signal is emit. The owner of this object should
-     * call g_object_free() as quickly as possible to be going to release ALSA
-     * control character device.
+     * Class closure for the [signal@Card::handle-disconnection] signal.
      */
     void (*handle_disconnection)(ALSACtlCard *self);
 };

--- a/src/ctl/elem-id.c
+++ b/src/ctl/elem-id.c
@@ -2,16 +2,14 @@
 #include "privates.h"
 
 /**
- * SECTION: elem-id
- * @Title: ALSACtlElemId
- * @Short_description: A boxed object to represent the identifier of element.
+ * ALSACtlElemId:
+ * A boxed object to represent the identifier of element.
  *
- * A #ALSACtlElemId is a boxed object to represent the identifier of element.
- * It points to a element by two ways; by the numerical ID, or by the
- * combination of the type of interface, the numerical ID of device, the
- * numerical ID of subdevice, the name, and the index.
+ * A [struct@ElemId] is a boxed object to represent the identifier of element. It points to a
+ * element by two ways; by the numeric identifier, or by the combination of the type of interface,
+ * the numeric identifier of device, the numeric identifier of subdevice, the name, and the index.
  *
- * The object wraps 'struct snd_ctl_elem_id' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_ctl_elem_id` in UAPI of Linux sound subsystem.
  */
 ALSACtlElemId *ctl_elem_id_copy(const ALSACtlElemId *self)
 {
@@ -30,11 +28,11 @@ G_DEFINE_BOXED_TYPE(ALSACtlElemId, alsactl_elem_id, ctl_elem_id_copy, g_free);
 
 /**
  * alsactl_elem_id_new_by_numid:
- * @numid: The numerical ID of the element.
+ * @numid: The numeric identifier of the element.
  *
- * Allocates and return an instance of ALSACtlElemId by the numerical ID.
+ * Allocates and return an instance of [struct@ElemId] by the numeric identifier.
  *
- * Returns: A #ALSACtlElemId.
+ * Returns: A [struct@ElemId].
  */
 ALSACtlElemId *alsactl_elem_id_new_by_numid(guint numid)
 {
@@ -49,15 +47,15 @@ ALSACtlElemId *alsactl_elem_id_new_by_numid(guint numid)
 /**
  * alsactl_elem_id_new_by_name:
  * @iface:          The interface of element, one of ALSACtlElemIfaceType.
- * @device_id:      The numerical ID of device to which the element belongs.
- * @subdevice_id:   The numerical ID of subdevice to which the element belongs.
- * @name:           The name of element, up to 44 byte
- *                  (=SNDRV_CTL_ELEM_ID_NAME_MAXLEN) including terminator.
+ * @device_id:      The numeric identifier of device to which the element belongs.
+ * @subdevice_id:   The numeric identifier of subdevice to which the element belongs.
+ * @name:           The name of element, up to 44 byte (=`SNDRV_CTL_ELEM_ID_NAME_MAXLEN`) including
+ *                  terminator.
  * @index:          The index of element in a set of elements with the same name.
  *
- * Allocates and return an instance of ALSACtlElemId by the name.
+ * Allocates and return an instance of [struct@ElemId] by the name.
  *
- * Returns: A #ALSACtlElemId.
+ * Returns: A [struct@ElemId].
  */
 ALSACtlElemId *alsactl_elem_id_new_by_name(ALSACtlElemIfaceType iface,
                                            guint device_id, guint subdevice_id,
@@ -80,10 +78,10 @@ ALSACtlElemId *alsactl_elem_id_new_by_name(ALSACtlElemIfaceType iface,
 
 /**
  * alsactl_elem_id_get_numid:
- * @self: A #ALSACtlElemId.
- * @numid: (out): The numerical ID of element.
+ * @self: A [struct@ElemId].
+ * @numid: (out): The numeric identifier of element.
  *
- * Get the numerical ID of element.
+ * Get the numeric identifier of element.
  */
 void alsactl_elem_id_get_numid(const ALSACtlElemId *self, guint *numid)
 {
@@ -92,7 +90,7 @@ void alsactl_elem_id_get_numid(const ALSACtlElemId *self, guint *numid)
 
 /**
  * alsactl_elem_id_get_iface:
- * @self: A #ALSACtlElemId.
+ * @self: A [struct@ElemId].
  * @iface: (out): The interface of element.
  *
  * Get the interface of element.
@@ -105,10 +103,10 @@ void alsactl_elem_id_get_iface(const ALSACtlElemId *self,
 
 /**
  * alsactl_elem_id_get_device_id:
- * @self: A #ALSACtlElemId.
- * @device_id: (out): The numerical ID of device to which the element belongs.
+ * @self: A [struct@ElemId].
+ * @device_id: (out): The numeric identifier of device to which the element belongs.
  *
- * Get the numerical ID of device to which the element belongs.
+ * Get the numeric identifier of device to which the element belongs.
  */
 void alsactl_elem_id_get_device_id(const ALSACtlElemId *self, guint *device_id)
 {
@@ -117,10 +115,10 @@ void alsactl_elem_id_get_device_id(const ALSACtlElemId *self, guint *device_id)
 
 /**
  * alsactl_elem_id_get_subdevice_id:
- * @self: A #ALSACtlElemId.
- * @subdevice_id: (out): The numerical ID of subdevice to which the element belongs.
+ * @self: A [struct@ElemId].
+ * @subdevice_id: (out): The numeric identifier of subdevice to which the element belongs.
  *
- * Get the numerical ID of element.
+ * Get the numeric identifier of element.
  */
 void alsactl_elem_id_get_subdevice_id(const ALSACtlElemId *self,
                                       guint *subdevice_id)
@@ -130,7 +128,7 @@ void alsactl_elem_id_get_subdevice_id(const ALSACtlElemId *self,
 
 /**
  * alsactl_elem_id_get_name:
- * @self: A #ALSACtlElemId.
+ * @self: A [struct@ElemId].
  * @name: (transfer none)(out): The name of element.
  *
  * Get the name of element.
@@ -142,7 +140,7 @@ void alsactl_elem_id_get_name(const ALSACtlElemId *self, const gchar **name)
 
 /**
  * alsactl_elem_id_get_index:
- * @self: A #ALSACtlElemId.
+ * @self: A [struct@ElemId].
  * @index: (out): The index of element.
  *
  * Get the index of element.
@@ -154,8 +152,8 @@ void alsactl_elem_id_get_index(const ALSACtlElemId *self, guint *index)
 
 /**
  * alsactl_elem_id_equal:
- * @self: A #ALSACtlElemId.
- * @target: A #ALSACtlElemId to compare.
+ * @self: A [struct@ElemId].
+ * @target: A [struct@ElemId] to compare.
  *
  * Returns: whether the given object indicates the same element.
  */

--- a/src/ctl/elem-info.c
+++ b/src/ctl/elem-info.c
@@ -4,15 +4,13 @@
 #include <errno.h>
 
 /**
- * SECTION: elem-info
- * @Title: ALSACtlElemInfo
- * @Short_description: An GObject-derived object to represent the information
- *                     of any type of element
+ * ALSACtlElemInfo:
+ * An GObject-derived object to represent the information of any type of element.
  *
- * A #ALSACtlElemInfo is an GObject-derived object to represent the information
- * of any type of element.
+ * A [class@ElemInfo] is an GObject-derived object to represent the information of any type of
+ * element.
  *
- * The object wraps 'struct snd_ctl_elem_info' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_ctl_elem_info` in UAPI of Linux sound subsystem.
  */
 typedef struct {
     struct snd_ctl_elem_info info;
@@ -155,12 +153,12 @@ static void alsactl_elem_info_init(ALSACtlElemInfo *self)
 
 /**
  * alsactl_elem_info_new:
- * @elem_type: The type of element, one of #ALSACtlElemType.
- * @error: A #GError.
+ * @elem_type: The type of element, one of [enum@ElemType].
+ * @error: A [struct@GLib.Error].
  *
- * Allocate and return the instance of #ALSACtlElemInfo.
+ * Allocate and return the instance of [class@ElemInfo].
  *
- * Returns: A #ALSACtlElemInfo.
+ * Returns: An instance of [class@ElemInfo].
  */
 ALSACtlElemInfo *alsactl_elem_info_new(ALSACtlElemType elem_type, GError **error)
 {
@@ -183,18 +181,16 @@ ALSACtlElemInfo *alsactl_elem_info_new(ALSACtlElemType elem_type, GError **error
 
 /**
  * alsactl_elem_info_get_int_data:
- * @self: A #ALSACtlElemInfo.
- * @data: (array fixed-size=3)(out)(transfer none): The array with elements for
- *        the data of integer element; minimum value, maximum value, and value
- *        step in the order.
- * @error: A #GError.
+ * @self: A [class@ElemInfo].
+ * @data: (array fixed-size=3)(out)(transfer none): The array with elements for the data of integer
+ *        element; minimum value, maximum value, and value step in the order.
+ * @error: A [struct@GLib.Error].
  *
- * Refer to the array with elements for the data of integer element; minimum
- * value, maximum value, and value step in the order. The call of function is
- * successful as long as the information is for integer type.
+ * Refer to the array with elements for the data of integer element; minimum value, maximum value,
+ * and value step in the order. The call of function is successful as long as the information is
+ * for integer type.
  */
-void alsactl_elem_info_get_int_data(ALSACtlElemInfo *self,
-                                    const gint32 *data[3], GError **error)
+void alsactl_elem_info_get_int_data(ALSACtlElemInfo *self, const gint32 *data[3], GError **error)
 {
     ALSACtlElemInfoPrivate *priv;
 
@@ -215,18 +211,16 @@ void alsactl_elem_info_get_int_data(ALSACtlElemInfo *self,
 
 /**
  * alsactl_elem_info_set_int_data:
- * @self: A #ALSACtlElemInfo.
- * @data: (array fixed-size=3)(transfer none): The array with elements for
- *        the data of integer element; minimum value, maximum value, and value
- *        step in the order.
- * @error: A #GError.
+ * @self: A [class@ElemInfo].
+ * @data: (array fixed-size=3)(transfer none): The array with elements for the data of integer
+ *        element; minimum value, maximum value, and value step in the order.
+ * @error: A [struct@GLib.Error].
  *
- * Get the array with elements for the data of integer element; minimum value,
- * maximum value, and value step in the order. The call of function is
- * successful as long as the information is for integer type.
+ * Get the array with elements for the data of integer element; minimum value, maximum value, and
+ * value step in the order. The call of function is successful as long as the information is for
+ * integer type.
  */
-void alsactl_elem_info_set_int_data(ALSACtlElemInfo *self,
-                                    const gint32 data[3], GError **error)
+void alsactl_elem_info_set_int_data(ALSACtlElemInfo *self, const gint32 data[3], GError **error)
 {
     ALSACtlElemInfoPrivate *priv;
 
@@ -245,18 +239,16 @@ void alsactl_elem_info_set_int_data(ALSACtlElemInfo *self,
 
 /**
  * alsactl_elem_info_get_int64_data:
- * @self: A #ALSACtlElemInfo.
- * @data: (array fixed-size=3)(out)(transfer none): The array with elements for
- *        the data of integer64 element; minimum value, maximum value, and value
- *        step in the order.
- * @error: A #GError.
+ * @self: A [class@ElemInfo].
+ * @data: (array fixed-size=3)(out)(transfer none): The array with elements for the data of
+ *        integer64 element; minimum value, maximum value, and value step in the order.
+ * @error: A [struct@GLib.Error].
  *
- * Refer to the array with elements for the data of integer64 element; minimum
- * value, maximum value, and value step in the order. The call of function is
- * successful as long as the information is for integer64 type.
+ * Refer to the array with elements for the data of integer64 element; minimum value, maximum
+ * value, and value step in the order. The call of function is successful as long as the
+ * information is for integer64 type.
  */
-void alsactl_elem_info_get_int64_data(ALSACtlElemInfo *self,
-                                      const gint64 *data[3], GError **error)
+void alsactl_elem_info_get_int64_data(ALSACtlElemInfo *self, const gint64 *data[3], GError **error)
 {
     ALSACtlElemInfoPrivate *priv;
 
@@ -277,18 +269,16 @@ void alsactl_elem_info_get_int64_data(ALSACtlElemInfo *self,
 
 /**
  * alsactl_elem_info_set_int64_data:
- * @self: A #ALSACtlElemInfo.
- * @data: (array fixed-size=3)(transfer none): The array with elements for
- *        the data of integer64 element; minimum value, maximum value, and value
- *        step in the order.
- * @error: A #GError.
+ * @self: A [class@ElemInfo].
+ * @data: (array fixed-size=3)(transfer none): The array with elements for the data of integer64
+ *        element; minimum value, maximum value, and value step in the order.
+ * @error: A [struct@GLib.Error].
  *
- * Get the array with elements for the data of integer64 element; minimum value,
- * maximum value, and value step in the order. The call of function is
- * successful as long as the information is for integer64 type.
+ * Get the array with elements for the data of integer64 element; minimum value, maximum value, and
+ * value step in the order. The call of function is successful as long as the information is for
+ * integer64 type.
  */
-void alsactl_elem_info_set_int64_data(ALSACtlElemInfo *self,
-                                      const gint64 data[3], GError **error)
+void alsactl_elem_info_set_int64_data(ALSACtlElemInfo *self, const gint64 data[3], GError **error)
 {
     ALSACtlElemInfoPrivate *priv;
 
@@ -307,17 +297,15 @@ void alsactl_elem_info_set_int64_data(ALSACtlElemInfo *self,
 
 /**
  * alsactl_elem_info_get_enum_data:
- * @self: A #ALSACtlElemInfo.
- * @data: (array zero-terminated=1)(out)(transfer none): The array with elements
- *        for the label entries of enumerated element.
- * @error: A #GError.
+ * @self: A [class@ElemInfo].
+ * @data: (array zero-terminated=1)(out)(transfer none): The array with elements for the label
+ *        entries of enumerated element.
+ * @error: A [struct@GLib.Error].
  *
- * Refer to the array with elements for the label entries of enumerated element
- * in internal storage. The call of function is successful as long as the
- * information is for enumerated type.
+ * Refer to the array with elements for the label entries of enumerated element in internal storage.
+ * The call of function is successful as long as the information is for enumerated type.
  */
-void alsactl_elem_info_get_enum_data(ALSACtlElemInfo *self,
-                                     const gchar ***data, GError **error)
+void alsactl_elem_info_get_enum_data(ALSACtlElemInfo *self, const gchar ***data, GError **error)
 {
     ALSACtlElemInfoPrivate *priv;
 
@@ -334,17 +322,15 @@ void alsactl_elem_info_get_enum_data(ALSACtlElemInfo *self,
 
 /**
  * alsactl_elem_info_set_enum_data:
- * @self: A #ALSACtlElemInfo.
- * @data: (array zero-terminated=1): The array with elements for the label
- *        entries of enumerated element.
- * @error: A #GError.
+ * @self: A [class@ElemInfo].
+ * @data: (array zero-terminated=1): The array with elements for the label entries of enumerated
+ *        element.
+ * @error: A [struct@GLib.Error].
  *
- * Copy the array with elements for the label entries of enumerated element
- * into internal storage. The call of function is successful as long as the
- * information is for enumerated type.
+ * Copy the array with elements for the label entries of enumerated element into internal storage.
+ * The call of function is successful as long as the information is for enumerated type.
  */
-void alsactl_elem_info_set_enum_data(ALSACtlElemInfo *self,
-                                     const gchar **data, GError **error)
+void alsactl_elem_info_set_enum_data(ALSACtlElemInfo *self, const gchar **data, GError **error)
 {
     ALSACtlElemInfoPrivate *priv;
 
@@ -361,8 +347,7 @@ void alsactl_elem_info_set_enum_data(ALSACtlElemInfo *self,
     priv->enum_data = g_strdupv((gchar **)data);
 }
 
-void ctl_elem_info_refer_private(ALSACtlElemInfo *self,
-                                 struct snd_ctl_elem_info **info)
+void ctl_elem_info_refer_private(ALSACtlElemInfo *self, struct snd_ctl_elem_info **info)
 {
     ALSACtlElemInfoPrivate *priv = alsactl_elem_info_get_instance_private(self);
 

--- a/src/ctl/elem-info.h
+++ b/src/ctl/elem-info.h
@@ -16,20 +16,14 @@ struct _ALSACtlElemInfoClass {
 
 ALSACtlElemInfo *alsactl_elem_info_new(ALSACtlElemType elem_type, GError **error);
 
-void alsactl_elem_info_get_int_data(ALSACtlElemInfo *self,
-                                    const gint32 *data[3], GError **error);
-void alsactl_elem_info_set_int_data(ALSACtlElemInfo *self,
-                                    const gint32 data[3], GError **error);
+void alsactl_elem_info_get_int_data(ALSACtlElemInfo *self, const gint32 *data[3], GError **error);
+void alsactl_elem_info_set_int_data(ALSACtlElemInfo *self, const gint32 data[3], GError **error);
 
-void alsactl_elem_info_get_int64_data(ALSACtlElemInfo *self,
-                                      const gint64 *data[3], GError **error);
-void alsactl_elem_info_set_int64_data(ALSACtlElemInfo *self,
-                                      const gint64 data[3], GError **error);
+void alsactl_elem_info_get_int64_data(ALSACtlElemInfo *self, const gint64 *data[3], GError **error);
+void alsactl_elem_info_set_int64_data(ALSACtlElemInfo *self, const gint64 data[3], GError **error);
 
-void alsactl_elem_info_get_enum_data(ALSACtlElemInfo *self,
-                                     const gchar ***data, GError **error);
-void alsactl_elem_info_set_enum_data(ALSACtlElemInfo *self,
-                                     const gchar **data, GError **error);
+void alsactl_elem_info_get_enum_data(ALSACtlElemInfo *self, const gchar ***data, GError **error);
+void alsactl_elem_info_set_enum_data(ALSACtlElemInfo *self, const gchar **data, GError **error);
 
 G_END_DECLS
 

--- a/src/ctl/elem-value.c
+++ b/src/ctl/elem-value.c
@@ -2,18 +2,16 @@
 #include "privates.h"
 
 /**
- * SECTION: elem-value
- * @Title: ALSACtlElemValue
- * @Short_description: A boxed object to represent the container of array of
- *                     values for any type of element.
+ * ALSACtlElemValue:
+ * A boxed object to represent the container of array of values for any type of element.
  *
- * A #ALSACtlElemValue is boxed object to represent the container of values for
- * any type of element. The arrays of values for each type of element shares the
- * same storage, thus it's important for applications to distinguish the type of
- * element in advance of accessing the array. The object is used for the call of
- * alsactl_card_write_elem_value() and alsactl_card_read_elem_value().
+ * A [class@ElemValue] is boxed object to represent the container of values for any type of
+ * element. The arrays of values for each type of element shares the same storage, thus it's
+ * important for applications to distinguish the type of element in advance of accessing the
+ * array. The object is used for the call of [method@Card.write_elem_value] and
+ * [method@Card.read_elem_value].
  *
- * The object wraps 'struct snd_ctl_elem_value' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_ctl_elem_value` in UAPI of Linux sound subsystem.
  */
 typedef struct {
     struct snd_ctl_elem_value value;
@@ -69,17 +67,16 @@ static void alsactl_elem_value_init(ALSACtlElemValue *self)
 /**
  * alsactl_elem_value_new:
  *
- * Allocate and return an instance of ALSACtlElemValue.
+ * Allocate and return an instance of [class@ElemValue].
  *
- * Returns: A #ALSACtlElemValue.
+ * Returns: An instance of [class@ElemValue].
  */
 ALSACtlElemValue *alsactl_elem_value_new()
 {
     return g_object_new(ALSACTL_TYPE_ELEM_VALUE, NULL);
 }
 
-void ctl_elem_value_refer_private(ALSACtlElemValue *self,
-                                  struct snd_ctl_elem_value **value)
+void ctl_elem_value_refer_private(ALSACtlElemValue *self, struct snd_ctl_elem_value **value)
 {
     ALSACtlElemValuePrivate *priv =
                                 alsactl_elem_value_get_instance_private(self);
@@ -88,14 +85,13 @@ void ctl_elem_value_refer_private(ALSACtlElemValue *self,
 
 /**
  * alsactl_elem_value_set_bool:
- * @self: A #ALSACtlElemValue.
+ * @self: A [class@ElemValue].
  * @values: (array length=value_count): The array for values of boolean type.
  * @value_count: The number of values up to 128.
  *
  * Copy the array for values of boolean type into internal data.
  */
-void alsactl_elem_value_set_bool(ALSACtlElemValue *self,
-                                 const gboolean *values, gsize value_count)
+void alsactl_elem_value_set_bool(ALSACtlElemValue *self, const gboolean *values, gsize value_count)
 {
     ALSACtlElemValuePrivate *priv;
     struct snd_ctl_elem_value *value;
@@ -114,15 +110,14 @@ void alsactl_elem_value_set_bool(ALSACtlElemValue *self,
 
 /**
  * alsactl_elem_value_get_bool:
- * @self: A #ALSACtlElemValue.
- * @values: (array length=value_count)(inout): The array for values of boolean
- *          type.
+ * @self: A [class@ElemValue].
+ * @values: (array length=value_count)(inout): The array for values of boolean type.
  * @value_count: The number of values up to 128.
  *
  * Copy the array for values of boolean type from internal data.
  */
-void alsactl_elem_value_get_bool(ALSACtlElemValue *self,
-                                 gboolean *const *values, gsize *value_count)
+void alsactl_elem_value_get_bool(ALSACtlElemValue *self, gboolean *const *values,
+                                 gsize *value_count)
 {
     ALSACtlElemValuePrivate *priv;
     struct snd_ctl_elem_value *value;
@@ -142,14 +137,13 @@ void alsactl_elem_value_get_bool(ALSACtlElemValue *self,
 
 /**
  * alsactl_elem_value_set_int:
- * @self: A #ALSACtlElemValue.
+ * @self: A [class@ElemValue].
  * @values: (array length=value_count): The array for values of integer type.
  * @value_count: The number of values up to 128.
  *
  * Copy the array for values of integer type into internal storage.
  */
-void alsactl_elem_value_set_int(ALSACtlElemValue *self, const gint32 *values,
-                                gsize value_count)
+void alsactl_elem_value_set_int(ALSACtlElemValue *self, const gint32 *values, gsize value_count)
 {
     ALSACtlElemValuePrivate *priv;
     struct snd_ctl_elem_value *value;
@@ -168,15 +162,14 @@ void alsactl_elem_value_set_int(ALSACtlElemValue *self, const gint32 *values,
 
 /**
  * alsactl_elem_value_get_int:
- * @self: A #ALSACtlElemValue.
+ * @self: A [class@ElemValue].
  * @values: (array length=value_count)(inout): The array for values of integer
  *          type.
  * @value_count: The number of values up to 128.
  *
  * Copy the array for values of integer type from internal storage.
  */
-void alsactl_elem_value_get_int(ALSACtlElemValue *self, gint32 *const *values,
-                                gsize *value_count)
+void alsactl_elem_value_get_int(ALSACtlElemValue *self, gint32 *const *values, gsize *value_count)
 {
     ALSACtlElemValuePrivate *priv;
     struct snd_ctl_elem_value *value;
@@ -196,15 +189,13 @@ void alsactl_elem_value_get_int(ALSACtlElemValue *self, gint32 *const *values,
 
 /**
  * alsactl_elem_value_set_enum:
- * @self: A #ALSACtlElemValue.
- * @values: (array length=value_count): The array for values of enumeration
- *          index.
+ * @self: A [class@ElemValue].
+ * @values: (array length=value_count): The array for values of enumeration index.
  * @value_count: The number of values up to 128.
  *
  * Copy the array for values of enumeration index into internal storage.
  */
-void alsactl_elem_value_set_enum(ALSACtlElemValue *self,
-                                 const guint32 *values, gsize value_count)
+void alsactl_elem_value_set_enum(ALSACtlElemValue *self, const guint32 *values, gsize value_count)
 {
     ALSACtlElemValuePrivate *priv;
     struct snd_ctl_elem_value *value;
@@ -223,15 +214,13 @@ void alsactl_elem_value_set_enum(ALSACtlElemValue *self,
 
 /**
  * alsactl_elem_value_get_enum:
- * @self: A #ALSACtlElemValue.
- * @values: (array length=value_count)(inout): The array for values of
- *          enumeration index.
+ * @self: A [class@ElemValue].
+ * @values: (array length=value_count)(inout): The array for values of enumeration index.
  * @value_count: The number of values up to 128.
  *
  * Copy the array for values of enumeration index from internal storage.
  */
-void alsactl_elem_value_get_enum(ALSACtlElemValue *self,
-                                 guint32 *const *values, gsize *value_count)
+void alsactl_elem_value_get_enum(ALSACtlElemValue *self, guint32 *const *values, gsize *value_count)
 {
     ALSACtlElemValuePrivate *priv;
     struct snd_ctl_elem_value *value;
@@ -251,14 +240,13 @@ void alsactl_elem_value_get_enum(ALSACtlElemValue *self,
 
 /**
  * alsactl_elem_value_set_bytes:
- * @self: A #ALSACtlElemValue.
+ * @self: A [class@ElemValue].
  * @values: (array length=value_count): The array for values of bytes type.
  * @value_count: The number of values up to 512.
  *
  * Copy the array for values of bytes type into internal storage.
  */
-void alsactl_elem_value_set_bytes(ALSACtlElemValue *self,
-                                  const guint8 *values, gsize value_count)
+void alsactl_elem_value_set_bytes(ALSACtlElemValue *self, const guint8 *values, gsize value_count)
 {
     ALSACtlElemValuePrivate *priv;
     struct snd_ctl_elem_value *value;
@@ -277,14 +265,13 @@ void alsactl_elem_value_set_bytes(ALSACtlElemValue *self,
 
 /**
  * alsactl_elem_value_get_bytes:
- * @self: A #ALSACtlElemValue.
+ * @self: A [class@ElemValue].
  * @values: (array length=value_count)(inout): The array for values of bytes type.
  * @value_count: The number of values up to 512.
  *
  * Copy the array for values of bytes type into internal storage.
  */
-void alsactl_elem_value_get_bytes(ALSACtlElemValue *self,
-                                  guint8 *const *values, gsize *value_count)
+void alsactl_elem_value_get_bytes(ALSACtlElemValue *self, guint8 *const *values, gsize *value_count)
 {
     ALSACtlElemValuePrivate *priv;
     struct snd_ctl_elem_value *value;
@@ -304,15 +291,14 @@ void alsactl_elem_value_get_bytes(ALSACtlElemValue *self,
 
 /**
  * alsactl_elem_value_set_iec60958_channel_status:
- * @self: A #ALSACtlElemValue.
- * @status: (array length=length): The array of byte data for channel status
- *          bits in IEC 60958.
+ * @self: A [class@ElemValue].
+ * @status: (array length=length): The array of byte data for channel status bits in IEC 60958.
  * @length: The number of bytes in channel_status argument, up to 24.
  *
  * Copy the given channel status of IEC 60958 into internal storage.
  */
-void alsactl_elem_value_set_iec60958_channel_status(ALSACtlElemValue *self,
-                                        const guint8 *status, gsize length)
+void alsactl_elem_value_set_iec60958_channel_status(ALSACtlElemValue *self, const guint8 *status,
+                                                    gsize length)
 {
     ALSACtlElemValuePrivate *priv;
     struct snd_ctl_elem_value *value;
@@ -331,15 +317,15 @@ void alsactl_elem_value_set_iec60958_channel_status(ALSACtlElemValue *self,
 
 /**
  * alsactl_elem_value_get_iec60958_channel_status:
- * @self: A #ALSACtlElemValue.
- * @status: (array length=length)(inout): The array of byte data for channel
- *          status bits for IEC 60958 element.
+ * @self: A [class@ElemValue].
+ * @status: (array length=length)(inout): The array of byte data for channel status bits for
+ *          IEC 60958 element.
  * @length: The number of bytes in status argument, up to 24.
  *
  * Copy channel status of IEC 60958 from internal storage.
  */
-void alsactl_elem_value_get_iec60958_channel_status(ALSACtlElemValue *self,
-                                        guint8 *const *status, gsize *length)
+void alsactl_elem_value_get_iec60958_channel_status(ALSACtlElemValue *self, guint8 *const *status,
+                                                    gsize *length)
 {
     ALSACtlElemValuePrivate *priv;
     struct snd_ctl_elem_value *value;
@@ -359,15 +345,14 @@ void alsactl_elem_value_get_iec60958_channel_status(ALSACtlElemValue *self,
 
 /**
  * alsactl_elem_value_set_iec60958_user_data:
- * @self: A #ALSACtlElemValue.
- * @data: (array length=length): The array of byte data for user data bits in
- *        IEC 60958.
+ * @self: A [class@ElemValue].
+ * @data: (array length=length): The array of byte data for user data bits in IEC 60958.
  * @length: The number of bytes in data argument, up to 147.
  *
  * Copy the given user data of IEC 60958 into internal storage.
  */
-void alsactl_elem_value_set_iec60958_user_data(ALSACtlElemValue *self,
-                                        const guint8 *data, gsize length)
+void alsactl_elem_value_set_iec60958_user_data(ALSACtlElemValue *self, const guint8 *data,
+                                               gsize length)
 {
     ALSACtlElemValuePrivate *priv;
     struct snd_ctl_elem_value *value;
@@ -386,15 +371,14 @@ void alsactl_elem_value_set_iec60958_user_data(ALSACtlElemValue *self,
 
 /**
  * alsactl_elem_value_get_iec60958_user_data:
- * @self: A #ALSACtlElemValue.
- * @data: (array length=length)(inout): The array of byte data for user data
- *        bits in IEC 60958.
+ * @self: A [class@ElemValue].
+ * @data: (array length=length)(inout): The array of byte data for user data bits in IEC 60958.
  * @length: The number of bytes in user_data argument, up to 147.
  *
  * Copy user data of IEC 60958 from internal storage.
  */
-void alsactl_elem_value_get_iec60958_user_data(ALSACtlElemValue *self,
-                                        guint8 *const *data, gsize *length)
+void alsactl_elem_value_get_iec60958_user_data(ALSACtlElemValue *self, guint8 *const *data,
+                                               gsize *length)
 {
     ALSACtlElemValuePrivate *priv;
     struct snd_ctl_elem_value *value;
@@ -414,14 +398,13 @@ void alsactl_elem_value_get_iec60958_user_data(ALSACtlElemValue *self,
 
 /**
  * alsactl_elem_value_set_int64:
- * @self: A #ALSACtlElemValue.
+ * @self: A [class@ElemValue].
  * @values: (array length=value_count): The array for values of integer64 type.
  * @value_count: The number of values up to 64.
  *
  * Copy the array for values of integer64 type into internal storage.
  */
-void alsactl_elem_value_set_int64(ALSACtlElemValue *self, const gint64 *values,
-                                  gsize value_count)
+void alsactl_elem_value_set_int64(ALSACtlElemValue *self, const gint64 *values, gsize value_count)
 {
     ALSACtlElemValuePrivate *priv;
     struct snd_ctl_elem_value *value;
@@ -440,15 +423,13 @@ void alsactl_elem_value_set_int64(ALSACtlElemValue *self, const gint64 *values,
 
 /**
  * alsactl_elem_value_get_int64:
- * @self: A #ALSACtlElemValue.
- * @values: (array length=value_count)(inout): The array for values of integer64
- *          type.
+ * @self: A [class@ElemValue].
+ * @values: (array length=value_count)(inout): The array for values of integer64 type.
  * @value_count: The number of values up to 64.
  *
  * Copy the array for values of integer64 type from internal storage.
  */
-void alsactl_elem_value_get_int64(ALSACtlElemValue *self,
-                                  gint64 *const *values, gsize *value_count)
+void alsactl_elem_value_get_int64(ALSACtlElemValue *self, gint64 *const *values, gsize *value_count)
 {
     ALSACtlElemValuePrivate *priv;
     struct snd_ctl_elem_value *value;
@@ -468,14 +449,14 @@ void alsactl_elem_value_get_int64(ALSACtlElemValue *self,
 
 /**
  * alsactl_elem_value_equal:
- * @self: A #ALSACtlElemValue.
- * @target: A #ALSACtlElemValue to compare.
+ * @self: A [class@ElemValue].
+ * @target: A [class@ElemValue] to compare.
  *
- * Returns: whether the given object includes the same values as the instance.
- *          The other fields are ignored to be compared.
+ * Returns: Whether the given object includes the same values as the instance. The other fields are
+ *          ignored to be compared.
  */
-gboolean alsactl_elem_value_equal(const ALSACtlElemValue *self,
-                                  const ALSACtlElemValue *target) {
+gboolean alsactl_elem_value_equal(const ALSACtlElemValue *self, const ALSACtlElemValue *target)
+{
     const ALSACtlElemValuePrivate *lhs, *rhs;
 
     g_return_val_if_fail(ALSACTL_IS_ELEM_VALUE((ALSACtlElemValue *)self), FALSE);

--- a/src/ctl/query.c
+++ b/src/ctl/query.c
@@ -4,20 +4,12 @@
 #include <utils.h>
 
 /**
- * SECTION: query
- * @Title: Global functions in ALSACtl
- * @Short_description: Global functions available without holding any file
- *                     descriptor
- */
-
-/**
  * alsactl_get_card_id_list:
- * @entries: (array length=entry_count)(out): The list of numerical ID for sound
- *           cards.
+ * @entries: (array length=entry_count)(out): The list of numeric ID for sound cards.
  * @entry_count: The number of entries.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with `GLib.FileError` domain.
  *
- * Get the list of numerical ID for available sound cards.
+ * Get the list of numeric ID for available sound cards.
  *
  * Nodes under sound subsystem in sysfs are used to gather the information.
  */
@@ -37,9 +29,9 @@ void alsactl_get_card_id_list(guint **entries, gsize *entry_count,
 
 /**
  * alsactl_get_card_sysname:
- * @card_id: The numeridcal ID of sound card.
+ * @card_id: The numeric ID of sound card.
  * @sysname: (out): The string for sysname of the sound card.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
  * Allocate sysname for the sound card and return it when it exists.
  *
@@ -61,10 +53,9 @@ void alsactl_get_card_sysname(guint card_id, char **sysname, GError **error)
  * alsactl_get_control_sysname:
  * @card_id: The numeridcal ID of sound card.
  * @sysname: (out): The string for sysname of control device for the sound card.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
- * Allocate sysname of control device for the sound card and return it when
- * it exists.
+ * Allocate sysname of control device for the sound card and return it if exists.
  *
  * Nodes under sound subsystem in sysfs are used to gather the information.
  */
@@ -82,12 +73,11 @@ void alsactl_get_control_sysname(guint card_id, char **sysname, GError **error)
 
 /**
  * alsactl_get_control_devnode:
- * @card_id: The numerical ID of sound card.
+ * @card_id: The numeric ID of sound card.
  * @devnode: (out): The string for devnode of control device for the sound card.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
- * Allocate string of devnode for control device of the sound card and return it
- * if exists.
+ * Allocate string of devnode for control device of the sound card and return it if exists.
  *
  * Nodes under sound subsystem in sysfs are used to gather the information.
  */

--- a/src/hwdep/alsahwdep-enum-types.h
+++ b/src/hwdep/alsahwdep-enum-types.h
@@ -47,7 +47,7 @@
  * @ALSAHWDEP_IFACE_TYPE_FW_MOTU:           For MOTU FireWire series. Available in Linux kernel 4.12.0 or later.
  * @ALSAHWDEP_IFACE_TYPE_FW_FIREFACE:       For RME Fireface series. Available in Linux kernel 4.12.0 or later.
  *
- * A set of enumerators for the interface of hwdep device.
+ * A set of enumerations for the interface of hwdep device.
  */
 typedef enum {
     ALSAHWDEP_IFACE_TYPE_OPL2           = SNDRV_HWDEP_IFACE_OPL2,

--- a/src/hwdep/device-info.c
+++ b/src/hwdep/device-info.c
@@ -2,16 +2,13 @@
 #include "privates.h"
 
 /**
- * SECTION: device-info
- * @Title: ALSAHwdepDeviceInfo
- * @Short_description: A GObject-derived object to represent information of
- *                     ALSA hwdep device.
+ * ALSAHwdepDeviceInfo:
+ * A GObject-derived object to represent information of ALSA hwdep device.
  *
- * A #ALSAHwdepDeviceInfo is a GObject-derived object to represent information
- * of ALSA hwdep device. The call of alsahwdep_get_device_info() returns an
- * instance of the object.
+ * A [class@DeviceInfo] is a GObject-derived object to represent information of ALSA hwdep device.
+ * The call of [func@get_device_info] returns an instance of the object.
  *
- * The object wraps 'struct snd_hwdep_info' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_hwdep_info` in UAPI of Linux sound subsystem.
  */
 typedef struct {
     struct snd_hwdep_info info;

--- a/src/hwdep/query.c
+++ b/src/hwdep/query.c
@@ -6,21 +6,13 @@
 #include <sys/ioctl.h>
 
 /**
- * SECTION: query
- * @Title: Global functions in ALSAHwdep
- * @Short_description: Global functions available without holding any file
- *                     descriptor
- */
-
-/**
  * alsahwdep_get_device_id_list:
- * @card_id: The numerical ID of sound card.
- * @entries: (array length=entry_count)(out): The list of numerical ID for
- *           hwdep device.
+ * @card_id: The numeric ID of sound card.
+ * @entries: (array length=entry_count)(out): The list of numeric ID for hwdep device.
  * @entry_count: The number of entries.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
- * Get the list of numerical ID for available hwdep devices of sound card.
+ * Get the list of numeric ID for available hwdep devices of sound card.
  *
  * Nodes under sound subsystem in sysfs are used to gather the information.
  */
@@ -41,9 +33,9 @@ void alsahwdep_get_device_id_list(guint card_id, guint **entries,
 /**
  * alsahwdep_get_hwdep_sysname:
  * @card_id: The numeridcal ID of sound card.
- * @device_id: The numerical ID of hwdep device for the sound card.
+ * @device_id: The numeric ID of hwdep device for the sound card.
  * @sysname: (out): The string for sysname of hwdep device.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
  * Allocate sysname for hwdep device and return it when it exists.
  *
@@ -65,9 +57,9 @@ void alsahwdep_get_hwdep_sysname(guint card_id, guint device_id,
 /**
  * alsahwdep_get_hwdep_devnode:
  * @card_id: The numeridcal ID of sound card.
- * @device_id: The numerical ID of hwdep device for the sound card.
+ * @device_id: The numeric ID of hwdep device for the sound card.
  * @devnode: (out): The string for devnode of hwdep device.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
  * Allocate devnode string for hwdep device and return it when exists.
  *
@@ -88,15 +80,15 @@ void alsahwdep_get_hwdep_devnode(guint card_id, guint device_id,
 
 /**
  * alsahwdep_get_device_info:
- * @card_id: The numberical value for sound card to query.
- * @device_id: The numerical value of hwdep device to query.
+ * @card_id: The numeric value for sound card to query.
+ * @device_id: The numeric value of hwdep device to query.
  * @device_info: (out): The information of the device.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
- * Get the information according to given numerical IDs for card and device.
+ * Get the information according to given numeric IDs for card and device.
  *
- * The call of function executes open(2), close(2), and ioctl(2) system call
- * with SNDRV_CTL_IOCTL_HWDEP_INFO command for ALSA control character device.
+ * The call of function executes `open(2)`, `close(2)`, and `ioctl(2)` system call
+ * with `SNDRV_CTL_IOCTL_HWDEP_INFO` command for ALSA control character device.
  */
 void alsahwdep_get_device_info(guint card_id, guint device_id,
                                ALSAHwdepDeviceInfo **device_info,

--- a/src/rawmidi/alsarawmidi-enum-types.h
+++ b/src/rawmidi/alsarawmidi-enum-types.h
@@ -7,7 +7,7 @@
  * @ALSARAWMIDI_STREAM_DIRECTION_OUTPUT:        Output direction of stream.
  * @ALSARAWMIDI_STREAM_DIRECTION_INPUT:         Input direction of stream.
  *
- * A set of enumerators for the direction of stream.
+ * A set of enumerations for the direction of stream.
  */
 typedef enum {
     ALSARAWMIDI_STREAM_DIRECTION_OUTPUT = SNDRV_RAWMIDI_STREAM_OUTPUT,

--- a/src/rawmidi/alsarawmidi-enum-types.h
+++ b/src/rawmidi/alsarawmidi-enum-types.h
@@ -35,7 +35,7 @@ typedef enum /*< flags >*/
  * @ALSARAWMIDI_STREAM_PAIR_ERROR_DISCONNECTED: The card associated to the instance is in disconnect state.
  * @ALSARAWMIDI_STREAM_PAIR_ERROR_UNREADABLE:   The instance is not for read operation.
  *
- * A set of error code for GError with domain which equals to #alsarawmidi_stream_pair_error_quark()
+ * A set of error code for [struct@GLib.Error] with `ALSARawmidi.StreamPairError` domain.
  */
 typedef enum {
     ALSARAWMIDI_STREAM_PAIR_ERROR_FAILED,

--- a/src/rawmidi/query.c
+++ b/src/rawmidi/query.c
@@ -6,21 +6,13 @@
 #include <sys/ioctl.h>
 
 /**
- * SECTION: query
- * @Title: Global functions in ALSARawmidi
- * @Short_description: Global functions available without holding any file
- *                     descriptor
- */
-
-/**
  * alsarawmidi_get_device_id_list:
- * @card_id: The numerical ID of sound card.
- * @entries: (array length=entry_count)(out): The list of numerical ID for
- *           rawmidi device.
+ * @card_id: The numeric identifier of sound card.
+ * @entries: (array length=entry_count)(out): The list of numeric identifier for rawmidi device.
  * @entry_count: The number of entries.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
- * Get the list of numerical ID for available rawmidi devices of sound card.
+ * Get the list of numeric identifier for available rawmidi devices of sound card.
  *
  * Nodes under sound subsystem in sysfs are used to gather the information.
  */
@@ -40,10 +32,10 @@ void alsarawmidi_get_device_id_list(guint card_id, guint **entries,
 
 /**
  * alsarawmidi_get_rawmidi_sysname:
- * @card_id: The numeridcal ID of sound card.
- * @device_id: The numerical ID of rawmidi device for the sound card.
+ * @card_id: The numeridcal identifier of sound card.
+ * @device_id: The numeric identifier of rawmidi device for the sound card.
  * @sysname: (out): The string for sysname of rawmidi device.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
  * Allocate sysname for rawmidi device and return it when it exists.
  *
@@ -64,10 +56,10 @@ void alsarawmidi_get_rawmidi_sysname(guint card_id, guint device_id,
 
 /**
  * alsarawmidi_get_rawmidi_devnode:
- * @card_id: The numeridcal ID of sound card.
- * @device_id: The numerical ID of rawmidi device for the sound card.
+ * @card_id: The numeridcal identifier of sound card.
+ * @device_id: The numeric identifier of rawmidi device for the sound card.
  * @devnode: (out): The string for devnode of rawmidi device.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
  * Allocate devnode string for rawmidi device and return it when exists.
  *
@@ -88,19 +80,18 @@ void alsarawmidi_get_rawmidi_devnode(guint card_id, guint device_id,
 
 /**
  * alsarawmidi_get_subdevice_id_list:
- * @card_id: The numberical value for sound card to query.
- * @device_id: The numerical value of rawmidi device to query.
- * @direction: The direction of stream to query, one of
- *             ALSARawmidiStreamDirection.
- * @entries: (array length=entry_count)(out): The list of card.
+ * @card_id: The numeric value for sound card to query.
+ * @device_id: The numeric value of rawmidi device to query.
+ * @direction: The direction of stream to query, one of [enum@StreamDirection].
+ * @entries: (array length=entry_count)(out): The list of numeric identifier of subdevice.
  * @entry_count: The number of entries.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
- * Get the list of numerical IDs for subdevices belongs to the numerical ID of
- * card, device, and the direction.
+ * Get the list of numeric identifier for subdevices belongs to the numerical identifier of card,
+ * device, and the direction.
  *
- * The call of function executes open(2), close(2), and ioctl(2) system call
- * with SNDRV_CTL_IOCTL_RAWMIDI_INFO command for ALSA control character device.
+ * The call of function executes `open(2)`, `close(2)`, and `ioctl(2)` system call with
+ * `SNDRV_CTL_IOCTL_RAWMIDI_INFO` command for ALSA control character device.
  */
 void alsarawmidi_get_subdevice_id_list(guint card_id, guint device_id,
                                        ALSARawmidiStreamDirection direction,
@@ -135,18 +126,18 @@ void alsarawmidi_get_subdevice_id_list(guint card_id, guint device_id,
 
 /**
  * alsarawmidi_get_substream_info:
- * @card_id: The numberical value for sound card to query.
- * @device_id: The numerical value of rawmidi device to query.
- * @direction: The direction of stream, one of ALSARawmidiStreamDirection.
- * @subdevice_id: The numerical value of subdevice in rawmidi device.
+ * @card_id: The numeric value for sound card to query.
+ * @device_id: The numeric value of rawmidi device to query.
+ * @direction: The direction of stream, one of [enum@StreamDirection].
+ * @subdevice_id: The numeric value of subdevice in rawmidi device.
  * @substream_info: (out): The information of substream for the subdevice.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
- * Get the information of substream pointed by the numerical ID of card, device,
- * subdevice, and the direction.
+ * Get the information of substream pointed by the numeric identifier of card, device, subdevice,
+ * and the direction.
  *
- * The call of function executes open(2), close(2), and ioctl(2) system call
- * with SNDRV_CTL_IOCTL_RAWMIDI_INFO command for ALSA control character device.
+ * The call of function executes `open(2)`, `close(2)`, and `ioctl(2)` system call with
+ * `SNDRV_CTL_IOCTL_RAWMIDI_INFO` command for ALSA control character device.
  */
 void alsarawmidi_get_substream_info(guint card_id, guint device_id,
                                     ALSARawmidiStreamDirection direction,

--- a/src/rawmidi/stream-pair.c
+++ b/src/rawmidi/stream-pair.c
@@ -12,27 +12,22 @@
 #include <sys/ioctl.h>
 
 /**
- * SECTION: stream-pair
- * @Title: ALSARawmidiStreamPair
- * @Short_description: A GObject-derived object to represent a pair of Rawmidi
- *                     stream.
+ * ALSARawmidiStreamPair:
+ * GObject-derived object to represent a pair of Rawmidi stream.
  *
- * A #ALSARawmidiStreamPair is a GObject-derived object to represent a pair
- * of Rawmidi stream to which substreams are attached. The substream is pointed
- * by the combination of the numerical ID of device, subdevice, and direction.
- * When the call of alsarawmidi_stream_pair_open() with the combination,
- * corresponding substreams are attached to the object. Then the object maintains
- * file descriptor till object destruction. The call of
- * alsarawmidi_stream_pair_create_source() returns the instance of GSource. Once
- * attached to the GSource, GMainContext/GMainLoop is available as event
- * dispatcher. The 'handle-messages' GObject signal is emit in the event
- * dispatcher to notify the intermediate buffer of capture substream has
- * available messages. The call of alsarawmidi_stream_pair_read_from_substream()
- * fills the given buffer with the available messages. The call of
- * alsarawmidi_stream_pair_write_to_substream() write messages in the given
- * buffer into the intermediate buffer of playback substream. The call of
- * alsarawmidi_stream_pair_get_substream_status() is available to check the
- * space in the intermediate buffer according to direction argument.
+ * A [class@StreamPair] is a GObject-derived object to represent a pair of Rawmidi stream to which
+ * substreams are attached. The substream is pointed by the combination of the numeric identifier
+ * of device, subdevice, and direction. When the call of [method@StreamPair.open] with the
+ * combination, corresponding substreams are attached to the object. Then the object maintains file
+ * descriptor till object destruction. The call of [method@StreamPair.create_source] returns the
+ * instance of [struct@GLib.Source]. Once attached to the [struct@GLib.Source],
+ * [struct@GLib.MainContext] / [struct@GLib.MainLoop] is available as event dispatcher. The
+ * [signal@StreamPair::handle-messages] signal is emitted in the event dispatcher to notify the
+ * intermediate buffer of capture substream has available messages. The call of
+ * [method@StreamPair.read_from_substream] fills the given buffer with the available messages. The
+ * call of [method@StreamPair.write_to_substream] write messages in the given buffer into the
+ * intermediate buffer of playback substream. The call of [method@StreamPair.get_substream_status]
+ * is available to check the space in the intermediate buffer according to direction argument.
  */
 typedef struct {
     int fd;
@@ -44,9 +39,10 @@ G_DEFINE_TYPE_WITH_PRIVATE(ALSARawmidiStreamPair, alsarawmidi_stream_pair, G_TYP
 /**
  * alsarawmidi_stream_pair_error_quark:
  *
- * Return the GQuark for error domain of GError which has code in #ALSARawmidiStreamPairError.
+ * Return the [alias@GLib.Quark] for [struct@GLib.Error] with code in [enum@StreamPairError]
+ * enumerations.
  *
- * Returns: A #GQuark.
+ * Returns: A [alias@GLib.Quark].
  */
 G_DEFINE_QUARK(alsarawmidi-stream-pair-error-quark, alsarawmidi_stream_pair_error)
 
@@ -131,7 +127,7 @@ static void alsarawmidi_stream_pair_class_init(ALSARawmidiStreamPairClass *klass
 
     /**
      * ALSARawmidiStreamPair::handle-messages:
-     * @self: A #ALSARawmidiStreamPair.
+     * @self: A [class@StreamPair].
      *
      * When any input message is available, this event is emit.
      */
@@ -146,12 +142,11 @@ static void alsarawmidi_stream_pair_class_init(ALSARawmidiStreamPairClass *klass
 
     /**
      * ALSARawmidiStreamPair::handle-disconnection:
-     * @self: A #ALSARawmidiStreamPair.
+     * @self: A [class@StreamPair].
      *
-     * When the sound card is not available anymore due to unbinding driver or
-     * hot unplugging, this signal is emit. The owner of this object should
-     * call g_object_free() as quickly as possible to release ALSA rawmidi
-     * character device.
+     * When the sound card is not available anymore due to unbinding driver or hot unplugging,
+     * this signal is emit. The owner of this object should call [method@GObject.Object.unref] as
+     * quickly as possible to release ALSA rawmidi character device.
      */
     rawmidi_stream_pair_sigs[RAWMIDI_STREAM_PAIR_SIG_DISCONNECTION] =
         g_signal_new("handle-disconnection",
@@ -174,7 +169,9 @@ static void alsarawmidi_stream_pair_init(ALSARawmidiStreamPair *self)
 /**
  * alsarawmidi_stream_pair_new:
  *
- * Allocate and return an instance of ALSARawmidiStreamPair class.
+ * Allocate and return an instance of [class@StreamPair].
+ *
+ * Returns: An instance of [class@StreamPair].
  */
 ALSARawmidiStreamPair *alsarawmidi_stream_pair_new()
 {
@@ -183,21 +180,20 @@ ALSARawmidiStreamPair *alsarawmidi_stream_pair_new()
 
 /**
  * alsarawmidi_stream_pair_open:
- * @self: A #ALSARawmidiStreamPair.
- * @card_id: The numerical ID of sound card.
- * @device_id: The numerical ID of rawmidi device for the sound card.
- * @subdevice_id: The numerical ID of subdevice for the rawmidi device.
+ * @self: A [class@StreamPair].
+ * @card_id: The numeric identifier of sound card.
+ * @device_id: The numeric identifier of rawmidi device for the sound card.
+ * @subdevice_id: The numeric identifier of subdevice for the rawmidi device.
  * @access_modes: Access flags for stream direction.
- * @open_flag: The flag of open(2) system call. O_RDWR, O_WRONLY and O_RDONLY
- *             are forced to fulfil internally according to the access_modes.
- * @error: A #GError. Error is generated with two domains; #g_file_error_quark()
- *         and #alsarawmidi_stream_pair_error_quark().
+ * @open_flag: The flag of `open(2)` system call. `O_RDWR`, `O_WRONLY` and `O_RDONLY` are forced
+ *             to fulfil internally according to the access_modes.
+ * @error: A [struct@GLib.Error]. Error is generated with two domains; `GLib.FileError`
+ *         and `ALSARawmidi.StreamPairError`.
  *
- * Open file descriptor for a pair of streams to attach input/output substreams
- * corresponding to the given subdevice.
+ * Open file descriptor for a pair of streams to attach input/output substreams corresponding to
+ * the given subdevice.
  *
- * The call of function executes open(2) system call for ALSA rawmidi character
- * device.
+ * The call of function executes `open(2)` system call for ALSA rawmidi character device.
  */
 void alsarawmidi_stream_pair_open(ALSARawmidiStreamPair *self, guint card_id,
                                   guint device_id, guint subdevice_id,
@@ -274,15 +270,14 @@ void alsarawmidi_stream_pair_open(ALSARawmidiStreamPair *self, guint card_id,
 
 /**
  * alsarawmidi_stream_pair_get_protocol_version:
- * @self: A #ALSARawmidiStreamPair.
- * @proto_ver_triplet: (array fixed-size=3)(out)(transfer none): The version of
- *                     protocol currently used.
- * @error: A #GError.
+ * @self: A [class@StreamPair].
+ * @proto_ver_triplet: (array fixed-size=3)(out)(transfer none): The version of protocol currently
+ *                     used.
+ * @error: A [struct@GLib.Error].
  *
- * Get the version of rawmidi protocol currently used. The version is
- * represented as the array with three elements; major, minor, and micro version
- * in the order. The length of major version is 16 bit, the length of minor
- * and micro version is 8 bit each.
+ * Get the version of rawmidi protocol currently used. The version is represented as the array with
+ * three elements; major, minor, and micro version in the order. The length of major version is
+ * 16 bit, the length of minor and micro version is 8 bit each.
  */
 void alsarawmidi_stream_pair_get_protocol_version(ALSARawmidiStreamPair *self,
                                        const guint16 *proto_ver_triplet[3],
@@ -302,15 +297,15 @@ void alsarawmidi_stream_pair_get_protocol_version(ALSARawmidiStreamPair *self,
 
 /**
  * alsarawmidi_stream_pair_get_substream_info:
- * @self: A #ALSARawmidiStreamPair.
+ * @self: A [class@StreamPair].
  * @direction: The direction of substream attached to the stream pair.
  * @substream_info: (out): The information for requested substream.
- * @error: A #GError. Error is generated with domain of #alsarawmidi_stream_pair_error_quark.
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSARawmidi.StreamPairError`.
  *
  * Get information of substream attached to the stream pair.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_RAWMIDI_IOCTL_INFO command for ALSA rawmidi character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_RAWMIDI_IOCTL_INFO` command
+ * for ALSA rawmidi character device.
  */
 void alsarawmidi_stream_pair_get_substream_info(ALSARawmidiStreamPair *self,
                                 ALSARawmidiStreamDirection direction,
@@ -342,16 +337,15 @@ void alsarawmidi_stream_pair_get_substream_info(ALSARawmidiStreamPair *self,
 
 /**
  * alsarawmidi_stream_pair_set_substream_params:
- * @self: A #ALSARawmidiStreamPair.
+ * @self: A [class@StreamPair].
  * @direction: The direction of substream attached to the stream pair.
  * @substream_params: The parameters of substream.
- * @error: A #GError. Error is generated with domain of #alsarawmidi_stream_pair_error_quark.
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSARawmidi.StreamPairError`.
  *
- * Set parameters of substream for given direction, which is attached to the
- * pair of streams.
+ * Set parameters of substream for given direction, which is attached to the pair of streams.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_RAWMIDI_IOCTL_PARAMS command for ALSA rawmidi character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_RAWMIDI_IOCTL_PARAMS` command
+ * for ALSA rawmidi character device.
  */
 void alsarawmidi_stream_pair_set_substream_params(ALSARawmidiStreamPair *self,
                                 ALSARawmidiStreamDirection direction,
@@ -380,16 +374,15 @@ void alsarawmidi_stream_pair_set_substream_params(ALSARawmidiStreamPair *self,
 
 /**
  * alsarawmidi_stream_pair_get_substream_status:
- * @self: A #ALSARawmidiStreamPair.
+ * @self: A [class@StreamPair].
  * @direction: The direction of substream attached to the stream pair.
  * @substream_status: (inout): The status of substream.
- * @error: A #GError. Error is generated with domain of #alsarawmidi_stream_pair_error_quark.
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSARawmidi.StreamPairError`.
  *
- * Retrieve status of substream for given direction, which is attached to the
- * pair of streams.
+ * Retrieve status of substream for given direction, which is attached to the pair of streams.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_RAWMIDI_IOCTL_STATUS command for ALSA rawmidi character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_RAWMIDI_IOCTL_STATUS` command
+ * for ALSA rawmidi character device.
  */
 void alsarawmidi_stream_pair_get_substream_status(ALSARawmidiStreamPair *self,
                             ALSARawmidiStreamDirection direction,
@@ -418,19 +411,17 @@ void alsarawmidi_stream_pair_get_substream_status(ALSARawmidiStreamPair *self,
 
 /**
  * alsarawmidi_stream_pair_read_from_substream:
- * @self: A #ALSARawmidiStreamPair.
+ * @self: A [class@StreamPair].
  * @buf: (array length=buf_size)(inout): The buffer to copy data.
  * @buf_size: The size of buffer.
- * @error: A #GError. Error is generated with two domains; #g_file_error_quark() and
- *         #alsarawmidi_stream_pair_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with two domains; `GLib.FileError` and
+ *         `ALSARawmidi.StreamPairError`.
  *
- * Copy data from intermediate buffer to given buffer for substream attached to
- * the pair of streams. In a case that the instance is opened without
- * O_NONBLOCK flag and the intermediate buffer has no data, call of the API
- * is blocked till any data is available.
+ * Copy data from intermediate buffer to given buffer for substream attached to the pair of
+ * streams. In a case that the instance is opened without `O_NONBLOCK` flag and the intermediate
+ * buffer has no data, call of the API is blocked till any data is available.
  *
- * The call of function executes read(2) system for ALSA rawmidi character
- * device.
+ * The call of function executes `read(2)` system for ALSA rawmidi character device.
  */
 void alsarawmidi_stream_pair_read_from_substream(ALSARawmidiStreamPair *self,
                                         guint8 *const *buf, gsize *buf_size,
@@ -467,19 +458,17 @@ void alsarawmidi_stream_pair_read_from_substream(ALSARawmidiStreamPair *self,
 
 /**
  * alsarawmidi_stream_pair_write_to_substream:
- * @self: A #ALSARawmidiStreamPair.
+ * @self: A [class@StreamPair].
  * @buf: (array length=buf_size): The buffer to copy data.
  * @buf_size: The size of buffer.
- * @error: A #GError. Error is generated with two domains; #g_file_error_quark() and
- *         #alsarawmidi_stream_pair_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with two domains; `GLib.FileError` and
+ *         `ALSARawmidi.StreamPairError`.
  *
- * Copy data from given buffer to intermediate buffer for substream attached to
- * the pair of streams. In a case that the instance is opened without
- * O_NONBLOCK flag and the intermediate buffer is full, call of the API is
- * blocked till the buffer has space for the data.
+ * Copy data from given buffer to intermediate buffer for substream attached to the pair of
+ * streams. In a case that the instance is opened without `O_NONBLOCK` flag and the intermediate
+ * buffer is full, call of the API is blocked till the buffer has space for the data.
  *
- * The call of function executes write(2) system for ALSA rawmidi character
- * device.
+ * The call of function executes `write(2) system for ALSA rawmidi character device.
  */
 void alsarawmidi_stream_pair_write_to_substream(ALSARawmidiStreamPair *self,
                                         const guint8 *buf, gsize buf_size,
@@ -513,17 +502,17 @@ void alsarawmidi_stream_pair_write_to_substream(ALSARawmidiStreamPair *self,
 
 /**
  * alsarawmidi_stream_pair_drain:
- * @self: A #ALSARawmidiStreamPair.
+ * @self: A [class@StreamPair].
  * @direction: The direction of substream attached to the stream pair.
- * @error: A #GError. Error is generated with domain of #alsarawmidi_stream_pair_error_quark.
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSARawmidi.StreamPairError`.
  *
- * Drain queued data in intermediate buffer for substream attached to the pair
- * of streams. In a case that the instance is opened without O_NONBLOCK and the
- * call is for output substream and any data is in the intermediate buffer, the
- * call is blocked till no data is in the intermediate buffer.
+ * Drain queued data in intermediate buffer for substream attached to the pair of streams. In a
+ * case that the instance is opened without `O_NONBLOCK` and the call is for output substream and
+ * any data is in the intermediate buffer, the call is blocked till no data is in the intermediate
+ * buffer.
  *
- * The call of function executes ioctl(2) system with
- * SNDRV_RAWMIDI_IOCTL_DRAIN command for ALSA rawmidi character device.
+ * The call of function executes `ioctl(2)` system with `SNDRV_RAWMIDI_IOCTL_DRAIN` command for
+ * ALSA rawmidi character device.
  */
 void alsarawmidi_stream_pair_drain_substream(ALSARawmidiStreamPair *self,
                                         ALSARawmidiStreamDirection direction,
@@ -546,16 +535,15 @@ void alsarawmidi_stream_pair_drain_substream(ALSARawmidiStreamPair *self,
 
 /**
  * alsarawmidi_stream_pair_drop:
- * @self: A #ALSARawmidiStreamPair.
+ * @self: A [class@StreamPair].
  * @direction: The direction of substream attached to the stream pair.
- * @error: A #GError. Error is generated with domain of #alsarawmidi_stream_pair_error_quark.
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSARawmidi.StreamPairError`.
  *
- * Drop queued data in intermediate buffer immediately for substream attached
- * to the pair of streams. In implementation of ALSA rawmidi core, the
- * direction should be for output substream.
+ * Drop queued data in intermediate buffer immediately for substream attached to the pair of
+ * streams. In implementation of ALSA rawmidi core, the direction should be for output substream.
  *
- * The call of function executes ioctl(2) system with
- * SNDRV_RAWMIDI_IOCTL_DROP command for ALSA rawmidi character device.
+ * The call of function executes `ioctl(2)` system with `SNDRV_RAWMIDI_IOCTL_DROP` command for
+ * ALSA rawmidi character device.
  */
 void alsarawmidi_stream_pair_drop_substream(ALSARawmidiStreamPair *self,
                                         ALSARawmidiStreamDirection direction,
@@ -626,15 +614,15 @@ static void rawmidi_stream_pair_finalize_src(GSource *gsrc)
 
 /**
  * alsarawmidi_stream_pair_create_source:
- * @self: A #ALSARawmidiStreamPair.
- * @gsrc: (out): A #GSource to handle events from ALSA rawmidi character device.
- * @error: A #GError. Error is generated with two domains; #g_file_error_quark() and
- *         #alsarawmidi_stream_pair_error_quark().
+ * @self: A [class@StreamPair].
+ * @gsrc: (out): A [struct@GLib.Source] to handle events from ALSA rawmidi character device.
+ * @error: A [struct@GLib.Error]. Error is generated with two domains; `GLib.FileError` and
+ *         `ALSARawmidi.StreamPairError`.
  *
- * Allocate GSource structure to handle events from ALSA rawmidi character
- * device for input substream. In each iteration of GManContext, the read(2)
- * system call is executed to dispatch control event for 'handle-message'
- * signal, according to the result of poll(2) system call.
+ * Allocate [struct@GLib.Source] structure to handle events from ALSA rawmidi character device for
+ * input substream. In each iteration of [struct@GLib.MainContext], the `read(2)` system call is
+ * executed to dispatch control event for [signal@StreamPair::handle-messages] signal, according to
+ * the result of `poll(2)` system call.
  */
 void alsarawmidi_stream_pair_create_source(ALSARawmidiStreamPair *self,
                                            GSource **gsrc, GError **error)

--- a/src/rawmidi/stream-pair.c
+++ b/src/rawmidi/stream-pair.c
@@ -217,13 +217,14 @@ void alsarawmidi_stream_pair_open(ALSARawmidiStreamPair *self, guint card_id,
                      ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_INPUT)) == 0);
     g_return_if_fail(error == NULL || *error == NULL);
 
+    open_flag &= ~(O_RDWR | O_WRONLY | O_RDONLY);
     if ((access_modes & ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_OUTPUT) &&
         (access_modes & ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_INPUT))
-        open_flag = O_RDWR;
+        open_flag |= O_RDWR;
     else if (access_modes & ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_OUTPUT)
-        open_flag = O_WRONLY;
+        open_flag |= O_WRONLY;
     else if (access_modes & ALSARAWMIDI_STREAM_PAIR_INFO_FLAG_INPUT)
-        open_flag = O_RDONLY;
+        open_flag |= O_RDONLY;
     else
         g_return_if_reached();
 

--- a/src/rawmidi/stream-pair.h
+++ b/src/rawmidi/stream-pair.h
@@ -19,20 +19,17 @@ struct _ALSARawmidiStreamPairClass {
 
     /**
      * ALSARawmidiStreamPairClass::handle_messages:
-     * @self: A #ALSARawmidiStreamPair.
+     * @self: A [class@StreamPair].
      *
-     * When any input message in available, this event is emit.
+     * Class closure for the [signal@StreamPair::handle-messages] singal.
      */
     void (*handle_messages)(ALSARawmidiStreamPair *self);
 
     /**
      * ALSARawmidiStreamPairClass::handle_disconnection:
-     * @self: A #ALSARawmidiStreamPair.
+     * @self: A [class@StreamPair].
      *
-     * When the sound card is not available anymore due to unbinding driver or
-     * hot unplugging, this signal is emit. The owner of this object should
-     * call g_object_free() as quickly as possible to release ALSA rawmidi
-     * character device.
+     * Class closure for the [signal@StreamPair::handle-disconnection] signal.
      */
     void (*handle_disconnection)(ALSARawmidiStreamPair *self);
 };

--- a/src/rawmidi/substream-info.c
+++ b/src/rawmidi/substream-info.c
@@ -2,17 +2,14 @@
 #include "privates.h"
 
 /**
- * SECTION: substream-info
- * @Title: ALSARawmidiSubstreamInfo
- * @Short_description: A GObject-derived object to represent information of
- *                     substream
+ * ALSARawmidiSubstreamInfo:
+ * A GObject-derived object to represent information of substream.
  *
- * A #ALSARawmidiSubstreamInfo is a GObject-derived object to represent
- * information of substream attached to the pair of streams. The call of
- * alsarawmidi_stream_pair_get_substream_info() or
- * alsarawmidi_get_substream_info() return the instance of object.
+ * A [class@SubstreamInfo] is a GObject-derived object to represent information of substream
+ * attached to the pair of streams. The call of [method@StreamPair.get_substream_info] or
+ * [func@get_substream_info] return the instance of object.
  *
- * The object wraps 'struct snd_rawmidi_info' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_rawmidi_info` in UAPI of Linux sound subsystem.
  */
 typedef struct {
     struct snd_rawmidi_info info;
@@ -86,14 +83,14 @@ static void alsarawmidi_substream_info_class_init(ALSARawmidiSubstreamInfoClass 
 
     rawmidi_substream_info_props[RAWMIDI_SUBSTREAM_INFO_PROP_DEVICE_ID] =
         g_param_spec_uint("device-id", "device-id",
-                         "The numerical ID of rawmidi device.",
+                         "The numerical identifier of rawmidi device.",
                          0, G_MAXINT,
                          0,
                          G_PARAM_READABLE);
 
     rawmidi_substream_info_props[RAWMIDI_SUBSTREAM_INFO_PROP_SUBDEVICE_ID] =
         g_param_spec_uint("subdevice-id", "subdevice-id",
-                          "The numerical ID of subdevice for rawmidi device..",
+                          "The numerical identifier of subdevice for rawmidi device..",
                           0, G_MAXINT,
                           0,
                           G_PARAM_READABLE);
@@ -108,7 +105,7 @@ static void alsarawmidi_substream_info_class_init(ALSARawmidiSubstreamInfoClass 
 
     rawmidi_substream_info_props[RAWMIDI_SUBSTREAM_INFO_PROP_CARD_ID] =
         g_param_spec_int("card-id", "card-id",
-                         "The numerical ID of sound card.",
+                         "The numerical identifier of sound card.",
                          G_MININT, G_MAXINT,
                          -1,
                          G_PARAM_READABLE);
@@ -123,7 +120,7 @@ static void alsarawmidi_substream_info_class_init(ALSARawmidiSubstreamInfoClass 
 
     rawmidi_substream_info_props[RAWMIDI_SUBSTREAM_INFO_PROP_ID] =
         g_param_spec_string("id", "id",
-                            "The string ID of rawmidi device.",
+                            "The string identifier of rawmidi device.",
                             "",
                             G_PARAM_READABLE);
 

--- a/src/rawmidi/substream-params.c
+++ b/src/rawmidi/substream-params.c
@@ -118,7 +118,7 @@ static void alsarawmidi_substream_params_init(ALSARawmidiSubstreamParams *self)
 /**
  * alsarawmidi_substream_params_new:
  *
- * Allocate and return an instance of ALSARawmidiSubstreamParams class.
+ * Allocate and return an instance of [class@SubstreamParams] class.
  */
 ALSARawmidiSubstreamParams *alsarawmidi_substream_params_new()
 {

--- a/src/rawmidi/substream-params.c
+++ b/src/rawmidi/substream-params.c
@@ -4,17 +4,14 @@
 #include <unistd.h>
 
 /**
- * SECTION: substream-params
- * @Title: ALSARawmidiSubstreamParams
- * @Short_description: A GObject-derived object to represent parameters of
- *                     substream.
+ * ALSARawmidiSubstreamParams:
+ * A GObject-derived object to represent parameters of substream.
  *
- * A #ALSARawmidiSubstreamParams is a GObject-derived object to represent
- * parameters of substream attached to the pair of streams. The call of
- * alsarawmidi_stream_pair_set_substream_params() requires the instance of
- * object.
+ * A [class@SubstreamParams] is a GObject-derived object to represent parameters of substream
+ * attached to the pair of streams. The call of [method@StreamPair.set_substream_params] requires
+ * the instance of object.
  *
- * The object wraps 'struct snd_rawmidi_params' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_rawmidi_params` in UAPI of Linux sound subsystem.
  */
 typedef struct {
     struct snd_rawmidi_params params;
@@ -118,7 +115,9 @@ static void alsarawmidi_substream_params_init(ALSARawmidiSubstreamParams *self)
 /**
  * alsarawmidi_substream_params_new:
  *
- * Allocate and return an instance of [class@SubstreamParams] class.
+ * Allocate and return an instance of [class@SubstreamParams].
+ *
+ * Returns: An instance of [class@SubstreamParams].
  */
 ALSARawmidiSubstreamParams *alsarawmidi_substream_params_new()
 {

--- a/src/rawmidi/substream-params.h
+++ b/src/rawmidi/substream-params.h
@@ -10,6 +10,7 @@ G_BEGIN_DECLS
 
 G_DECLARE_DERIVABLE_TYPE(ALSARawmidiSubstreamParams, alsarawmidi_substream_params, ALSARAWMIDI,
                          SUBSTREAM_PARAMS, GObject);
+
 struct _ALSARawmidiSubstreamParamsClass {
     GObjectClass parent_class;
 };

--- a/src/rawmidi/substream-status.c
+++ b/src/rawmidi/substream-status.c
@@ -2,16 +2,14 @@
 #include "privates.h"
 
 /**
- * SECTION: substream-status
- * @Title: ALSARawmidiSubstreamStatus
- * @Short_description: A GObject-derived object to represent status of substream
+ * ALSARawmidiSubstreamStatus:
+ * A GObject-derived object to represent status of substream.
  *
- * A #ALSARawmidiSubstreamStatus is a GObject-derived object to represent status
- * of substream attached to the pair of stream. The call of
- * alsarawmidi_stream_pair_get_substream_status() returns the instance of
- * object.
+ * A [class@SubstreamStatus] is a GObject-derived object to represent status of substream attached
+ * to the pair of stream. The call of [method@StreamPair.get_substream_status] returns the instance
+ * of object.
  *
- * The object wraps 'struct snd_rawmidi_status' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_rawmidi_status` in UAPI of Linux sound subsystem.
  */
 typedef struct {
     struct snd_rawmidi_status status;
@@ -78,7 +76,9 @@ static void alsarawmidi_substream_status_init(ALSARawmidiSubstreamStatus *self)
 /**
  * alsarawmidi_substream_status_new:
  *
- * Allocate and return an instance of ALSARawmidiSubstreamStatus class.
+ * Allocate and return an instance of [class@SubstreamStatus].
+ *
+ * Returns: An instance of [class@SubstreamStatus].
  */
 ALSARawmidiSubstreamStatus *alsarawmidi_substream_status_new()
 {

--- a/src/seq/addr.c
+++ b/src/seq/addr.c
@@ -2,14 +2,13 @@
 #include "privates.h"
 
 /**
- * SECTION: addr
- * @Title: ALSASeqAddr
- * @Short_description: A boxed object to represent address in ALSA Sequencer.
+ * ALSASeqAddr:
+ * A boxed object to represent address in ALSA Sequencer.
  *
- * A #ALSASeqAddr is a boxed object to represent address in ALSA Sequencer. The
- * address consists of two parts; the numerical ID of client and port.
+ * A [struct@Addr] is a boxed object to represent address in ALSA Sequencer. The address consists
+ * of two parts; the numeric ID of client and port.
  *
- * The object wraps 'struct snd_seq_addr' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_seq_addr` in UAPI of Linux sound subsystem.
  */
 ALSASeqAddr *seq_addr_copy(const ALSASeqAddr *self)
 {
@@ -28,12 +27,12 @@ G_DEFINE_BOXED_TYPE(ALSASeqAddr, alsaseq_addr, seq_addr_copy, g_free)
 
 /**
  * alsaseq_addr_new:
- * @client_id: The numerical ID of client to address.
- * @port_id: The numerical ID of port to address.
+ * @client_id: The numeric ID of client to address.
+ * @port_id: The numeric ID of port to address.
  *
- * Allocate and return an instance of ALSASeqAddr.
+ * Allocate and return an instance of [struct@Addr].
  *
- * Returns: A #ALSASeqAddr.
+ * Returns: A [struct@Addr].
  */
 ALSASeqAddr *alsaseq_addr_new(guint8 client_id, guint8 port_id)
 {
@@ -47,10 +46,10 @@ ALSASeqAddr *alsaseq_addr_new(guint8 client_id, guint8 port_id)
 
 /**
  * alsaseq_addr_get_client_id:
- * @self: A #ALSASeqAddr.
- * @client_id: (out): The numerical ID of client to address.
+ * @self: A [struct@Addr].
+ * @client_id: (out): The numeric ID of client to address.
  *
- * Get the numerical ID of client to address.
+ * Get the numeric ID of client to address.
  */
 void alsaseq_addr_get_client_id(const ALSASeqAddr *self, guint8 *client_id)
 {
@@ -59,10 +58,10 @@ void alsaseq_addr_get_client_id(const ALSASeqAddr *self, guint8 *client_id)
 
 /**
  * alsaseq_addr_get_port_id:
- * @self: A #ALSASeqAddr.
- * @port_id: (out): The numerical ID of port to address.
+ * @self: A [struct@Addr].
+ * @port_id: (out): The numeric ID of port to address.
  *
- * Get the numerical ID of port to address.
+ * Get the numeric ID of port to address.
  */
 void alsaseq_addr_get_port_id(const ALSASeqAddr *self, guint8 *port_id)
 {
@@ -71,8 +70,8 @@ void alsaseq_addr_get_port_id(const ALSASeqAddr *self, guint8 *port_id)
 
 /**
  * alsaseq_addr_equal:
- * @self: A #ALSASeqAddr.
- * @target: A #ALSASeqAddr to compare.
+ * @self: A [struct@Addr].
+ * @target: A [struct@Addr] to compare.
  *
  * Returns: whether the given object indicates the same element.
  */

--- a/src/seq/alsaseq-enum-types.h
+++ b/src/seq/alsaseq-enum-types.h
@@ -366,7 +366,7 @@ typedef enum /*< flags >*/
  * @ALSASEQ_USER_CLIENT_ERROR_PORT_PERMISSION:      The operation fails due to access permission of port.
  * @ALSASEQ_USER_CLIENT_ERROR_QUEUE_PERMISSION:     The operation fails due to access permission of queue.
  *
- * A set of error code for GError with domain which equals to #alsaseq_user_client_error_quark()
+ * A set of error code for [structGLib.Error] with `struct@UserClientError` domain.
  */
 typedef enum {
     ALSASEQ_USER_CLIENT_ERROR_FAILED,

--- a/src/seq/client-info.c
+++ b/src/seq/client-info.c
@@ -5,17 +5,14 @@
 #include <errno.h>
 
 /**
- * SECTION: client-info
- * @Title: ALSASeqClientInfo
- * @Short_description: A GObject-derived object to represent information of
- *                     client.
+ * ALSASeqClientInfo:
+ * A GObject-derived object to represent information of client.
  *
- * A #ALSASeqClientInfo is a GObject-derived object to represent information of
- * client. The call of alsaseq_get_client_info() returns the instance of object.
- * The call of alsaseq_user_client_set_info() and alsaseq_user_client_get_info()
- * require the instance of object.
+ * A [class@ClientInfo] is a GObject-derived object to represent information of client. The call
+ * of [func@get_client_info] returns the instance of object.  The call of
+ * [method@UserClient.set_info] and [method@UserClient.get_info] require the instance of object.
  *
- * The object wraps 'struct snd_seq_client_info' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_seq_client_info` in UAPI of Linux sound subsystem.
  */
 typedef struct {
     struct snd_seq_client_info info;
@@ -201,7 +198,9 @@ static void alsaseq_client_info_init(ALSASeqClientInfo *self)
 /**
  * alsaseq_client_info_new:
  *
- * Allocate and return an instance of ALSASeqClientinfo class.
+ * Allocate and return an instance of [class@ClientInfo].
+ *
+ * Returns: An instance of [class@ClientInfo].
  */
 ALSASeqClientInfo *alsaseq_client_info_new()
 {
@@ -210,11 +209,11 @@ ALSASeqClientInfo *alsaseq_client_info_new()
 
 /**
  * alsaseq_client_info_set_event_filter:
- * @self: A #ALSASeqClientInfo.
- * @event_types: (array length=event_type_count): The array with elements for
- *               the type of event to listen.
+ * @self: A [class@ClientInfo].
+ * @event_types: (array length=event_type_count): The array with elements for the type of event to
+ *               listen.
  * @event_type_count: The number of elements for the type of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Set the list of type of events configured to be listen.
  */
@@ -246,11 +245,11 @@ void alsaseq_client_info_set_event_filter(ALSASeqClientInfo *self,
 
 /**
  * alsaseq_client_info_get_event_filter:
- * @self: A #ALSASeqClientInfo.
- * @event_types: (array length=event_type_count)(out): The array with elements
- *               for the type of event to listen.
+ * @self: A [class@ClientInfo].
+ * @event_types: (array length=event_type_count)(out): The array with elements for the type of
+ *               event to listen.
  * @event_type_count: The number of elements for the type of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Get the list of type of events configured to be listen.
  */

--- a/src/seq/client-pool.c
+++ b/src/seq/client-pool.c
@@ -2,18 +2,15 @@
 #include "privates.h"
 
 /**
- * SECTION: client-pool
- * @Title: ALSASeqClientPool
- * @Short_description: A GObject-derived object to represent information of
- *                     pool owned by client.
+ * ALSASeqClientPool:
+ * A GObject-derived object to represent information of pool owned by client.
  *
- * A #ALSASeqClientPool is a GObject-derived object to represent information of
- * pool owned by client. The pool consists of a batch of cells to store message
- * contents in kernel space. The call of alsaseq_get_client_pool() returns the
- * instance of object. The call of alsaseq_user_client_set_pool() and
- * alsaseq_user_client_get_pool() require the instance of object.
+ * A [class@ClientPool] is a GObject-derived object to represent information of pool owned by
+ * client. The pool consists of a batch of cells to store message contents in kernel space. The
+ * call of [func@get_client_pool] returns the instance of object. The call of
+ * [method@UserClient.set_pool]) and [method@UserClient.get_pool] require the instance of object.
  *
- * The object wraps 'struct snd_seq_client_pool' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_seq_client_pool` in UAPI of Linux sound subsystem.
  */
 typedef struct {
     struct snd_seq_client_pool pool;

--- a/src/seq/event-cntr.c
+++ b/src/seq/event-cntr.c
@@ -4,16 +4,13 @@
 #include <errno.h>
 
 /**
- * SECTION: event-cntr
- * @Title: ALSASeqEventCntr
- * @Short_description: A GObject-derived object to represent container for a
- *                     batch of events
+ * ALSASeqEventCntr:
+ * A GObject-derived object to represent container for a batch of events.
  *
- * A #ALSASeqEventCntr is a GObject-derived object to represent container for
- * a batch of events. The instance of object has accessor methods to properties
- * and data for each events expanded to the flat memory space. The object is
- * designed for applications to maintain collections of event by the convenient
- * way which each programming language produces.
+ * A [class@EventCntr] is a GObject-derived object to represent container for a batch of events.
+ * The instance of object has accessor methods to properties and data for each events expanded to
+ * the flat memory space. The object is designed for applications to maintain collections of event
+ * by the convenient way which each programming language produces.
  *
  * This is the list of properties for event:
  * - the type of event
@@ -22,13 +19,13 @@
  * - the mode of length
  * - the mode of priority
  * - associated tag
- * - the numerical ID of associated queue
+ * - the numeric ID of associated queue
  * - time stamp
  * - destination address
  * - source address
  *
- * This is the list of data for event. These data shared the same storage and
- * an event can have the sole type of data:
+ * This is the list of data for event. These data shared the same storage and an event can have the
+ * sole type of data:
  * - note
  * - control
  * - 12 bytes
@@ -40,8 +37,8 @@
  * - connection with source and destination addresses
  * - result
  *
- * The data shares the same storage in event. An event can have the sole type
- * of data. The type of data is not associated to the type of event directly.
+ * The data shares the same storage in event. An event can have the sole type of data. The type of
+ * data is not associated to the type of event directly.
  */
 typedef struct _ALSASeqEventCntrPrivate {
     guint8 *buf;
@@ -83,12 +80,11 @@ static void alsaseq_event_cntr_init(ALSASeqEventCntr *self)
 /**
  * alsaseq_event_cntr_new:
  * @count: The number of events going to be allocated.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
- * Allocates and return an instance of #ALSASeqEventCntr to store the count
- * of events.
+ * Allocates and return an instance of [class@EventCntr] to store the count of events.
  *
- * Returns: A #ALSASeqEventCntr.
+ * Returns: A [class@EventCntr].
  */
 ALSASeqEventCntr *alsaseq_event_cntr_new(guint count, GError **error)
 {
@@ -189,7 +185,7 @@ static struct snd_seq_event *event_iterator_find(struct event_iterator *iter,
 
 /**
  * alsaseq_event_cntr_count_events:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @count: (out): The count of stored events.
  *
  * count stored events.
@@ -214,13 +210,12 @@ void alsaseq_event_cntr_count_events(ALSASeqEventCntr *self, gsize *count)
 
 /**
  * alsaseq_event_cntr_calculate_pool_consumption:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @count: The amount of events for calculation.
  * @cells: (out): The amount of cells to be consumed in pool.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
- * Calculate the amount of cells in client pool to be consumed by a part
- * of events in the container.
+ * Calculate the amount of cells in client pool to be consumed by a part of events in the container.
  */
 void alsaseq_event_cntr_calculate_pool_consumption(ALSASeqEventCntr *self,
                                     gsize count, gsize *cells, GError **error)
@@ -251,10 +246,10 @@ void alsaseq_event_cntr_calculate_pool_consumption(ALSASeqEventCntr *self,
 
 /**
  * alsaseq_event_cntr_get_event_type:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to refer to.
  * @ev_type: (out): The type of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Get the type of event pointed by the index.
  */
@@ -281,10 +276,10 @@ void alsaseq_event_cntr_get_event_type(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_set_event_type:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
- * @ev_type: A #ALSASeqEventType.
- * @error: A #GError.
+ * @ev_type: A [enum@EventType].
+ * @error: A [struct@GLib.Error].
  *
  * Set the type to event pointed by the index;
  */
@@ -311,10 +306,10 @@ void alsaseq_event_cntr_set_event_type(ALSASeqEventCntr *self,
 
 /**
  * alsaseq_event_cntr_get_tstamp_mode:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
- * @mode: (out): The mode of timestamping, one of #ALSASeqEventTimestampMode.
- * @error: A #GError.
+ * @mode: (out): The mode of timestamping, one of [enum@EventTimestampMode].
+ * @error: A [struct@GLib.Error].
  *
  * Get the mode of timestamping for the event pointed by the index.
  */
@@ -342,10 +337,10 @@ void alsaseq_event_cntr_get_tstamp_mode(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_set_tstamp_mode:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
- * @mode: The mode of timestamping, one of #ALSASeqEventTimestampMode.
- * @error: A #GError.
+ * @mode: The mode of timestamping, one of [enum@EventTimestampMode].
+ * @error: A [struct@GLib.Error].
  *
  * Set the mode of timestamping for the event pointed by the index.
  */
@@ -373,10 +368,10 @@ void alsaseq_event_cntr_set_tstamp_mode(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_get_time_mode:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
- * @mode: (out): The mode of time, one of #ALSASeqEventTimeMode.
- * @error: A #GError.
+ * @mode: (out): The mode of time, one of [enum@EventTimestampMode].
+ * @error: A [struct@GLib.Error].
  *
  * Get the mode of time for the event pointed by the index.
  */
@@ -404,10 +399,10 @@ void alsaseq_event_cntr_get_time_mode(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_set_time_mode:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
- * @mode: The mode of time, one of #ALSASeqEventTimeMode.
- * @error: A #GError.
+ * @mode: The mode of time, one of [enum@EventTimestampMode].
+ * @error: A [struct@GLib.Error].
  *
  * Set the mode of time for the event pointed by the index.
  */
@@ -435,10 +430,10 @@ void alsaseq_event_cntr_set_time_mode(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_get_length_mode:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
- * @mode: (out): The mode of length, one of #ALSASeqEventLengthMode.
- * @error: A #GError.
+ * @mode: (out): The mode of length, one of [enum@EventTimestampMode].
+ * @error: A [struct@GLib.Error].
  *
  * Get the mode of length for the event pointed by the index.
  */
@@ -466,10 +461,10 @@ void alsaseq_event_cntr_get_length_mode(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_get_priority_mode:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
- * @mode: (out): The mode of priority, one of #ALSASeqEventPriorityMode.
- * @error: A #GError.
+ * @mode: (out): The mode of priority, one of [enum@EventTimestampMode].
+ * @error: A [struct@GLib.Error].
  *
  * Get the mode of priority for the event pointed by the index.
  */
@@ -497,10 +492,10 @@ void alsaseq_event_cntr_get_priority_mode(
 
 /**
  * alsaseq_event_cntr_set_priority_mode:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
- * @mode: The mode of priority, one of #ALSASeqEventPriorityMode.
- * @error: A #GError.
+ * @mode: The mode of priority, one of [enum@EventTimestampMode].
+ * @error: A [struct@GLib.Error].
  *
  * Set the mode of priority for the event pointed by the index.
  */
@@ -528,10 +523,10 @@ void alsaseq_event_cntr_set_priority_mode(
 
 /**
  * alsaseq_event_cntr_get_tag:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @tag: (out): The tag assigned to the event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Get the tag assignd to the event pointed by the index.
  */
@@ -558,10 +553,10 @@ void alsaseq_event_cntr_get_tag(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_set_tag:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @tag: The tag going to be assignd to the event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Get the tag assignd to the event pointed by the index.
  */
@@ -587,13 +582,13 @@ void alsaseq_event_cntr_set_tag(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_get_queue_id:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
- * @queue_id: (out): The numerical ID of queue to deliver the event. One of
- *                   #ALSASeqSpecificQueueId is available as well.
- * @error: A #GError.
+ * @queue_id: (out): The numeric ID of queue to deliver the event. One of [enum@SpecificQueueId]
+ *            is available as well.
+ * @error: A [struct@GLib.Error].
  *
- * Get the numerical ID of queue to deliver the event.
+ * Get the numeric ID of queue to deliver the event.
  */
 void alsaseq_event_cntr_get_queue_id(ALSASeqEventCntr *self, gsize index,
                                        guint8 *queue_id, GError **error)
@@ -618,13 +613,13 @@ void alsaseq_event_cntr_get_queue_id(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_set_queue_id:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
- * @queue_id: The numerical ID of queue to deliver the event. One of
- *            #ALSASeqSpecificQueueId is available as well.
- * @error: A #GError.
+ * @queue_id: The numeric ID of queue to deliver the event. One of [enum@SpecificQueueId] is
+ *            available as well.
+ * @error: A [struct@GLib.Error].
  *
- * Set the numerical ID of queue to deliver the event.
+ * Set the numeric ID of queue to deliver the event.
  */
 void alsaseq_event_cntr_set_queue_id(ALSASeqEventCntr *self, gsize index,
                                        guint8 queue_id, GError **error)
@@ -648,11 +643,11 @@ void alsaseq_event_cntr_set_queue_id(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_get_tstamp:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
- * @tstamp: (out)(transfer none): The timestamp for the event. The content is
- *          affected by the mode of tstamping.
- * @error: A #GError.
+ * @tstamp: (out)(transfer none): The timestamp for the event. The content is affected by the mode
+ *          of tstamping.
+ * @error: A [struct@GLib.Error].
  *
  * Get the timestamp of event pointed by index.
  */
@@ -679,11 +674,10 @@ void alsaseq_event_cntr_get_tstamp(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_set_tstamp:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
- * @tstamp: The timestamp for the event. The content is affected by the mode of
- *          tstamping.
- * @error: A #GError.
+ * @tstamp: The timestamp for the event. The content is affected by the mode of tstamping.
+ * @error: A [struct@GLib.Error].
  *
  * Set the timestamp for the event pointed by index.
  */
@@ -710,10 +704,10 @@ void alsaseq_event_cntr_set_tstamp(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_get_dst:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @dst: (out)(transfer none): The destination of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Get the destination of event pointed by index.
  */
@@ -740,10 +734,10 @@ void alsaseq_event_cntr_get_dst(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_set_dst:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @dst: The destination of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Set the destination of event pointed by index.
  */
@@ -770,10 +764,10 @@ void alsaseq_event_cntr_set_dst(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_get_src:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @src: (out)(transfer none): The source of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Get the destination of event pointed by index.
  */
@@ -800,10 +794,10 @@ void alsaseq_event_cntr_get_src(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_set_src:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @src: The source of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Set the destination of event pointed by index.
  */
@@ -909,10 +903,10 @@ static void ensure_variable_length_event(ALSASeqEventCntrPrivate *priv,
 
 /**
  * alsaseq_event_cntr_get_note_data:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @data: (out)(transfer none): The note data of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Get the note data of event pointed by the index.
  */
@@ -938,10 +932,10 @@ void alsaseq_event_cntr_get_note_data(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_set_note_data:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @data: The note data of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Copy the note data to the event pointed by the index.
  */
@@ -971,10 +965,10 @@ void alsaseq_event_cntr_set_note_data(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_get_ctl_data:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @data: (out)(transfer none): The control data of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Get the control data of event pointed by the index.
  */
@@ -1000,10 +994,10 @@ void alsaseq_event_cntr_get_ctl_data(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_set_ctl_data:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @data: The control data of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Copy the control data to the event pointed by the index.
  */
@@ -1033,10 +1027,10 @@ void alsaseq_event_cntr_set_ctl_data(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_get_byte_data:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @data: (array fixed-size=12)(out)(transfer none): The byte data of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Get the byte data of event pointed by the index.
  */
@@ -1062,10 +1056,10 @@ void alsaseq_event_cntr_get_byte_data(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_set_byte_data:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @data: (array fixed-size=12): The byte data of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Copy the byte data to the event pointed by the index.
  */
@@ -1095,10 +1089,10 @@ void alsaseq_event_cntr_set_byte_data(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_get_quadlet_data:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @data: (array fixed-size=3)(out)(transfer none): The quadlet data of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Get the quadlet data of event pointed by the index.
  */
@@ -1125,10 +1119,10 @@ void alsaseq_event_cntr_get_quadlet_data(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_set_quadlet_data:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @data: (array fixed-size=3): The quadlet data of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Copy the quadlet data to the event pointed by the index.
  */
@@ -1159,11 +1153,11 @@ void alsaseq_event_cntr_set_quadlet_data(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_get_blob_data:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @data: (array length=size)(out)(transfer none): The pointer to blob data.
  * @size: The size of data.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Refer to the blob data of event.
  */
@@ -1205,11 +1199,11 @@ void alsaseq_event_cntr_get_blob_data(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_set_blob_data:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @data: (array length=size): The pointer to blob data for the event.
  * @size: The size of data.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Copy the quadlet data to the event pointed by the index.
  */
@@ -1236,10 +1230,10 @@ void alsaseq_event_cntr_set_blob_data(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_get_queue_data:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @data: (out)(transfer none): The queue data of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Get the queue data of event pointed by the index.
  */
@@ -1265,10 +1259,10 @@ void alsaseq_event_cntr_get_queue_data(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_set_queue_data:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @data: The queue data of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Copy the queue data to the event pointed by the index.
  */
@@ -1298,10 +1292,10 @@ void alsaseq_event_cntr_set_queue_data(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_get_tstamp_data:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @data: (out)(transfer none): The timestamp data of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Get the timestamp data of event pointed by the index.
  */
@@ -1327,10 +1321,10 @@ void alsaseq_event_cntr_get_tstamp_data(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_set_tstamp_data:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @data: The timestamp data of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Copy the timestamp data to the event pointed by the index.
  */
@@ -1360,10 +1354,10 @@ void alsaseq_event_cntr_set_tstamp_data(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_get_addr_data:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @data: (out)(transfer none): The address data of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Get the address data of event pointed by the index.
  */
@@ -1389,10 +1383,10 @@ void alsaseq_event_cntr_get_addr_data(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_set_addr_data:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @data: The address data of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Copy the address data to the event pointed by the index.
  */
@@ -1422,10 +1416,10 @@ void alsaseq_event_cntr_set_addr_data(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_get_connect_data:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @data: (out)(transfer none): The connect data of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Get the connect data of event pointed by the index.
  */
@@ -1451,10 +1445,10 @@ void alsaseq_event_cntr_get_connect_data(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_set_connect_data:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @data: The connect data of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Copy the connect data to the event pointed by the index.
  */
@@ -1484,10 +1478,10 @@ void alsaseq_event_cntr_set_connect_data(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_get_result_data:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @data: (out)(transfer none): The result data of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Get the result data of event pointed by the index.
  */
@@ -1513,10 +1507,10 @@ void alsaseq_event_cntr_get_result_data(ALSASeqEventCntr *self, gsize index,
 
 /**
  * alsaseq_event_cntr_set_result_data:
- * @self: A #ALSASeqEventCntr.
+ * @self: A [class@EventCntr].
  * @index: The index of event to set.
  * @data: The result data of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Copy the result data to the event pointed by the index.
  */

--- a/src/seq/event-data-connect.c
+++ b/src/seq/event-data-connect.c
@@ -2,14 +2,13 @@
 #include "privates.h"
 
 /**
- * SECTION: event-data-connect
- * @Title: ALSASeqEventDataConnect
- * @Short_description: A boxed object to represent data of connect event
+ * ALSASeqEventDataConnect:
+ * A boxed object to represent data of connect event.
  *
- * A #ALSASeqEventDataConnect is a boxed object to represent data of connect
- * event. The instance of object is one of data properties in event.
+ * A [struct@EventDataConnect] is a boxed object to represent data of connect event. The instance
+ * of object is one of data properties in event.
  *
- * The object wraps 'struct snd_seq_connect' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_seq_connect` in UAPI of Linux sound subsystem.
  */
 ALSASeqEventDataConnect *seq_event_data_connect_copy(const ALSASeqEventDataConnect *self)
 {
@@ -28,7 +27,7 @@ G_DEFINE_BOXED_TYPE(ALSASeqEventDataConnect, alsaseq_event_data_connect, seq_eve
 
 /**
  * alsaseq_event_data_connect_get_src:
- * @self: A #ALSASeqEventDataConnect.
+ * @self: A [struct@EventDataConnect].
  * @src: (out)(transfer none): The source of connection event.
  *
  * Get the source of connection event.
@@ -41,8 +40,8 @@ void alsaseq_event_data_connect_get_src(const ALSASeqEventDataConnect *self,
 
 /**
  * alsaseq_event_data_connect_set_src:
- * @self: A #ALSASeqEventDataConnect.
- * @src: A #ALSASeqAddr.
+ * @self: A [struct@EventDataConnect].
+ * @src: A [struct@Addr].
  *
  * Set the source to the connection event.
  */
@@ -54,7 +53,7 @@ void alsaseq_event_data_connect_set_src(ALSASeqEventDataConnect *self,
 
 /**
  * alsaseq_event_data_connect_get_dst:
- * @self: A #ALSASeqEventDataConnect.
+ * @self: A [struct@EventDataConnect].
  * @dst: (out)(transfer none): The destination of connection event.
  *
  * Get the destination of connection event.
@@ -67,8 +66,8 @@ void alsaseq_event_data_connect_get_dst(const ALSASeqEventDataConnect *self,
 
 /**
  * alsaseq_event_data_connect_set_dst:
- * @self: A #ALSASeqEventDataConnect.
- * @dst: A #ALSASeqAddr.
+ * @self: A [struct@EventDataConnect].
+ * @dst: A [struct@Addr].
  *
  * Set the source to the connection event.
  */

--- a/src/seq/event-data-ctl.c
+++ b/src/seq/event-data-ctl.c
@@ -2,14 +2,13 @@
 #include "privates.h"
 
 /**
- * SECTION: event-data-ctl
- * @Title: ALSASeqEventDataCtl
- * @Short_description: A boxed object to represent data of control event
+ * ALSASeqEventDataCtl:
+ * A boxed object to represent data of control event.
  *
- * A #ALSASeqEventDataCtl is a boxed object to represent data of control
- * event. The instance of object is one of data properties in event.
+ * A [struct@EventDataCtl] is a boxed object to represent data of control event. The instance of
+ * object is one of data properties in event.
  *
- * The object wraps 'struct snd_seq_ev_ctrl' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_seq_ev_ctrl` in UAPI of Linux sound subsystem.
  */
 ALSASeqEventDataCtl *seq_event_data_ctl_copy(const ALSASeqEventDataCtl *self)
 {
@@ -28,7 +27,7 @@ G_DEFINE_BOXED_TYPE(ALSASeqEventDataCtl, alsaseq_event_data_ctl, seq_event_data_
 
 /**
  * alsaseq_event_data_ctl_get_channel:
- * @self: A #ALSASeqEventDataCtl.
+ * @self: A [struct@EventDataCtl].
  * @channel: (out): The value of channel for the control event.
  *
  * Get the value of channel for the control event.
@@ -41,7 +40,7 @@ void alsaseq_event_data_ctl_get_channel(const ALSASeqEventDataCtl *self,
 
 /**
  * alsaseq_event_data_ctl_set_channel:
- * @self: A #ALSASeqEventDataCtl.
+ * @self: A [struct@EventDataCtl].
  * @channel: The channel for the control event.
  *
  * Set the channel for the control event.
@@ -54,7 +53,7 @@ void alsaseq_event_data_ctl_set_channel(ALSASeqEventDataCtl *self,
 
 /**
  * alsaseq_event_data_ctl_get_param:
- * @self: A #ALSASeqEventDataCtl.
+ * @self: A [struct@EventDataCtl].
  * @param: (out): The parameter for the control event.
  *
  * Get the parameter for the control event.
@@ -67,7 +66,7 @@ void alsaseq_event_data_ctl_get_param(const ALSASeqEventDataCtl *self,
 
 /**
  * alsaseq_event_data_ctl_set_param:
- * @self: A #ALSASeqEventDataCtl.
+ * @self: A [struct@EventDataCtl].
  * @param: The parameter for the control event.
  *
  * Set the parameter for the control event.
@@ -79,7 +78,7 @@ void alsaseq_event_data_ctl_set_param(ALSASeqEventDataCtl *self, guint param)
 
 /**
  * alsaseq_event_data_ctl_get_value:
- * @self: A #ALSASeqEventDataCtl.
+ * @self: A [struct@EventDataCtl].
  * @value: (out): The value for the control event.
  *
  * Get the value for the control event.
@@ -92,7 +91,7 @@ void alsaseq_event_data_ctl_get_value(const ALSASeqEventDataCtl *self,
 
 /**
  * alsaseq_event_data_ctl_set_value:
- * @self: A #ALSASeqEventDataCtl.
+ * @self: A [struct@EventDataCtl].
  * @value: The value for the control event.
  *
  * Set the value for the control event.

--- a/src/seq/event-data-note.c
+++ b/src/seq/event-data-note.c
@@ -2,14 +2,13 @@
 #include "privates.h"
 
 /**
- * SECTION: event-data-note
- * @Title: ALSASeqEventDataNote
- * @Short_description: A boxed object to represent data of note event
+ * ALSASeqEventDataNote:
+ * A boxed object to represent data of note event.
  *
- * A #ALSASeqEventDataNote is a boxed object to represent data of note event.
- * The instance of object is one of data properties in event.
+ * A [struct@EventDataNote] is a boxed object to represent data of note event. The instance of
+ * object is one of data properties in event.
  *
- * The object wraps 'struct snd_seq_ev_note' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_seq_ev_note` in UAPI of Linux sound subsystem.
  */
 ALSASeqEventDataNote *seq_event_data_note_copy(const ALSASeqEventDataNote *self)
 {
@@ -28,7 +27,7 @@ G_DEFINE_BOXED_TYPE(ALSASeqEventDataNote, alsaseq_event_data_note, seq_event_dat
 
 /**
  * alsaseq_event_data_note_get_channel:
- * @self: A #ALSASeqEventDataNote.
+ * @self: A [struct@EventDataNote].
  * @channel: (out): The value of channel in the note event.
  *
  * Get the value of channel in the note event.
@@ -41,7 +40,7 @@ void alsaseq_event_data_note_get_channel(const ALSASeqEventDataNote *self,
 
 /**
  * alsaseq_event_data_note_set_channel:
- * @self: A #ALSASeqEventDataNote.
+ * @self: A [struct@EventDataNote].
  * @channel: The value of channel for the note event.
  *
  * Set the value of channel for the note event.
@@ -54,7 +53,7 @@ void alsaseq_event_data_note_set_channel(ALSASeqEventDataNote *self,
 
 /**
  * alsaseq_event_data_note_get_note:
- * @self: A #ALSASeqEventDataNote.
+ * @self: A [struct@EventDataNote].
  * @note: (out): The value of note in the note event.
  *
  * Get the value of note in the note event.
@@ -67,7 +66,7 @@ void alsaseq_event_data_note_get_note(const ALSASeqEventDataNote *self,
 
 /**
  * alsaseq_event_data_note_set_note:
- * @self: A #ALSASeqEventDataNote.
+ * @self: A [struct@EventDataNote].
  * @note: The value of note for the note event.
  *
  * Set the value of note for the note event.
@@ -79,7 +78,7 @@ void alsaseq_event_data_note_set_note(ALSASeqEventDataNote *self, guint8 note)
 
 /**
  * alsaseq_event_data_note_get_velocity:
- * @self: A #ALSASeqEventDataNote.
+ * @self: A [struct@EventDataNote].
  * @velocity: (out): The value of velocity in the note event.
  *
  * Get the value of velocity in the note event.
@@ -92,7 +91,7 @@ void alsaseq_event_data_note_get_velocity(const ALSASeqEventDataNote *self,
 
 /**
  * alsaseq_event_data_note_set_velocity:
- * @self: A #ALSASeqEventDataNote.
+ * @self: A [struct@EventDataNote].
  * @velocity: The value of note for the velocity event.
  *
  * Set the value of note for the velocity event.
@@ -105,7 +104,7 @@ void alsaseq_event_data_note_set_velocity(ALSASeqEventDataNote *self,
 
 /**
  * alsaseq_event_data_note_get_off_velocity:
- * @self: A #ALSASeqEventDataNote.
+ * @self: A [struct@EventDataNote].
  * @off_velocity: (out): The value of off-velocity in the note event.
  *
  * Get the value of off-velocity in the note event.
@@ -118,7 +117,7 @@ void alsaseq_event_data_note_get_off_velocity(const ALSASeqEventDataNote *self,
 
 /**
  * alsaseq_event_data_note_set_off_velocity:
- * @self: A #ALSASeqEventDataNote.
+ * @self: A [struct@EventDataNote].
  * @off_velocity: The value of note for the off-velocity event.
  *
  * Set the value of note for the off-velocity event.
@@ -131,7 +130,7 @@ void alsaseq_event_data_note_set_off_velocity(ALSASeqEventDataNote *self,
 
 /**
  * alsaseq_event_data_note_get_duration:
- * @self: A #ALSASeqEventDataNote.
+ * @self: A [struct@EventDataNote].
  * @duration: (out): The value of duratino in the note event.
  *
  * Get the value of duration in the note event.
@@ -144,7 +143,7 @@ void alsaseq_event_data_note_get_duration(const ALSASeqEventDataNote *self,
 
 /**
  * alsaseq_event_data_note_set_duration:
- * @self: A #ALSASeqEventDataNote.
+ * @self: A [struct@EventDataNote].
  * @duration: The value of duration for the note event.
  *
  * Set the value of duration for the note event.

--- a/src/seq/event-data-queue.c
+++ b/src/seq/event-data-queue.c
@@ -2,15 +2,13 @@
 #include "privates.h"
 
 /**
- * SECTION: event-data-queue
- * @Title: ALSASeqEventDataQueue
- * @Short_description: A boxed object to represent data of queue event
+ * ALSASeqEventDataQueue:
+ * A boxed object to represent data of queue event.
  *
- * A #ALSASeqEventDataQueue is a boxed object to represent data of queue event.
- * The instance of object is one of data properties in event.
+ * A [struct@EventDataQueue] is a boxed object to represent data of queue event. The instance of
+ * object is one of data properties in event.
  *
- * The object wraps 'struct snd_seq_ev_queue_control' in UAPI of Linux sound
- * subsystem.
+ * The object wraps `struct snd_seq_ev_queue_control` in UAPI of Linux sound subsystem.
  */
 ALSASeqEventDataQueue *seq_event_data_queue_copy(const ALSASeqEventDataQueue *self)
 {
@@ -29,10 +27,10 @@ G_DEFINE_BOXED_TYPE(ALSASeqEventDataQueue, alsaseq_event_data_queue, seq_event_d
 
 /**
  * alsaseq_event_data_queue_get_queue_id:
- * @self: A #ALSASeqEventDataQueue.
- * @queue_id: (out): the numerical ID of queue for the event.
+ * @self: A [struct@EventDataQueue].
+ * @queue_id: (out): the numeric identifier of queue for the event.
  *
- * Get the numerical ID of queue for the event.
+ * Get the numeric identifier of queue for the event.
  */
 void alsaseq_event_data_queue_get_queue_id(const ALSASeqEventDataQueue *self,
                                            guint8 *queue_id)
@@ -42,10 +40,10 @@ void alsaseq_event_data_queue_get_queue_id(const ALSASeqEventDataQueue *self,
 
 /**
  * alsaseq_event_data_queue_set_queue_id:
- * @self: A #ALSASeqEventDataQueue.
- * @queue_id: The numerical ID of queue for the event.
+ * @self: A [struct@EventDataQueue].
+ * @queue_id: The numeric identifier of queue for the event.
  *
- * Se the numerical ID of queue for the event.
+ * Se the numeric identifier of queue for the event.
  */
 void alsaseq_event_data_queue_set_queue_id(ALSASeqEventDataQueue *self,
                                            guint8 queue_id)
@@ -55,7 +53,7 @@ void alsaseq_event_data_queue_set_queue_id(ALSASeqEventDataQueue *self,
 
 /**
  * alsaseq_event_data_queue_get_value_param:
- * @self: A #ALSASeqEventDataQueue.
+ * @self: A [struct@EventDataQueue].
  * @value: (out): The value as param of the queue event.
  *
  * Get the value as param of the queue event.
@@ -68,7 +66,7 @@ void alsaseq_event_data_queue_get_value_param(const ALSASeqEventDataQueue *self,
 
 /**
  * alsaseq_event_data_queue_set_value_param:
- * @self: A #ALSASeqEventDataQueue.
+ * @self: A [struct@EventDataQueue].
  * @value: The value as param of the queue event.
  *
  * Set the value as param of the queue event.
@@ -81,7 +79,7 @@ void alsaseq_event_data_queue_set_value_param(ALSASeqEventDataQueue *self,
 
 /**
  * alsaseq_event_data_queue_get_tstamp_param:
- * @self: A #ALSASeqEventDataQueue.
+ * @self: A [struct@EventDataQueue].
  * @tstamp: (out)(transfer none): The timestamp as param of the queue event.
  *
  * Get the timestamp as param of the queue event.
@@ -94,7 +92,7 @@ void alsaseq_event_data_queue_get_tstamp_param(const ALSASeqEventDataQueue *self
 
 /**
  * alsaseq_event_data_queue_set_tstamp_param:
- * @self: A #ALSASeqEventDataQueue.
+ * @self: A [struct@EventDataQueue].
  * @tstamp: (transfer none): The timestamp as param of the queue event.
  *
  * Set the timestamp as param of the queue event.
@@ -107,7 +105,7 @@ void alsaseq_event_data_queue_set_tstamp_param(ALSASeqEventDataQueue *self,
 
 /**
  * alsaseq_event_data_queue_get_position_param:
- * @self: A #ALSASeqEventDataQueue.
+ * @self: A [struct@EventDataQueue].
  * @position: (out): The position as param of the queue event.
  *
  * Get the position as param of the queue event.
@@ -120,7 +118,7 @@ void alsaseq_event_data_queue_get_position_param(const ALSASeqEventDataQueue *se
 
 /**
  * alsaseq_event_data_queue_set_position_param:
- * @self: A #ALSASeqEventDataQueue.
+ * @self: A [struct@EventDataQueue].
  * @position: the position as param of the queue event.
  *
  * Set the position as param of the queue event.
@@ -133,12 +131,11 @@ void alsaseq_event_data_queue_set_position_param(ALSASeqEventDataQueue *self,
 
 /**
  * alsaseq_event_data_queue_get_skew_param:
- * @self: A #ALSASeqEventDataQueue.
- * @skew: (array fixed-size=2)(out)(transfer none): The array with two elements
- *        for numerator and denominator of fraction for skew.
+ * @self: A [struct@EventDataQueue].
+ * @skew: (array fixed-size=2)(out)(transfer none): The array with two elements for numerator and
+ *        denominator of fraction for skew.
  *
- * Refer to numerator and denominator of fraction for skew as the parameter of
- * queue event.
+ * Refer to numerator and denominator of fraction for skew as the parameter of queue event.
  */
 void alsaseq_event_data_queue_get_skew_param(const ALSASeqEventDataQueue *self,
                                              const guint *skew[2])
@@ -150,12 +147,12 @@ void alsaseq_event_data_queue_get_skew_param(const ALSASeqEventDataQueue *self,
 
 /**
  * alsaseq_event_data_queue_set_skew_param:
- * @self: A #ALSASeqEventDataQueue.
- * @skew: (array fixed-size=2)(transfer none): The array with two elements for
- *        numerator and denominator of fraction for skew.
+ * @self: A [struct@EventDataQueue].
+ * @skew: (array fixed-size=2)(transfer none): The array with two elements for numerator and
+ *        denominator of fraction for skew.
  *
- * Copy numerator and denominator of fraction for skew from the given buffer as
- * the parameter of queue event.
+ * Copy numerator and denominator of fraction for skew from the given buffer as the parameter of
+ * queue event.
  */
 void alsaseq_event_data_queue_set_skew_param(ALSASeqEventDataQueue *self,
                                              const guint skew[2])
@@ -166,9 +163,9 @@ void alsaseq_event_data_queue_set_skew_param(ALSASeqEventDataQueue *self,
 
 /**
  * alsaseq_event_data_queue_get_quadlet_param:
- * @self: A #ALSASeqEventDataQueue.
- * @quadlets: (array fixed-size=2)(out)(transfer none): The array with two
- *            elements for quadlets as the parameter of queue event.
+ * @self: A [struct@EventDataQueue].
+ * @quadlets: (array fixed-size=2)(out)(transfer none): The array with two elements for quadlets as
+ *            the parameter of queue event.
  *
  * Refer to two quadlets as the parameter of queue event.
  */
@@ -180,9 +177,9 @@ void alsaseq_event_data_queue_get_quadlet_param(const ALSASeqEventDataQueue *sel
 
 /**
  * alsaseq_event_data_queue_set_quadlet_param:
- * @self: A #ALSASeqEventDataQueue.
- * @quadlets: (array fixed-size=2)(transfer none): The array with two elements
- *            for quadlets as the parameter of queue event.
+ * @self: A [struct@EventDataQueue].
+ * @quadlets: (array fixed-size=2)(transfer none): The array with two elements for quadlets as the
+ *            parameter of queue event.
  *
  * Set two quadlets from the given buffer as the parameter of queue event.
  */
@@ -194,9 +191,9 @@ void alsaseq_event_data_queue_set_quadlet_param(ALSASeqEventDataQueue *self,
 
 /**
  * alsaseq_event_data_queue_get_byte_param:
- * @self: A #ALSASeqEventDataQueue.
- * @bytes: (array fixed-size=8)(out)(transfer none): The array with eight
- *         elements for bytes parameter of the queue event.
+ * @self: A [struct@EventDataQueue].
+ * @bytes: (array fixed-size=8)(out)(transfer none): The array with eight elements for bytes
+ *         parameter of the queue event.
  *
  * Refer to eight bytes as the parameter of queue event.
  */
@@ -208,9 +205,9 @@ void alsaseq_event_data_queue_get_byte_param(const ALSASeqEventDataQueue *self,
 
 /**
  * alsaseq_event_data_queue_set_byte_param:
- * @self: A #ALSASeqEventDataQueue.
- * @bytes: (array fixed-size=8)(transfer none): The array with eight elements
- *         for bytes parameter of the queue event.
+ * @self: A [struct@EventDataQueue].
+ * @bytes: (array fixed-size=8)(transfer none): The array with eight elements for bytes parameter
+ *         of the queue event.
  *
  * Copy eight bytes from the given buffer as the parameter of queue event.
  */

--- a/src/seq/event-data-result.c
+++ b/src/seq/event-data-result.c
@@ -2,14 +2,13 @@
 #include "privates.h"
 
 /**
- * SECTION: event-data-result
- * @Title: ALSASeqEventDataResult
- * @Short_description: A boxed object to represent data of result event
+ * ALSASeqEventDataResult:
+ * A boxed object to represent data of result event.
  *
- * A #ALSASeqEventDataResult is a boxed object to represent data of result
- * event. The instance of object is one of data properties in event.
+ * A [struct@EventDataResult] is a boxed object to represent data of result event. The instance of
+ * object is one of data properties in event.
  *
- * The object wraps 'struct snd_seq_result' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_seq_result` in UAPI of Linux sound subsystem.
  */
 ALSASeqEventDataResult *seq_event_data_result_copy(const ALSASeqEventDataResult *self)
 {
@@ -28,7 +27,7 @@ G_DEFINE_BOXED_TYPE(ALSASeqEventDataResult, alsaseq_event_data_result, seq_event
 
 /**
  * alsaseq_event_data_result_get_event:
- * @self: A #ALSASeqEventDataResult.
+ * @self: A [struct@EventDataResult].
  * @event_type: (out): The type of event in which the data results.
  *
  * Get the type of event in which the data results.
@@ -41,7 +40,7 @@ void alsaseq_event_data_result_get_event(const ALSASeqEventDataResult *self,
 
 /**
  * alsaseq_event_data_result_set_event:
- * @self: A #ALSASeqEventDataResult.
+ * @self: A [struct@EventDataResult].
  * @event_type: A #ALSASeqEventType.
  *
  * Set the type of event in which the data results.
@@ -54,7 +53,7 @@ void alsaseq_event_data_result_set_event(ALSASeqEventDataResult *self,
 
 /**
  * alsaseq_event_data_result_get_result:
- * @self: A #ALSASeqEventDataResult.
+ * @self: A [struct@EventDataResult].
  * @result: (out): the status of the event.
  *
  * Get the status of event.
@@ -67,7 +66,7 @@ void alsaseq_event_data_result_get_result(const ALSASeqEventDataResult *self,
 
 /**
  * alsaseq_event_data_result_set_result:
- * @self: A #ALSASeqEventDataResult.
+ * @self: A [struct@EventDataResult].
  * @result: The status of event.
  *
  * Set the status of event.

--- a/src/seq/port-info.c
+++ b/src/seq/port-info.c
@@ -2,16 +2,14 @@
 #include "privates.h"
 
 /**
- * SECTION: port-info
- * @Title: ALSASeqPortInfo
- * @Short_description: A GObject-derived object to represent information of port
+ * ALSASeqPortInfo:
+ * A GObject-derived object to represent information of port.
  *
- * A #ALSASeqPortInfo is a GObject-derived object to represent information of
- * port. The call of alsaseq_get_port_info() returns the instance of object.
- * The call of alsaseq_user_client_create_port() and
- * alsaseq_user_client_update_port() requires the instance of object.
+ * A [class@PortInfo] is a GObject-derived object to represent information of port. The call of
+ * [func@get_port_info] returns the instance of object. The call of [method@UserClient.create_port]
+ * and [method@UserClient.update_port] requires the instance of object.
  *
- * The object wraps 'struct snd_port_info' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_port_info` in UAPI of Linux sound subsystem.
  */
 typedef struct {
     struct snd_seq_port_info info;
@@ -253,7 +251,9 @@ static void alsaseq_port_info_init(ALSASeqPortInfo *self)
 /**
  * alsaseq_port_info_new:
  *
- * Allocate and return an instance of ALSASeqPortInfo class.
+ * Allocate and return an instance of [class@PortInfo].
+ *
+ * Returns: An instance of [class@PortInfo].
  */
 ALSASeqPortInfo *alsaseq_port_info_new()
 {

--- a/src/seq/query.c
+++ b/src/seq/query.c
@@ -10,16 +10,9 @@
 #include <unistd.h>
 
 /**
- * SECTION: query
- * @Title: Global functions in ALSASeq
- * @Short_description: Global functions available without holding any file
- *                     descriptor
- */
-
-/**
  * alsaseq_get_seq_sysname:
  * @sysname: (out): The sysname of ALSA Sequencer.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
  * Allocate sysname string for ALSA sequencer and return it when exists.
  *
@@ -40,7 +33,7 @@ void alsaseq_get_seq_sysname(gchar **sysname, GError **error)
 /**
  * alsaseq_get_seq_devnode:
  * @devnode: (out): The devnode of ALSA Sequencer.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
  * Allocate devnode string for ALSA Sequencer and return it when exists.
  *
@@ -78,12 +71,12 @@ static int open_fd(GError **error)
 /**
  * alsaseq_get_system_info:
  * @system_info: (out): The information of ALSA Sequencer.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
  * Get information of ALSA Sequencer.
  *
- * The call of function executes open(2), close(2), and ioctl(2) system calls
- * with SNDRV_SEQ_IOCTL_SYSTEM_INFO command for ALSA sequencer character device.
+ * The call of function executes `open(2)``, ``close(2)``, and ``ioctl(2)`` system calls with
+ * `SNDRV_SEQ_IOCTL_SYSTEM_INFO` command for ALSA sequencer character device.
  */
 void alsaseq_get_system_info(ALSASeqSystemInfo **system_info, GError **error)
 {
@@ -115,18 +108,17 @@ end:
 
 /**
  * alsaseq_get_client_id_list:
- * @entries: (array length=entry_count)(out): The array with elements for
- *           numerical ID of client. One of ALSASeqSpecificClientId can be
- *           included in result as well as any numerical value.
+ * @entries: (array length=entry_count)(out): The array with elements for numeric identified of
+ *           client. One of [enum@SpecificClientId] can be included in result as well as any
+ *           numeric value.
  * @entry_count: The number of entries.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
- * Get the list of clients as the numerical ID.
+ * Get the list of clients as the numeric identifier.
  *
- * The call of function executes open(2), close(2), and ioctl(2) system calls
- * with SNDRV_SEQ_IOCTL_CLIENT_ID, SNDRV_SEQ_IOCTL_SYSTEM_INFO, and
- * SNDRV_SEQ_IOCTL_QUERY_NEXT_CLIENT command for ALSA sequencer character
- * device.
+ * The call of function executes `open(2)``, ``close(2)``, and ``ioctl(2)`` system calls with
+ * `SNDRV_SEQ_IOCTL_CLIENT_ID`, `SNDRV_SEQ_IOCTL_SYSTEM_INFO`, and
+ * `SNDRV_SEQ_IOCTL_QUERY_NEXT_CLIENT` command for ALSA sequencer character device.
  */
 void alsaseq_get_client_id_list(guint8 **entries, gsize *entry_count,
                                 GError **error)
@@ -197,17 +189,15 @@ end:
 
 /**
  * alsaseq_get_client_info:
- * @client_id: The numerical ID of client to query. One of
- *             ALSASeqSpecificClientId is available as well as any numerical
- *             value.
- * @client_info: (out): A #ALSASeqClientInfo for the client.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @client_id: The numeric identifier of client to query. One of [enum@SpecificClientId] is
+ *             available as well as any numeric value.
+ * @client_info: (out): A [class@ClientInfo] for the client.
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
- * Get the information of client according to the numerical ID.
+ * Get the information of client according to the numeric ID.
  *
- * The call of function executes open(2), close(2), and ioctl(2) system calls
- * with SNDRV_SEQ_IOCTL_GET_CLIENT_INFO command for ALSA sequencer character
- * device.
+ * The call of function executes `open(2)``, ``close(2)``, and ``ioctl(2)`` system calls with
+ * `SNDRV_SEQ_IOCTL_GET_CLIENT_INFO` command for ALSA sequencer character device.
  */
 void alsaseq_get_client_info(guint8 client_id, ALSASeqClientInfo **client_info,
                              GError **error)
@@ -237,20 +227,18 @@ void alsaseq_get_client_info(guint8 client_id, ALSASeqClientInfo **client_info,
 
 /**
  * alsaseq_get_port_id_list:
- * @client_id: The numerical ID of client to query. One of
- *             ALSASeqSpecificClientId is available as well as any numerical
- *             value.
- * @entries: (array length=entry_count)(out): The array with elements for
- *           numerical ID of port. One of ALSASeqSpecificPortId is available as
- *           well as any numerical value.
+ * @client_id: The numeric ID of client to query. One of [enum@SpecificClientId] is available as
+ *             well as any numeric value.
+ * @entries: (array length=entry_count)(out): The array with elements for numeric identifier of
+ *           port. One of [enum@SpecificPortId] is available as well as any numeric value.
  * @entry_count: The number of entries in the array.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
- * Get the list of numerical IDs for port added by the client.
+ * Get the list of numeric identifiers for port added by the client.
  *
- * The call of function executes open(2), close(2), and ioctl(2) system calls
- * with SNDRV_SEQ_IOCTL_GET_CLIENT_INFO and SNDRV_SEQ_IOCTL_QUERY_NEXT_PORT
- * commands for ALSA sequencer character device.
+ * The call of function executes `open(2)``, ``close(2)``, and ``ioctl(2)`` system calls with
+ * `SNDRV_SEQ_IOCTL_GET_CLIENT_INFO` and `SNDRV_SEQ_IOCTL_QUERY_NEXT_PORT` commands for ALSA
+ * sequencer character device.
  */
 void alsaseq_get_port_id_list(guint8 client_id, guint8 **entries,
                               gsize *entry_count, GError **error)
@@ -310,19 +298,17 @@ end:
 
 /**
  * alsaseq_get_port_info:
- * @client_id: The numerical ID of client to query. One of
- *             ALSASeqSpecificClientId is available as well as any numerica
- *             value.
- * @port_id: The numerical ID of port in the client. One of
- *           ALSASeqSpecificPortId is available as well as any numerical value.
- * @port_info: (out): A #ALSASeqPortInfo for the port.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @client_id: The numeric identifier of client to query. One of [enum@SpecificClientId] is
+ *             available as well as any numerica value.
+ * @port_id: The numeric identifier of port in the client. One of [enum@SpecificPortId] is
+ *           available as well as any numeric value.
+ * @port_info: (out): A [class@PortInfo] for the port.
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
  * Get the information of port in client.
  *
- * The call of function executes open(2), close(2), and ioctl(2) system calls
- * with SNDRV_SEQ_IOCTL_GET_PORT_INFO command for ALSA sequencer character
- * device.
+ * The call of function executes `open(2)`, `close(2)`, and `ioctl(2)` system calls with
+ * `SNDRV_SEQ_IOCTL_GET_PORT_INFO` command for ALSA sequencer character device.
  */
 void alsaseq_get_port_info(guint8 client_id, guint8 port_id,
                            ALSASeqPortInfo **port_info, GError **error)
@@ -353,17 +339,15 @@ void alsaseq_get_port_info(guint8 client_id, guint8 port_id,
 
 /**
  * alsaseq_get_client_pool:
- * @client_id: The numerical ID of client to query. One of
- *             ALSASeqSpecificClientId is available as well as any numerical
- *             value.
+ * @client_id: The numeric ID of client to query. One of [enum@SpecificClientId] is available as
+ *             well as any numeric value.
  * @client_pool: (out): The information of memory pool for the client.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
  * Get statistical information of memory pool for the given client.
  *
- * The call of function executes open(2), close(2), and ioctl(2) system calls
- * with SNDRV_SEQ_IOCTL_GET_CLIENT_POOL command for ALSA sequencer character
- * device.
+ * The call of function executes `open(2)`, `close(2)`, and `ioctl(2)` system calls with
+ * `SNDRV_SEQ_IOCTL_GET_CLIENT_POOL` command for ALSA sequencer character device.
  */
 void alsaseq_get_client_pool(guint8 client_id, ALSASeqClientPool **client_pool,
                              GError **error)
@@ -406,16 +390,16 @@ static void fill_data_with_result(struct snd_seq_port_subscribe *data,
 
 /**
  * alsaseq_get_subscription_list:
- * @addr: A #ALSASeqAddr to query.
- * @query_type: The type of query, one of #ALSASeqQuerySubscribeType.
- * @entries: (element-type ALSASeq.SubscribeData)(out): The array with element
- *           for subscription data.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @addr: A [struct@Addr] to query.
+ * @query_type: The type of query, one of [enum@QuerySubscribeType].
+ * @entries: (element-type ALSASeq.SubscribeData)(out): The array with element for subscription
+ *           data.
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
  * Get the list of subscription for given address and query type.
  *
- * The call of function executes open(2), close(2), and ioctl(2) system calls
- * with SNDRV_SEQ_IOCTL_QUERY_SUBS command for ALSA sequencer character device.
+ * The call of function executes `open(2)`, `close(2)`, and `ioctl(2)` system calls with
+ * `SNDRV_SEQ_IOCTL_QUERY_SUBS` command for ALSA sequencer character device.
  */
 void alsaseq_get_subscription_list(const ALSASeqAddr *addr,
                                    ALSASeqQuerySubscribeType query_type,
@@ -475,16 +459,15 @@ end:
 
 /**
  * alsaseq_get_queue_id_list:
- * @entries: (array length=entry_count)(out): The array of elements for
- *           numerical ID of queue.
+ * @entries: (array length=entry_count)(out): The array of elements for numeric identifier of queue.
  * @entry_count: The number of entries.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
  * Get the list of queue in ALSA Sequencer.
  *
- * The call of function executes open(2), close(2), and ioctl(2) system calls
- * with SNDRV_SEQ_IOCTL_SYSTEM_INFO and SNDRV_SEQ_IOCTL_GET_QUEUE_INFO commands
- * for ALSA sequencer character device.
+ * The call of function executes `open(2)`, `close(2)`, and `ioctl(2)` system calls with
+ * `SNDRV_SEQ_IOCTL_SYSTEM_INFO` and `SNDRV_SEQ_IOCTL_GET_QUEUE_INFO` commands for ALSA
+ * sequencer character device.
  */
 void alsaseq_get_queue_id_list(guint8 **entries, gsize *entry_count,
                                GError **error)
@@ -540,16 +523,14 @@ end:
 
 /**
  * alsaseq_get_queue_info_by_id:
- * @queue_id: The numerical ID of queue, except for one of
- *            ALSASeqSpecificQueueId.
+ * @queue_id: The numeric ID of queue, except for one of [enum@SpecificQueueId].
  * @queue_info: (out): The information of queue.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
- * Get the information of queue, according to the numerical ID.
+ * Get the information of queue, according to the numeric ID.
  *
- * The call of function executes open(2), close(2), and ioctl(2) system calls
- * with SNDRV_SEQ_IOCTL_GET_QUEUE_INFO command for ALSA sequencer character
- * device.
+ * The call of function executes `open(2)`, `close(2)`, and `ioctl(2)` system calls with
+ * `SNDRV_SEQ_IOCTL_GET_QUEUE_INFO` command for ALSA sequencer character device.
  */
 void alsaseq_get_queue_info_by_id(guint8 queue_id, ALSASeqQueueInfo **queue_info,
                                   GError **error)
@@ -580,13 +561,12 @@ void alsaseq_get_queue_info_by_id(guint8 queue_id, ALSASeqQueueInfo **queue_info
  * alsaseq_get_queue_info_by_name:
  * @name: The name string of queue to query.
  * @queue_info: (out): The information of queue.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
  * Get the information of queue, according to the name string.
  *
- * The call of function executes open(2), close(2), and ioctl(2) system calls
- * with SNDRV_SEQ_IOCTL_GET_NAMED_QUEUE command for ALSA sequencer character
- * device.
+ * The call of function executes `open(2)`, `close(2)`, and `ioctl(2)` system calls with
+ * `SNDRV_SEQ_IOCTL_GET_NAMED_QUEUE` command for ALSA sequencer character device.
  */
 void alsaseq_get_queue_info_by_name(const gchar *name,
                                     ALSASeqQueueInfo **queue_info,
@@ -616,16 +596,14 @@ void alsaseq_get_queue_info_by_name(const gchar *name,
 
 /**
  * alsaseq_get_queue_status:
- * @queue_id: The numerical ID of queue, except for entries in
- *            ALSASeqSpecificQueueId.
+ * @queue_id: The numeric ID of queue, except for entries in [enum@SpecificQueueId].
  * @queue_status: (inout): The current status of queue.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
  * Get current status of queue.
  *
- * The call of function executes open(2), close(2), and ioctl(2) system calls
- * with SNDRV_SEQ_IOCTL_GET_QUEUE_STATUS command for ALSA sequencer character
- * device.
+ * The call of function executes `open(2)`, `close(2)`, and `ioctl(2)` system calls with
+ * `SNDRV_SEQ_IOCTL_GET_QUEUE_STATUS` command for ALSA sequencer character device.
  */
 void alsaseq_get_queue_status(guint8 queue_id,
                               ALSASeqQueueStatus *const *queue_status,

--- a/src/seq/queue-info.c
+++ b/src/seq/queue-info.c
@@ -2,18 +2,15 @@
 #include "privates.h"
 
 /**
- * SECTION: queue-info
- * @Title: ALSASeqQueueInfo
- * @Short_description: A GObject-derived object to represent information of
- *                     queue
+ * ALSASeqQueueInfo:
+ * A GObject-derived object to represent information of queue.
  *
- * A #ALSASeqQueueInfo is a GObject-derived object to represent information of
- * queue. The call of alsaseq_get_queue_info_by_id() and
- * alsaseq_get_queue_info_by_name() returns the instance of object. The call of
- * alsaseq_user_client_create_queue() and alsaseq_user_client_update_queue()
- * requires the instance of object.
+ * A [class@QueueInfo] is a GObject-derived object to represent information of queue. The call of
+ * [func@get_queue_info_by_id] and [func@get_queue_info_by_name] returns the instance of object.
+ * The call of [method@UserClient.create_queue] and [method@UserClient.update_queue] requires the
+ * instance of object.
  *
- * The object wraps 'struct snd_seq_queue_info' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_seq_queue_info` in UAPI of Linux sound subsystem.
  */
 typedef struct {
     struct snd_seq_queue_info info;
@@ -129,9 +126,9 @@ static void alsaseq_queue_info_init(ALSASeqQueueInfo *self)
 /**
  * alsaseq_queue_info_new:
  *
- * Allocate and return an instance of ALSASeqQueueInfo.
+ * Allocate and return an instance of [class@QueueInfo].
  *
- * Returns: A #ALSASeqQueueInfo.
+ * Returns: An instance of [class@QueueInfo].
  */
 ALSASeqQueueInfo *alsaseq_queue_info_new()
 {

--- a/src/seq/queue-status.c
+++ b/src/seq/queue-status.c
@@ -2,15 +2,13 @@
 #include "privates.h"
 
 /**
- * SECTION: queue-status
- * @Title: ALSASeqQueueStatus
- * @Short_description: A GObject-derived object to represent status of queue
+ * ALSASeqQueueStatus:
+ * A GObject-derived object to represent status of queue.
  *
- * A #ALSASeqQueueStatus is a GObject-derived object to represent status of
- * queue. The call of alsaseq_get_queue_status() returns the instance of object.
+ * A [class@QueueStatus] is a GObject-derived object to represent status of queue. The call of
+ * [func@get_queue_status] returns the instance of object.
  *
- * The object wraps 'struct snd_seq_queue_status' in UAPI of Linux sound
- * subsystem.
+ * The object wraps `struct snd_seq_queue_status` in UAPI of Linux sound subsystem.
  */
 typedef struct {
     struct snd_seq_queue_status status;
@@ -88,9 +86,9 @@ static void alsaseq_queue_status_init(ALSASeqQueueStatus *self)
 /**
  * alsaseq_queue_status_new:
  *
- * Allocate and returns an instance of #ALSASeqQueueStatus.
+ * Allocate and returns an instance of [class@QueueStatus].
  *
- * Returns: A #ALSASeqQueueStatus.
+ * Returns: An instance of [class@QueueStatus].
  */
 ALSASeqQueueStatus *alsaseq_queue_status_new()
 {
@@ -99,8 +97,8 @@ ALSASeqQueueStatus *alsaseq_queue_status_new()
 
 /**
  * alsaseq_queue_status_get_tick_time:
- * @self: A #ALSASeqQueueStatus.
- * @tick_time: (out): The number of MIDI ticks.
+ * @self: A [class@QueueStatus].
+ * @tick_time: (out): The value of MIDI ticks.
  *
  * Get time as MIDI ticks.
  */
@@ -119,9 +117,9 @@ void alsaseq_queue_status_get_tick_time(ALSASeqQueueStatus *self,
 
 /**
  * alsaseq_queue_status_get_real_time:
- * @self: A #ALSASeqQueueStatus.
- * @real_time: (array fixed-size=2)(out)(transfer none): The array with two
- *             elements for sec part and nsec part of real time.
+ * @self: A [class@QueueStatus].
+ * @real_time: (array fixed-size=2)(out)(transfer none): The array with two elements for sec part
+ *             and nsec part of real time.
  *
  * Get time as wall-clock time.
  */

--- a/src/seq/queue-tempo.c
+++ b/src/seq/queue-tempo.c
@@ -2,14 +2,12 @@
 #include "privates.h"
 
 /**
- * SECTION: queue-tempo
- * @Title: ALSASeqQueueTempo
- * @Short_description: A GObject-derived object to represent tempo of queue
+ * ALSASeqQueueTempo:
+ * A GObject-derived object to represent tempo of queue.
  *
- * A #ALSASeqQueueTempo is a GObject-derived object to represent tempo of queue.
- * The call of alsaseq_get_queue_status() returns the instance of object.
+ * A [class@QueueTempo] is a GObject-derived object to represent tempo of queue.
  *
- * The object wraps 'struct snd_seq_queue_tempo' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_seq_queue_tempo` in UAPI of Linux sound subsystem.
  */
 typedef struct {
     struct snd_seq_queue_tempo tempo;
@@ -112,9 +110,9 @@ static void alsaseq_queue_tempo_init(ALSASeqQueueTempo *self)
 /**
  * alsaseq_queue_tempo_new:
  *
- * Allocate and return an instance of ALSASeqQueueTempo.
+ * Allocate and return an instance of [class@QueueTempo].
  *
- * Returns: A #ALSASeqQueueTempo.
+ * Returns: An instance of [class@QueueTempo].
  */
 ALSASeqQueueTempo *alsaseq_queue_tempo_new()
 {
@@ -123,9 +121,9 @@ ALSASeqQueueTempo *alsaseq_queue_tempo_new()
 
 /**
  * alsaseq_queue_tempo_get_skew:
- * @self: A #ALSASeqQueueTempo.
- * @skew: (array fixed-size=2)(out)(transfer none): The array with two elements
- *        for numerator and denominator of fraction for skew.
+ * @self: A [class@QueueTempo].
+ * @skew: (array fixed-size=2)(out)(transfer none): The array with two elements for numerator and
+ *        denominator of fraction for skew.
  *
  * Refer to numerator and denominator of fraction for skew.
  */
@@ -146,9 +144,9 @@ void alsaseq_queue_tempo_get_skew(ALSASeqQueueTempo *self, const guint32 *skew[2
 
 /**
  * alsaseq_queue_tempo_set_skew:
- * @self: A #ALSASeqQueueTempo.
- * @skew: (array fixed-size=2)(transfer none): The array with two elements for
- *        numerator and denominator of fraction for skew.
+ * @self: A [class@QueueTempo].
+ * @skew: (array fixed-size=2)(transfer none): The array with two elements for numerator and
+ *        denominator of fraction for skew.
  *
  * Copy numerator and denominator of fraction for skew.
  */

--- a/src/seq/queue-timer-data-alsa.c
+++ b/src/seq/queue-timer-data-alsa.c
@@ -2,14 +2,11 @@
 #include "privates.h"
 
 /**
- * SECTION: queue-timer-data-alsa
- * @Title: ALSASeqQueueTimerDataAlsa
- * @Short_description: A boxed object to represent data of queue timer in the
- *                     case of ALSATimer
+ * ALSASeqQueueTimerDataAlsa:
+ * A boxed object to represent data of queue timer in the case of ALSATimer.
  *
- * A #ALSASeqQueueTimerDataAlsa is a boxed object to represent data of queue
- * timer in the case of ALSATimer. The instance of object is one of data
- * properties in queue timer.
+ * A [struct@QueueTimerDataAlsa] is a boxed object to represent data of queue timer in the case of
+ * ALSATimer. The instance of object is one of data properties in queue timer.
  */
 ALSASeqQueueTimerDataAlsa *seq_queue_timer_data_alsa_copy(const ALSASeqQueueTimerDataAlsa *self)
 {
@@ -28,10 +25,10 @@ G_DEFINE_BOXED_TYPE(ALSASeqQueueTimerDataAlsa, alsaseq_queue_timer_data_alsa, se
 
 /**
  * alsaseq_queue_timer_data_alsa_get_device_id:
- * @self: A #ALSASeqQueueTimerDataAlsa.
- * @device_id: (out)(transfer none): A #ALSATimerDeviceId.
+ * @self: A [struct@QueueTimerDataAlsa].
+ * @device_id: (out)(transfer none): A [struct@ALSATimer.DeviceId].
  *
- * Refer to the device ID of timer which drives the queue.
+ * Refer to the device identifier of timer which drives the queue.
  */
 void alsaseq_queue_timer_data_alsa_get_device_id(const ALSASeqQueueTimerDataAlsa *self,
                                         const ALSATimerDeviceId **device_id)
@@ -41,10 +38,10 @@ void alsaseq_queue_timer_data_alsa_get_device_id(const ALSASeqQueueTimerDataAlsa
 
 /**
  * alsaseq_queue_timer_data_alsa_set_device_id:
- * @self: A #ALSASeqQueueTimerDataAlsa.
- * @device_id: A #ALSATimerDeviceId.
+ * @self: A [struct@QueueTimerDataAlsa].
+ * @device_id: A [struct@ALSATimer.DeviceId].
  *
- * Copy the device ID of timer which drives the queue.
+ * Copy the device identifier of timer which drives the queue.
  */
 void alsaseq_queue_timer_data_alsa_set_device_id(ALSASeqQueueTimerDataAlsa *self,
                                         const ALSATimerDeviceId *device_id)
@@ -54,7 +51,7 @@ void alsaseq_queue_timer_data_alsa_set_device_id(ALSASeqQueueTimerDataAlsa *self
 
 /**
  * alsaseq_queue_timer_data_alsa_get_resolution:
- * @self: A #ALSASeqQueueTimerDataAlsa.
+ * @self: A [struct@QueueTimerDataAlsa].
  * @resolution: (out): The resolution of timer.
  *
  * Get the resolution of timer which drives the queue.
@@ -67,7 +64,7 @@ void alsaseq_queue_timer_data_alsa_get_resolution(const ALSASeqQueueTimerDataAls
 
 /**
  * alsaseq_queue_timer_data_alsa_set_resolution:
- * @self: A #ALSASeqQueueTimerDataAlsa.
+ * @self: A [struct@QueueTimerDataAlsa].
  * @resolution: The resolution of timer.
  *
  * Set the resolution of timer which drives the queue.

--- a/src/seq/queue-timer.c
+++ b/src/seq/queue-timer.c
@@ -2,14 +2,13 @@
 #include "privates.h"
 
 /**
- * SECTION: queue-timer
- * @Title: ALSASeqQueueTimer
- * @Short_description: A GObject-derived object to represent timer for queue
+ * ALSASeqQueueTimer:
+ * A GObject-derived object to represent timer for queue.
  *
- * A #ALSASeqQueueTimer is a GObject-derived object to represent the information
- * of timer which drives the queue.
+ * A [class@QueueTimer] is a GObject-derived object to represent the information of timer which
+ * drives the queue.
  *
- * The object wraps 'struct snd_seq_queue_timer' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_seq_queue_timer` in UAPI of Linux sound subsystem.
  */
 typedef struct {
     struct snd_seq_queue_timer timer;
@@ -78,9 +77,9 @@ static void alsaseq_queue_timer_init(ALSASeqQueueTimer *self)
 /**
  * alsaseq_queue_timer_new:
  *
- * Allocate and return the instance of #ALSASeqQueueTimer.
+ * Allocate and return an instance of [class@QueueTimer].
  *
- * Returns: the instance of #ALSASeqQueueTimer.
+ * Returns: An instance of [class@QueueTimer].
  */
 ALSASeqQueueTimer *alsaseq_queue_timer_new()
 {
@@ -89,11 +88,10 @@ ALSASeqQueueTimer *alsaseq_queue_timer_new()
 
 /**
  * alsaseq_queue_timer_get_alsa_data:
- * @self: A #ALSASeqQueueTimer.
- * @data: (out)(transfer none): A #ALSASeqQueueTimerDataAlsa.
+ * @self: A [class@QueueTimer].
+ * @data: (out)(transfer none): A [struct@QueueTimerDataAlsa].
  *
- * Refer to the data of timer for queue in the case that the device in ALSATimer
- * drives the timer.
+ * Refer to the data of timer for queue in the case that the device in ALSATimer drives the timer.
  */
 void alsaseq_queue_timer_get_alsa_data(ALSASeqQueueTimer *self,
                                        const ALSASeqQueueTimerDataAlsa **data)
@@ -110,11 +108,10 @@ void alsaseq_queue_timer_get_alsa_data(ALSASeqQueueTimer *self,
 
 /**
  * alsaseq_queue_timer_set_alsa_data:
- * @self: A #ALSASeqQueueTimer.
- * @data: A #ALSASeqQueueTimerDataAlsa.
+ * @self: A [class@QueueTimer].
+ * @data: A [struct@QueueTimerDataAlsa].
  *
- * Set the data of timer for queue in the case that the device in ALSATimer
- * drives the timer.
+ * Set the data of timer for queue in the case that the device in ALSATimer drives the timer.
  */
 void alsaseq_queue_timer_set_alsa_data(ALSASeqQueueTimer *self,
                                        const ALSASeqQueueTimerDataAlsa *data)

--- a/src/seq/remove-filter.c
+++ b/src/seq/remove-filter.c
@@ -4,18 +4,14 @@
 #include <errno.h>
 
 /**
- * SECTION: remove-filter
- * @Title: ALSASeqRemoveFilter
- * @Short_description: A boxed object to represent filter to remove scheduled
- *                     event in queue
+ * ALSASeqRemoveFilter:
+ * A boxed object to represent filter to remove scheduled event in queue.
  *
- * A #ALSASeqRemoveFilter is a boxed object to represent filter to remove
- * scheduled event in queue. The call of alsaseq_user_client_remove_events()
- * requires the instance of object. In the object, data shares the same storage,
- * thus it's not possible to use several purposes.
+ * A [struct@RemoveFilter] is a boxed object to represent filter to remove scheduled event in
+ * queue. The call of [method@UserClient.remove_events] requires the instance of object. In the
+ * object, data shares the same storage, thus it's not possible to use several purposes.
  *
- * The object wraps 'struct snd_seq_remove_events' in UAPI of Linux sound
- * subsystem.
+ * The object wraps `struct snd_seq_remove_events` in UAPI of Linux sound subsystem.
  */
 ALSASeqRemoveFilter *seq_remove_filter_copy(const ALSASeqRemoveFilter *self)
 {
@@ -34,14 +30,16 @@ G_DEFINE_BOXED_TYPE(ALSASeqRemoveFilter, alsaseq_remove_filter, seq_remove_filte
 
 /**
  * alsaseq_remove_filter_new_with_dest_addr:
- * @inout: The direction of queue; ALSASEQ_REMOVE_FILTER_FLAG_INPUT or
- *         ALSASEQ_REMOVE_FILTER_FLAG_OUTPUT.
- * @queue_id: The numerical ID of queue.
+ * @inout: The direction of queue; [flags@RemoveFilterFlag].INPUT or
+ *         [flags@RemoveFilterFlag].OUTPUT.
+ * @queue_id: The numeric identifier of queue.
  * @dest: The address of destination.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
- * Allocate and return a memory object of ALSASeqRemoveFilter to remove queued
- * events towards the destination.
+ * Allocate and return a memory object of [struct@RemoveFilter] to remove queued events towards the
+ * destination.
+ *
+ * Returns: A [struct@RemoveFilter].
  */
 ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_dest_addr(
                                 ALSASeqRemoveFilterFlag inout, guint8 queue_id,
@@ -61,14 +59,16 @@ ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_dest_addr(
 
 /**
  * alsaseq_remove_filter_new_with_note_channel:
- * @inout: The direction of queue; ALSASEQ_REMOVE_FILTER_FLAG_INPUT or
- *         ALSASEQ_REMOVE_FILTER_FLAG_OUTPUT.
- * @queue_id: The numerical ID of queue.
+ * @inout: The direction of queue; [flags@RemoveFilterFlag].INPUT or
+ *         [flags@RemoveFilterFlag].OUTPUT.
+ * @queue_id: The numeric identifier of queue.
  * @channel: The channel for note event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
- * Allocate and return a memory object of ALSASeqRemoveFilter to remove queued
- * events with note type towards the channel.
+ * Allocate and return a memory object of [struct@RemoveFilter] to remove queued events with note
+ * type towards the channel.
+ *
+ * Returns: A [struct@RemoveFilter].
  */
 ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_note_channel(
                                 ALSASeqRemoveFilterFlag inout, guint8 queue_id,
@@ -88,14 +88,16 @@ ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_note_channel(
 
 /**
  * alsaseq_remove_filter_new_with_event_type:
- * @inout: The direction of queue; ALSASEQ_REMOVE_FILTER_FLAG_INPUT or
- *         ALSASEQ_REMOVE_FILTER_FLAG_OUTPUT.
- * @queue_id: The numerical ID of queue.
+ * @inout: The direction of queue; [flags@RemoveFilterFlag].INPUT or
+ *         [flags@RemoveFilterFlag].OUTPUT.
+ * @queue_id: The numeric identifier of queue.
  * @ev_type: The type of event.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
- * Allocate and return a memory object of ALSASeqRemoveFilter to remove queued
- * events with the type.
+ * Allocate and return a memory object of [struct@RemoveFilter] to remove queued events with the
+ * type.
+ *
+ * Returns: A [struct@RemoveFilter].
  */
 ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_event_type(
                                 ALSASeqRemoveFilterFlag inout, guint8 queue_id,
@@ -115,13 +117,15 @@ ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_event_type(
 
 /**
  * alsaseq_remove_filter_new_with_note:
- * @inout: The direction of queue; ALSASEQ_REMOVE_FILTER_FLAG_INPUT or
- *         ALSASEQ_REMOVE_FILTER_FLAG_OUTPUT.
- * @queue_id: The numerical ID of queue.
- * @error: A #GError.
+ * @inout: The direction of queue; [flags@RemoveFilterFlag].INPUT or
+ *         [flags@RemoveFilterFlag].OUTPUT.
+ * @queue_id: The numeric identifier of queue.
+ * @error: A [struct@GLib.Error].
  *
- * Allocate and return a memory object of ALSASeqRemoveFilter to remove queued
- * events for note, except for ALSASEQ_EVENT_TYPE_NOTEOFF.
+ * Allocate and return a memory object of [struct@RemoveFilter] to remove queued events for note,
+ * except for [enum@EventType:NOTEOFF].
+ *
+ * Returns: A [struct@RemoveFilter].
  */
 ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_note(
                                 ALSASeqRemoveFilterFlag inout, guint8 queue_id,
@@ -140,14 +144,16 @@ ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_note(
 
 /**
  * alsaseq_remove_filter_new_with_tag:
- * @inout: The direction of queue; ALSASEQ_REMOVE_FILTER_FLAG_INPUT or
- *         ALSASEQ_REMOVE_FILTER_FLAG_OUTPUT.
- * @queue_id: The numerical ID of queue.
+ * @inout: The direction of queue; [flags@RemoveFilterFlag].INPUT or
+ *         [flags@RemoveFilterFlag].OUTPUT.
+ * @queue_id: The numeric identifier of queue.
  * @tag: The tag of event to remove.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
- * Allocate and return a memory object of ALSASeqRemoveFilter to remove queued
- * events with the tag.
+ * Allocate and return a memory object of [struct@RemoveFilter] to remove queued events with the
+ * tag.
+ *
+ * Returns: A [struct@RemoveFilter].
  */
 ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_tag(
                                 ALSASeqRemoveFilterFlag inout, guint8 queue_id,
@@ -167,16 +173,17 @@ ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_tag(
 
 /**
  * alsaseq_remove_filter_new_with_tick_time:
- * @inout: The direction of queue; ALSASEQ_REMOVE_FILTER_FLAG_INPUT or
- *         ALSASEQ_REMOVE_FILTER_FLAG_OUTPUT.
- * @queue_id: The numerical ID of queue.
+ * @inout: The direction of queue; [flags@RemoveFilterFlag].INPUT or
+ *         [flags@RemoveFilterFlag].OUTPUT.
+ * @queue_id: The numeric identifier of queue.
  * @tick_time: The count of tick.
- * @after: Remove events after the tick time if true, else remove events before
- *         the tick time.
- * @error: A #GError.
+ * @after: Remove events after the tick time if true, else remove events before the tick time.
+ * @error: A [struct@GLib.Error].
  *
- * Allocate and return a memory object of ALSASeqRemoveFilter to remove queued
- * events before/after the tick time.
+ * Allocate and return a memory object of [struct@RemoveFilter] to remove queued events
+ * before/after the tick time.
+ *
+ * Returns: A [struct@RemoveFilter].
  */
 ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_tick_time(
                                 ALSASeqRemoveFilterFlag inout, guint8 queue_id,
@@ -201,17 +208,18 @@ ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_tick_time(
 
 /**
  * alsaseq_remove_filter_new_with_real_time:
- * @inout: The direction of queue; ALSASEQ_REMOVE_FILTER_FLAG_INPUT or
- *         ALSASEQ_REMOVE_FILTER_FLAG_OUTPUT.
- * @queue_id: The numerical ID of queue.
+ * @inout: The direction of queue; [flags@RemoveFilterFlag].INPUT or
+ *         [flags@RemoveFilterFlag].OUTPUT.
+ * @queue_id: The numeric identifier of queue.
  * @tv_sec: The second part of time.
  * @tv_nsec: The nanosecond part of time.
- * @after: Remove events after the real time if true, else remove events before
- *         the real time.
- * @error: A #GError.
+ * @after: Remove events after the real time if true, else remove events before the real time.
+ * @error: A [struct@GLib.Error].
  *
- * Allocate and return a memory object of ALSASeqRemoveFilter to remove queued
- * events before/after the real time.
+ * Allocate and return a memory object of [struct@RemoveFilter] to remove queued events
+ * before/after the real time.
+ *
+ * Returns: A [struct@RemoveFilter].
  */
 ALSASeqRemoveFilter *alsaseq_remove_filter_new_with_real_time(
                                 ALSASeqRemoveFilterFlag inout, guint8 queue_id,

--- a/src/seq/subscribe-data.c
+++ b/src/seq/subscribe-data.c
@@ -2,18 +2,14 @@
 #include "privates.h"
 
 /**
- * SECTION: subscribe-data
- * @Title: ALSASeqSubscribeData
- * @Short_description: A GObject-derived object to represent data for
- *                     subscription between ports.
+ * ALSASeqSubscribeData:
+ * A GObject-derived object to represent data for subscription between ports.
  *
- * A #ALSASeqSubscribeData is a GObject-derived object to represent data for
- * subscription between a pair of ports. The call of
- * alsaseq_get_subscription_list() returns the list of data. The call of
- * alsaseq_user_client_operate_subscription() requires the instance of object.
+ * A [class@SubscribeData] is a GObject-derived object to represent data for subscription between
+ * a pair of ports. The call of [func@get_subscription_list] returns the list of data. The call of
+ * [method@UserClient.operate_subscription] requires the instance of object.
  *
- * The object wraps 'struct snd_seq_port_subscribe' in UAPI of Linux sound
- * subsystem.
+ * The object wraps `struct snd_seq_port_subscribe` in UAPI of Linux sound subsystem.
  */
 typedef struct {
     struct snd_seq_port_subscribe data;
@@ -136,9 +132,9 @@ static void alsaseq_subscribe_data_init(ALSASeqSubscribeData *self)
 /**
  * alsaseq_subscribe_data_new:
  *
- * Allocates and returns the instance of ALSASeqSubscribeData class.
+ * Allocates and returns the instance of [class@SubscribeData].
  *
- * Returns: A #ALSASeqSubscribeData.
+ * Returns: A [class@SubscribeData].
  */
 ALSASeqSubscribeData *alsaseq_subscribe_data_new()
 {

--- a/src/seq/system-info.c
+++ b/src/seq/system-info.c
@@ -2,16 +2,13 @@
 #include "privates.h"
 
 /**
- * SECTION: system-info
- * @Title: ALSASeqSystemInfo
- * @Short_description: A GObject-derived object to represent information of
- *                     ALSA Sequencer
+ * ALSASeqSystemInfo:
+ * A GObject-derived object to represent information of ALSA Sequencer.
  *
- * A #ALSASeqSystemInfo is a GObject-derived object to represent information of
- * ALSA Sequencer. The call of alsaseq_get_system_info() returns the instance of
- * object.
+ * A [class@SystemInfo] is a GObject-derived object to represent information of ALSA Sequencer. The
+ * call of [func@get_system_info] returns the instance of object.
  *
- * The object wraps 'struct snd_seq_system_info' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_seq_system_info` in UAPI of Linux sound subsystem.
  */
 typedef struct {
     struct snd_seq_system_info info;

--- a/src/seq/tstamp.c
+++ b/src/seq/tstamp.c
@@ -2,14 +2,13 @@
 #include "privates.h"
 
 /**
- * SECTION: tstamp
- * @Title: ALSASeqTstamp
- * @Short_description: A boxed object to represent timestamp
+ * ALSASeqTstamp:
+ * A boxed object to represent timestamp.
  *
- * A #ALSASeqTstamp is a boxed object to represent timestamp. The object shares
- * storage for two types of time; tick time and real time.
+ * A [struct@Tstamp] is a boxed object to represent timestamp. The object shares storage for two
+ * types of time; tick time and real time.
  *
- * The object wraps 'struct snd_seq_timestamp' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_seq_timestamp` in UAPI of Linux sound subsystem.
  */
 ALSASeqTstamp *seq_tstamp_copy(const ALSASeqTstamp *self)
 {
@@ -28,8 +27,8 @@ G_DEFINE_BOXED_TYPE(ALSASeqTstamp, alsaseq_tstamp, seq_tstamp_copy, g_free)
 
 /**
  * alsaseq_tstamp_get_tick_time:
- * @self: A #ALSASeqTstamp.
- * @tick_time: (out): The number of MIDI ticks.
+ * @self: A [struct@Tstamp].
+ * @tick_time: (out): The value of MIDI ticks.
  *
  * Get time as MIDI ticks.
  */
@@ -40,7 +39,7 @@ void alsaseq_tstamp_get_tick_time(const ALSASeqTstamp *self, guint32 *tick_time)
 
 /**
  * alsaseq_tstamp_set_tick_time:
- * @self: A #ALSASeqTstamp.
+ * @self: A [struct@Tstamp].
  * @tick_time: The number of MIDI ticks.
  *
  * Set time as MIDI ticks.
@@ -52,9 +51,9 @@ void alsaseq_tstamp_set_tick_time(ALSASeqTstamp *self, const guint32 tick_time)
 
 /**
  * alsaseq_tstamp_get_real_time:
- * @self: A #ALSASeqTstamp.
- * @real_time: (array fixed-size=2)(out)(transfer none): The array with two
- *             elements for sec part and nsec part of real time.
+ * @self: A [struct@Tstamp].
+ * @real_time: (array fixed-size=2)(out)(transfer none): The array with two elements for sec part
+ *             and nsec part of real time.
  *
  * Refer to the time as wall-clock time.
  */
@@ -69,9 +68,9 @@ void alsaseq_tstamp_get_real_time(const ALSASeqTstamp *self,
 
 /**
  * alsaseq_tstamp_set_real_time:
- * @self: A #ALSASeqTstamp.
- * @real_time: (array fixed-size=2)(transfer none): The array with two elements
- *             for sec part and nsec part of real time.
+ * @self: A [struct@Tstamp].
+ * @real_time: (array fixed-size=2)(transfer none): The array with two elements for sec part and
+ *             nsec part of real time.
  *
  * Copy the time as wall-clock time.
  */

--- a/src/seq/user-client.c
+++ b/src/seq/user-client.c
@@ -11,20 +11,18 @@
 #include <errno.h>
 
 /**
- * SECTION: user-client
- * @Title: ALSASeqUserClient
- * @Short_description: A GObject-derived object to represent user client
+ * ALSASeqUserClient:
+ * A GObject-derived object to represent user client.
  *
- * A #ALSASeqUserClient is a GObject-derived object to represent user client.
- * Any port can be added to the client as destination or source for any event.
+ * A [class@UserClient] is a GObject-derived object to represent user client. Any port can be added
+ * to the client as destination or source for any event.
  *
- * When the call of alsaseq_user_client_open(), the object maintain file
- * descriptor till object destruction. The call of
- * alsaseq_user_client_create_source() returns the instance of GSource. Once
- * attached to the GSource, GMainContext/GMainLoop is available as event
- * dispatcher. The #handle-event GObject signal is emitted in the event
- * dispatcher to notify the event. The call of
- * alsaseq_user_client_schedule_event() schedules event with given parameters.
+ * When the call of [method@UserClient.open] the object maintain file descriptor till object
+ * destruction. The call of [method@UserClient.create_source] returns the instance of
+ * [struct@GLib.Source]. Once attached to the [struct@GLib.Source],
+ * [struct@GLib.MainContext] / [struct@GLib.MainLoop] is available as event dispatcher. The
+ * [signal@UserClient::handle-event] signal is emitted in the event dispatcher to notify the
+ * event. The call of [method@UserClient.schedule_event] schedules event with given parameters.
  */
 typedef struct {
     int fd;
@@ -37,9 +35,10 @@ G_DEFINE_TYPE_WITH_PRIVATE(ALSASeqUserClient, alsaseq_user_client, G_TYPE_OBJECT
 /**
  * alsaseq_user_client_error_quark:
  *
- * Return the GQuark for error domain of GError which has code in #ALSASeqUserClientError enumerations.
+ * Return the [alias@GLib.Quark] for [struct@GLib.Error] which has code of [enum@UserClientError]
+ * enumerations.
  *
- * Returns: A #GQuark.
+ * Returns: A [alias@GLib.Quark].
  */
 G_DEFINE_QUARK(alsaseq-user-client-error-quark, alsaseq_user_client_error)
 
@@ -115,7 +114,7 @@ static void alsaseq_user_client_class_init(ALSASeqUserClientClass *klass)
 
     seq_user_client_props[SEQ_USER_CLIENT_PROP_CLIENT_ID] =
         g_param_spec_uchar("client-id", "client-id",
-                           "The numerical ID of the client.",
+                           "The numeric ID of the client.",
                            0, G_MAXUINT8,
                            0,
                            G_PARAM_READABLE);
@@ -126,14 +125,13 @@ static void alsaseq_user_client_class_init(ALSASeqUserClientClass *klass)
 
     /**
      * ALSASeqUserClient::handle-event:
-     * @self: A #ALSASeqUserClient.
-     * @ev_cntr: (transfer none): The instance of ALSASeqEventCntr which
-     *             points to the batch of events.
+     * @self: A [class@UserClient].
+     * @ev_cntr: (transfer none): The instance of [class@EventCntr] which points to the batch of
+     *           events.
      *
-     * When event occurs, this signal is emit with the instance of object which
-     * points to a batch of events. The instance should not be passed directly
-     * to alsaseq_user_client_schedule_event() again because its memory
-     * alignment is different for events with blob data.
+     * When event occurs, this signal is emit with the instance of object which points to a batch
+     * of events. The instance should not be passed directly to [method@UserClient.schedule_event]
+     * again because its memory alignment is different for events with blob data.
      */
     seq_user_client_sigs[SEQ_USER_CLIENT_SIG_TYPE_HANDLE_EVENT] =
         g_signal_new("handle-event",
@@ -155,7 +153,9 @@ static void alsaseq_user_client_init(ALSASeqUserClient *self)
 /**
  * alsaseq_user_client_new:
  *
- * Allocate and return an instance of ALSASeqUserClient class.
+ * Allocate and return an instance of [class@UserClient].
+ *
+ * Returns: An instance of [class@UserClient].
  */
 ALSASeqUserClient *alsaseq_user_client_new()
 {
@@ -164,16 +164,15 @@ ALSASeqUserClient *alsaseq_user_client_new()
 
 /**
  * alsaseq_user_client_open:
- * @self: A #ALSASeqUserClient.
- * @open_flag: The flag of open(2) system call. O_RDWR is forced to fulfil internally.
- * @error: A #GError. Error is generated with two domains; #g_file_error_quark() and
- *         #alsaseq_user_client_error_quark().
+ * @self: A [class@UserClient].
+ * @open_flag: The flag of `open(2)` system call. `O_RDWR` is forced to fulfil internally.
+ * @error: A [struct@GLib.Error]. Error is generated with two domains; `GLib.FileError` and
+ *         `ALSASeq.UserClientError`.
  *
  * Open ALSA sequencer character device.
  *
- * The call of function executes open(2) system call, then executes ioctl(2)
- * system call with SNDRV_SEQ_IOCTL_CLIENT_ID command for ALSA sequencer
- * character device.
+ * The call of function executes `open(2)` system call, then executes `ioctl(2)` system call with
+ * `SNDRV_SEQ_IOCTL_CLIENT_ID` command for ALSA sequencer character device.
  */
 void alsaseq_user_client_open(ALSASeqUserClient *self, gint open_flag,
                               GError **error)
@@ -227,15 +226,14 @@ void alsaseq_user_client_open(ALSASeqUserClient *self, gint open_flag,
 
 /**
  * alsaseq_user_client_get_protocol_version:
- * @self: A #ALSASeqUserClient.
- * @proto_ver_triplet: (array fixed-size=3)(out)(transfer none): The version of
- *                     protocol currently used.
- * @error: A #GError.
+ * @self: A [class@UserClient].
+ * @proto_ver_triplet: (array fixed-size=3)(out)(transfer none): The version of protocol currently
+ *                     used.
+ * @error: A [struct@GLib.Error].
  *
- * Get the version of sequencer protocol currently used. The version is
- * represented as the array with three elements; major, minor, and micro version
- * in the order. The length of major version is 16 bit, the length of minor
- * and micro version is 8 bit each.
+ * Get the version of sequencer protocol currently used. The version is represented as the array
+ * with three elements; major, minor, and micro version in the order. The length of major version
+ * is 16 bit, the length of minor and micro version is 8 bit each.
  */
 void alsaseq_user_client_get_protocol_version(ALSASeqUserClient *self,
                                         const guint16 *proto_ver_triplet[3],
@@ -255,14 +253,14 @@ void alsaseq_user_client_get_protocol_version(ALSASeqUserClient *self,
 
 /**
  * alsaseq_user_client_set_info:
- * @self: A #ALSASeqUserClient.
- * @client_info: A #ALSASeqClientInfo.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
+ * @self: A [class@UserClient].
+ * @client_info: A [class@ClientInfo].
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSASeq.UserClientError`.
  *
  * Get client information.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_SEQ_IOCTL_SET_CLIENT_INFO command for ALSA sequencer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_SEQ_IOCTL_SET_CLIENT_INFO`
+ * command for ALSA sequencer character device.
  */
 void alsaseq_user_client_set_info(ALSASeqUserClient *self,
                                   ALSASeqClientInfo *client_info,
@@ -286,14 +284,14 @@ void alsaseq_user_client_set_info(ALSASeqUserClient *self,
 
 /**
  * alsaseq_user_client_get_info:
- * @self: A #ALSASeqUserClient.
- * @client_info: (inout): A #ALSASeqClientInfo.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
+ * @self: A [class@UserClient].
+ * @client_info: (inout): A [class@ClientInfo].
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSASeq.UserClientError`.
  *
  * Set client information.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_SEQ_IOCTL_GET_CLIENT_INFO command for ALSA sequencer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_SEQ_IOCTL_GET_CLIENT_INFO`
+ * command for ALSA sequencer character device.
  */
 void alsaseq_user_client_get_info(ALSASeqUserClient *self,
                                   ALSASeqClientInfo *const *client_info,
@@ -317,14 +315,14 @@ void alsaseq_user_client_get_info(ALSASeqUserClient *self,
 
 /**
  * alsaseq_user_client_create_port:
- * @self: A #ALSASeqUserClient.
- * @port_info: (inout): A #ALSASeqPortInfo.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
+ * @self: A [class@UserClient].
+ * @port_info: (inout): A [class@PortInfo].
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSASeq.UserClientError`.
  *
  * Create a port into the client.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_SEQ_IOCTL_CREATE_PORT command for ALSA sequencer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_SEQ_IOCTL_CREATE_PORT` command
+ * for ALSA sequencer character device.
  */
 void alsaseq_user_client_create_port(ALSASeqUserClient *self,
                                      ALSASeqPortInfo *const *port_info,
@@ -348,15 +346,15 @@ void alsaseq_user_client_create_port(ALSASeqUserClient *self,
 
 /**
  * alsaseq_user_client_create_port_at:
- * @self: A #ALSASeqUserClient.
- * @port_info: (inout): A #ALSASeqPortInfo.
- * @port_id: The numerical ID of port to create.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
+ * @self: A [class@UserClient].
+ * @port_info: (inout): A [class@PortInfo].
+ * @port_id: The numeric ID of port to create.
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSASeq.UserClientError`.
  *
- * Create a port into the client with the given numerical port ID.
+ * Create a port into the client with the given numeric port ID.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_SEQ_IOCTL_CREATE_PORT command for ALSA sequencer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_SEQ_IOCTL_CREATE_PORT` command
+ * for ALSA sequencer character device.
  */
 void alsaseq_user_client_create_port_at(ALSASeqUserClient *self,
                                         ALSASeqPortInfo *const *port_info,
@@ -378,15 +376,15 @@ void alsaseq_user_client_create_port_at(ALSASeqUserClient *self,
 
 /**
  * alsaseq_user_client_update_port:
- * @self: A #ALSASeqUserClient.
- * @port_info: A #ALSASeqPortInfo.
- * @port_id: The numerical ID of port.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
+ * @self: A [class@UserClient].
+ * @port_info: A [class@PortInfo].
+ * @port_id: The numeric ID of port.
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSASeq.UserClientError`.
  *
  * Update port information.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_SEQ_IOCTL_SET_PORT_INFO command for ALSA sequencer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_SEQ_IOCTL_SET_PORT_INFO` command
+ * for ALSA sequencer character device.
  */
 void alsaseq_user_client_update_port(ALSASeqUserClient *self,
                                      ALSASeqPortInfo *port_info,
@@ -412,14 +410,14 @@ void alsaseq_user_client_update_port(ALSASeqUserClient *self,
 
 /**
  * alsaseq_user_client_delete_port:
- * @self: A #ALSASeqUserClient.
- * @port_id: The numerical ID of port.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
+ * @self: A [class@UserClient].
+ * @port_id: The numeric ID of port.
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSASeq.UserClientError`.
  *
  * Delete a port from the client.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_SEQ_IOCTL_DELETE_PORT command for ALSA sequencer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_SEQ_IOCTL_DELETE_PORT` command
+ * for ALSA sequencer character device.
  */
 void alsaseq_user_client_delete_port(ALSASeqUserClient *self,
                                      guint8 port_id, GError **error)
@@ -440,14 +438,14 @@ void alsaseq_user_client_delete_port(ALSASeqUserClient *self,
 
 /**
  * alsaseq_user_client_set_pool:
- * @self: A #ALSASeqUserClient.
- * @client_pool: A #ALSASeqClientPool to be configured for the client.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
+ * @self: A [class@UserClient].
+ * @client_pool: A [class@ClientPool] to be configured for the client.
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSASeq.UserClientError`.
  *
  * Configure memory pool in the client.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_SEQ_IOCTL_SET_CLIENT_POOL command for ALSA sequencer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_SEQ_IOCTL_SET_CLIENT_POOL`
+ * command for ALSA sequencer character device.
  */
 void alsaseq_user_client_set_pool(ALSASeqUserClient *self,
                                   ALSASeqClientPool *client_pool,
@@ -470,14 +468,14 @@ void alsaseq_user_client_set_pool(ALSASeqUserClient *self,
 
 /**
  * alsaseq_user_client_get_pool:
- * @self: A #ALSASeqUserClient.
- * @client_pool: (inout): A #ALSASeqClientPool to be configured for the client.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
+ * @self: A [class@UserClient].
+ * @client_pool: (inout): A [class@ClientPool] to be configured for the client.
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSASeq.UserClientError`.
  *
  * Get information of memory pool in the client.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_SEQ_IOCTL_GET_CLIENT_POOL command for ALSA sequencer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_SEQ_IOCTL_GET_CLIENT_POOL`
+ * command for ALSA sequencer character device.
  */
 void alsaseq_user_client_get_pool(ALSASeqUserClient *self,
                                   ALSASeqClientPool *const *client_pool,
@@ -500,16 +498,15 @@ void alsaseq_user_client_get_pool(ALSASeqUserClient *self,
 
 /**
  * alsaseq_user_client_schedule_event:
- * @self: A #ALSASeqUserClient.
- * @ev_cntr: An instance of #ALSASeqEventCntr pointing to events.
+ * @self: A [class@UserClient].
+ * @ev_cntr: An instance of [class@EventCntr] pointing to events.
  * @count: The number of events in the ev_cntr to write.
- * @error: A #GError. Error is generated with two domains; #g_file_error_quark()
- *         and #alsaseq_user_client_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with two domains; `GLib.FileError` and
+ *         `ALSASeq.UserClientError`.
  *
  * Deliver the event immediately, or schedule it into memory pool of the client.
  *
- * The call of function executes write(2) system call for ALSA sequencer
- * character device.
+ * The call of function executes `write(2)` system call for ALSA sequencer character device.
  */
 void alsaseq_user_client_schedule_event(ALSASeqUserClient *self,
                                         ALSASeqEventCntr *ev_cntr,
@@ -602,14 +599,14 @@ static void seq_user_client_finalize_src(GSource *gsrc)
 
 /**
  * alsaseq_user_client_create_source:
- * @self: A #ALSASeqUserClient.
+ * @self: A [class@UserClient].
  * @gsrc: (out): A #GSource to handle events from ALSA seq character device.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
- * Allocate GSource structure to handle events from ALSA seq character device.
- * In each iteration of GMainContext, the read(2) system call is exected to
- * dispatch sequencer event for 'handle-event' signal, according to the result
- * of poll(2) system call.
+ * Allocate [struct@GLib.Source] structure to handle events from ALSA seq character device. In each
+ * iteration of [struct@GLib.MainContext], the `read(2)` system call is exected to dispatch
+ * sequencer event for [signal@UserClient::handle-event] signal, according to the result of
+ * `poll(2)` system call.
  */
 void alsaseq_user_client_create_source(ALSASeqUserClient *self,
                                        GSource **gsrc, GError **error)
@@ -650,16 +647,15 @@ void alsaseq_user_client_create_source(ALSASeqUserClient *self,
 
 /**
  * alsaseq_user_client_operate_subscription:
- * @self: A #ALSASeqUserClient.
- * @subs_data: A #ALSASeqSubscribeData.
+ * @self: A [class@UserClient].
+ * @subs_data: A [class@SubscribeData].
  * @establish: Whether to establish subscription between two ports, or break it.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSASeq.UserClientError`.
  *
  * Operate subscription between two ports pointed by the data.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_SEQ_IOCTL_SUBSCRIBE_PORT and SNDRV_SEQ_IOCTL_UNSUBSCRIBE_PORT commands
- * for ALSA sequencer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_SEQ_IOCTL_SUBSCRIBE_PORT` and
+ * `SNDRV_SEQ_IOCTL_UNSUBSCRIBE_PORT` commands for ALSA sequencer character device.
  */
 void alsaseq_user_client_operate_subscription(ALSASeqUserClient *self,
                                          ALSASeqSubscribeData *subs_data,
@@ -697,15 +693,14 @@ void alsaseq_user_client_operate_subscription(ALSASeqUserClient *self,
 
 /**
  * alsaseq_user_client_create_queue:
- * @self: A #ALSASeqUserClient.
+ * @self: A [class@UserClient].
  * @queue_info: (inout): The information of queue to add.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSASeq.UserClientError`.
  *
- * Create a new queue owned by the client. The content of information is updated
- * if success.
+ * Create a new queue owned by the client. The content of information is updated if success.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_SEQ_IOCTL_CREATE_QUEUE command for ALSA sequencer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_SEQ_IOCTL_CREATE_QUEUE` command
+ * for ALSA sequencer character device.
  */
 void alsaseq_user_client_create_queue(ALSASeqUserClient *self,
                                       ALSASeqQueueInfo *const *queue_info,
@@ -728,14 +723,14 @@ void alsaseq_user_client_create_queue(ALSASeqUserClient *self,
 
 /**
  * alsaseq_user_client_delete_queue:
- * @self: A #ALSASeqUserClient.
- * @queue_id: The numerical ID of queue, except for one of ALSASeqSpecificQueueId.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
+ * @self: A [class@UserClient].
+ * @queue_id: The numeric ID of queue, except for one of [enum@SpecificQueueId].
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSASeq.UserClientError`.
  *
  * Delete the queue owned by the client.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_SEQ_IOCTL_DELETE_QUEUE command for ALSA sequencer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_SEQ_IOCTL_DELETE_QUEUE` command
+ * for ALSA sequencer character device.
  */
 void alsaseq_user_client_delete_queue(ALSASeqUserClient *self,
                                       guint8 queue_id, GError **error)
@@ -756,14 +751,14 @@ void alsaseq_user_client_delete_queue(ALSASeqUserClient *self,
 
 /**
  * alsaseq_user_client_update_queue:
- * @self: A #ALSASeqUserClient.
+ * @self: A [class@UserClient].
  * @queue_info: The information of queue to add.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSASeq.UserClientError`.
  *
  * Update owned queue according to the information.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_SEQ_IOCTL_SET_QUEUE_INFO command for ALSA sequencer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_SEQ_IOCTL_SET_QUEUE_INFO`
+ * command for ALSA sequencer character device.
  */
 void alsaseq_user_client_update_queue(ALSASeqUserClient *self,
                                       ALSASeqQueueInfo *queue_info,
@@ -790,16 +785,15 @@ void alsaseq_user_client_update_queue(ALSASeqUserClient *self,
 
 /**
  * alsaseq_user_client_get_queue_usage:
- * @self: A #ALSASeqUserClient.
- * @queue_id: The numerical ID of queue, except for entries in
- *            ALSASeqSpecificQueueId.
+ * @self: A [class@UserClient].
+ * @queue_id: The numeric ID of queue, except for entries in [enum@SpecificQueueId].
  * @use: (out): Whether the client uses the queue or not.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSASeq.UserClientError`.
  *
  * Get usage of the queue by the client.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_SEQ_IOCTL_GET_QUEUE_CLIENT command for ALSA sequencer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_SEQ_IOCTL_GET_QUEUE_CLIENT`
+ * command for ALSA sequencer character device.
  */
 void alsaseq_user_client_get_queue_usage(ALSASeqUserClient *self,
                                          guint8 queue_id, gboolean *use,
@@ -825,16 +819,15 @@ void alsaseq_user_client_get_queue_usage(ALSASeqUserClient *self,
 
 /**
  * alsaseq_user_client_set_queue_usage:
- * @self: A #ALSASeqUserClient.
- * @queue_id: The numerical ID of queue, except for entries in
- *            ALSASeqSpecificQueueId.
+ * @self: A [class@UserClient].
+ * @queue_id: The numeric ID of queue, except for entries in [enum@SpecificQueueId].
  * @use: Whether to use the queue or not.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSASeq.UserClientError`.
  *
  * Start the queue to use or not.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_SEQ_IOCTL_SET_QUEUE_CLIENT command for ALSA sequencer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_SEQ_IOCTL_SET_QUEUE_CLIENT`
+ * command for ALSA sequencer character device.
  */
 void alsaseq_user_client_set_queue_usage(ALSASeqUserClient *self,
                                          guint8 queue_id, gboolean use,
@@ -858,16 +851,15 @@ void alsaseq_user_client_set_queue_usage(ALSASeqUserClient *self,
 
 /**
  * alsaseq_user_client_set_queue_tempo:
- * @self: A #ALSASeqUserClient.
- * @queue_id: The numerical ID of queue, except for entries in
- *            ALSASeqSpecificQueueId.
+ * @self: A [class@UserClient].
+ * @queue_id: The numeric ID of queue, except for entries in [enum@SpecificQueueId].
  * @queue_tempo: The data of tempo for queue.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSASeq.UserClientError`.
  *
  * Set the data of tempo to the queue.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_SEQ_IOCTL_SET_QUEUE_TEMPO command for ALSA sequencer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_SEQ_IOCTL_SET_QUEUE_TEMPO`
+ * command for ALSA sequencer character device.
  */
 void alsaseq_user_client_set_queue_tempo(ALSASeqUserClient *self,
                                 guint8 queue_id, ALSASeqQueueTempo *queue_tempo,
@@ -894,16 +886,15 @@ void alsaseq_user_client_set_queue_tempo(ALSASeqUserClient *self,
 
 /**
  * alsaseq_user_client_get_queue_tempo:
- * @self: A #ALSASeqUserClient.
- * @queue_id: The numerical ID of queue, except for entries in
- *            ALSASeqSpecificQueueId.
+ * @self: A [class@UserClient].
+ * @queue_id: The numeric ID of queue, except for entries in [enum@SpecificQueueId].
  * @queue_tempo: (out): The data of tempo for queue.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSASeq.UserClientError`.
  *
  * Get the data of tempo for the queue.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_SEQ_IOCTL_GET_QUEUE_TEMPO command for ALSA sequencer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_SEQ_IOCTL_GET_QUEUE_TEMPO`
+ * command for ALSA sequencer character device.
  */
 void alsaseq_user_client_get_queue_tempo(ALSASeqUserClient *self,
                                 guint8 queue_id, ALSASeqQueueTempo **queue_tempo,
@@ -930,16 +921,15 @@ void alsaseq_user_client_get_queue_tempo(ALSASeqUserClient *self,
 
 /**
  * alsaseq_user_client_set_queue_timer:
- * @self: A #ALSASeqUserClient.
- * @queue_id: The numerical ID of queue, except for entries in
- *            ALSASeqSpecificQueueId.
+ * @self: A [class@UserClient].
+ * @queue_id: The numeric ID of queue, except for entries in [enum@SpecificQueueId].
  * @queue_timer: The data of timer for queue.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSASeq.UserClientError`.
  *
  * Set the data of timer for the queue.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_SEQ_IOCTL_SET_QUEUE_TIMER command for ALSA sequencer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_SEQ_IOCTL_SET_QUEUE_TIMER`
+ * command for ALSA sequencer character device.
  */
 void alsaseq_user_client_set_queue_timer(ALSASeqUserClient *self,
                                          guint8 queue_id,
@@ -977,16 +967,15 @@ void alsaseq_user_client_set_queue_timer(ALSASeqUserClient *self,
 
 /**
  * alsaseq_user_client_get_queue_timer:
- * @self: A #ALSASeqUserClient.
- * @queue_id: The numerical ID of queue, except for entries in
- *            ALSASeqSpecificQueueId.
+ * @self: A [class@UserClient].
+ * @queue_id: The numeric ID of queue, except for entries in [enum@SpecificQueueId].
  * @queue_timer: (out): The data of timer for queue.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSASeq.UserClientError`.
  *
  * Get the data of timer for the queue.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_SEQ_IOCTL_GET_QUEUE_TIMER command for ALSA sequencer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_SEQ_IOCTL_GET_QUEUE_TIMER`
+ * command for ALSA sequencer character device.
  */
 void alsaseq_user_client_get_queue_timer(ALSASeqUserClient *self,
                                          guint8 queue_id,
@@ -1026,14 +1015,14 @@ void alsaseq_user_client_get_queue_timer(ALSASeqUserClient *self,
 
 /**
  * alsaseq_user_client_remove_events:
- * @self: A #ALSASeqUserClient.
- * @filter: A #ALSASeqRemoveFilter.
- * @error: A #GError. Error is generated with domain of #alsaseq_user_client_error_quark().
+ * @self: A [class@UserClient].
+ * @filter: A [struct@RemoveFilter].
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSASeq.UserClientError`.
  *
  * Remove queued events according to the filter.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_SEQ_IOCTL_REMOVE_EVENTS command for ALSA sequencer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_SEQ_IOCTL_REMOVE_EVENTS`
+ * command for ALSA sequencer character device.
  */
 void alsaseq_user_client_remove_events(ALSASeqUserClient *self,
                                        ALSASeqRemoveFilter *filter,

--- a/src/seq/user-client.h
+++ b/src/seq/user-client.h
@@ -19,8 +19,8 @@ struct _ALSASeqUserClientClass {
 
     /**
      * ALSASeqUserClientClass::handle_event:
-     * @self: A #ALSASeqUserClient.
-     * @ev_cntr: (transfer none): The instance of ALSASeqEventCntr which
+     * @self: A [class@UserClient].
+     * @ev_cntr: (transfer none): The instance of [class@EventCntr] which
      *             points to the batch of events.
      *
      * When event occurs, this signal is emit with the instance of object which

--- a/src/timer/alsatimer-enum-types.h
+++ b/src/timer/alsatimer-enum-types.h
@@ -130,7 +130,7 @@ typedef enum {
  * @ALSATIMER_USER_INSTANCE_ERROR_ATTACHED:         The timer instance is already attached to timer
  *                                                  device or the other instance.
  *
- * A set of error code for GError with domain which equals to #alsatimer_user_instance_error_quark()
+ * A set of error code for [struct@GLib.Error] with `ALSATimer.UserInstanceError` domain.
  */
 typedef enum {
     ALSATIMER_USER_INSTANCE_ERROR_FAILED,

--- a/src/timer/device-id.c
+++ b/src/timer/device-id.c
@@ -2,17 +2,14 @@
 #include "privates.h"
 
 /**
- * SECTION: device-id
- * @Title: ALSATimerDeviceId
- * @Short_description: A boxed object to represent the identifier of timer
- *                     device.
+ * ALSATimerDeviceId:
+ * A boxed object to represent the identifier of timer device.
  *
- * A #ALSATimerDeviceId is a boxed object to represent the identifier of timer
- * device. The identifier mainly consists of the class of timer device. The
- * other members; the numerical ID of card, device, and subdevice are optional
- * according to the class of timer device.
+ * A [struct@DeviceId] is a boxed object to represent the identifier of timer device. The
+ * identifier mainly consists of the class of timer device. The other members; the numeric ID of
+ * card, device, and subdevice are optional according to the class of timer device.
  *
- * The object wraps 'struct snd_timer_id' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_timer_id` in UAPI of Linux sound subsystem.
  */
 ALSATimerDeviceId *timer_device_id_copy(const ALSATimerDeviceId *self)
 {
@@ -31,14 +28,14 @@ G_DEFINE_BOXED_TYPE(ALSATimerDeviceId, alsatimer_device_id, timer_device_id_copy
 
 /**
  * alsatimer_device_id_new:
- * @class: The class of device, one of #ALSATimerClass.
- * @card_id: The numerical ID of relevant sound card.
- * @device_id: The numerical ID of relevant device.
- * @subdevice_id: The numerical ID of relevant subdevice.
+ * @class: The class of device, one of [enum@Class].
+ * @card_id: The numeric ID of relevant sound card.
+ * @device_id: The numeric ID of relevant device.
+ * @subdevice_id: The numeric ID of relevant subdevice.
  *
- * Allocate and return an instance of ALSATimerDeviceId.
+ * Allocate and return an instance of [struct@DeviceId].
  *
- * Returns: A #ALSATimerDeviceId.
+ * Returns: A [struct@DeviceId].
  */
 ALSATimerDeviceId *alsatimer_device_id_new(ALSATimerClass class,
                                            gint card_id, gint device_id,
@@ -56,8 +53,8 @@ ALSATimerDeviceId *alsatimer_device_id_new(ALSATimerClass class,
 
 /**
  * alsatimer_device_id_get_class:
- * @self: A #ALSATimerDeviceId.
- * @class: (out): The class of timer, one of #ALSATimerClass.
+ * @self: A [struct@DeviceId].
+ * @class: (out): The class of timer, one of [enum@Class].
  *
  * Get the class of timer.
  */
@@ -69,10 +66,10 @@ void alsatimer_device_id_get_class(const ALSATimerDeviceId *self,
 
 /**
  * alsatimer_device_id_get_card_id:
- * @self: A #ALSATimerDeviceId.
- * @card_id: (out): The numerical ID of sound card to which the timer belongs.
+ * @self: A [struct@DeviceId].
+ * @card_id: (out): The numeric ID of sound card to which the timer belongs.
  *
- * Get the numerical ID of sound card to which the device belongs.
+ * Get the numeric ID of sound card to which the device belongs.
  */
 void alsatimer_device_id_get_card_id(const ALSATimerDeviceId *self,
                                      gint *card_id)
@@ -82,10 +79,10 @@ void alsatimer_device_id_get_card_id(const ALSATimerDeviceId *self,
 
 /**
  * alsatimer_device_id_get_device_id:
- * @self: A #ALSATimerDeviceId.
- * @device_id: (out): The numerical ID of device to which the timer belongs.
+ * @self: A [struct@DeviceId].
+ * @device_id: (out): The numeric ID of device to which the timer belongs.
  *
- * Get the numerical ID of device to which the timer belongs.
+ * Get the numeric ID of device to which the timer belongs.
  */
 void alsatimer_device_id_get_device_id(const ALSATimerDeviceId *self,
                                        gint *device_id)
@@ -95,10 +92,10 @@ void alsatimer_device_id_get_device_id(const ALSATimerDeviceId *self,
 
 /**
  * alsatimer_device_id_get_subdevice_id:
- * @self: A #ALSATimerDeviceId.
- * @subdevice_id: (out): The numerical ID of subdevice to which the timer belongs.
+ * @self: A [struct@DeviceId].
+ * @subdevice_id: (out): The numeric ID of subdevice to which the timer belongs.
  *
- * Get the numerical ID of subdevice to which the timer belongs.
+ * Get the numeric ID of subdevice to which the timer belongs.
  */
 void alsatimer_device_id_get_subdevice_id(const ALSATimerDeviceId *self,
                                           gint *subdevice_id)

--- a/src/timer/device-info.c
+++ b/src/timer/device-info.c
@@ -2,16 +2,14 @@
 #include "privates.h"
 
 /**
- * SECTION: device-info
- * @Title: ALSATimerDeviceInfo
- * @Short_description: A GObject-derived object to represent information of
- *                     timer device.
+ * ALSATimerDeviceInfo:
+ * A GObject-derived object to represent information of timer device.
  *
- * A #ALSATimerDeviceInfo is a GObject-derived object to represent information
- * of timer device. The call of alsatimer_get_device_info() returns an instance
- * of the object according to the identifier of timer device.
+ * A [class@DeviceInfo] is a GObject-derived object to represent information of timer device.
+ * The call of alsatimer_get_device_info() returns an instance of the object according to the
+ * identifier of timer device.
  *
- * The object wraps 'struct snd_timer_ginfo' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_timer_ginfo` in UAPI of Linux sound subsystem.
  */
 typedef struct {
     struct snd_timer_ginfo info;

--- a/src/timer/device-params.c
+++ b/src/timer/device-params.c
@@ -2,16 +2,13 @@
 #include "privates.h"
 
 /**
- * SECTION: device-params
- * @Title: ALSATimerDeviceParams
- * @Short_description: A GObject-derived object to represent parameter of timer
- *                     device.
+ * ALSATimerDeviceParams:
+ * A GObject-derived object to represent parameter of timer device.
  *
- * A #ALSATimerDeviceParams is a GObject-derived object to represent parameter
- * of timer device. The call of alsatimer_set_device_params() requires the
- * instance of object.
+ * A [class@DeviceParams] is a GObject-derived object to represent parameter of timer device. The
+ * call of alsatimer_set_device_params() requires the instance of object.
  *
- * The object wraps 'struct snd_timer_gparams' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_timer_gparams` in UAPI of Linux sound subsystem.
  */
 typedef struct {
     struct snd_timer_gparams params;
@@ -98,9 +95,9 @@ static void alsatimer_device_params_init(ALSATimerDeviceParams *self)
 /**
  * alsatimer_device_params_new:
  *
- * Instantiate #ALSATimerDeviceParams object and return the instance.
+ * Instantiate [class@DeviceParams] object and return the instance.
  *
- * Returns: an instance of #ALSATimerDeviceParams.
+ * Returns: an instance of [class@DeviceParams].
  */
 ALSATimerDeviceParams *alsatimer_device_params_new()
 {

--- a/src/timer/device-status.c
+++ b/src/timer/device-status.c
@@ -2,14 +2,11 @@
 #include "privates.h"
 
 /**
- * SECTION: device-status
- * @Title: ALSATimerDeviceStatus
- * @Short_description: A GObject-derived object to represent status of timer
- *                     device.
+ * ALSATimerDeviceStatus:
+ * A GObject-derived object to represent status of timer device.
  *
- * A #ALSATimerDeviceStatus is a GObject-derived object to represent status of
- * timer device. The call of alsatimer_get_device_status() returns the instance
- * of object.
+ * A [class@DeviceStatus] is a GObject-derived object to represent status of timer device. The
+ * call of [func@get_device_status] returns the instance of object.
  *
  * The object wraps 'struct snd_timer_gstatus' in UAPI of Linux sound subsystem.
  */
@@ -90,9 +87,9 @@ static void alsatimer_device_status_init(ALSATimerDeviceStatus *self)
 /**
  * alsatimer_device_status_new:
  *
- * Allocate and return an instance of #ALSATimerDeviceStatus.
+ * Allocate and return an instance of [class@DeviceStatus].
  *
- * Returns: A #ALSATimerDeviceStatus.
+ * Returns: An instance of [class@DeviceStatus].
  */
 ALSATimerDeviceStatus *alsatimer_device_status_new()
 {

--- a/src/timer/event-data-tick.c
+++ b/src/timer/event-data-tick.c
@@ -2,15 +2,12 @@
 #include "privates.h"
 
 /**
- * SECTION: event-data-tick
- * @Title: ALSATimerEventDataTick
- * @Short_description: A boxed object to represent event of timer with tick
- *                     count
+ * ALSATimerEventDataTick:
+ * A boxed object to represent event of timer with tick count.
  *
- * A #ALSATimerEventDataTick is a boxed object to represent event of timer with
- * tick count.
+ * A [struct@EventDataTick] is a boxed object to represent event of timer with tick count.
  *
- * The object wraps 'struct snd_timer_read' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_timer_read` in UAPI of Linux sound subsystem.
  */
 ALSATimerEventDataTick *timer_event_data_tick_copy(const ALSATimerEventDataTick *self)
 {
@@ -29,7 +26,7 @@ G_DEFINE_BOXED_TYPE(ALSATimerEventDataTick, alsatimer_event_data_tick, timer_eve
 
 /**
  * alsatimer_event_data_tick_get_resolution:
- * @self: A #ALSATimerEventDataTick.
+ * @self: A [struct@EventDataTick].
  * @resolution: (out): The resolution of tick event.
  *
  * Get the resolution of tick event.
@@ -42,7 +39,7 @@ void alsatimer_event_data_tick_get_resolution(const ALSATimerEventDataTick *self
 
 /**
  * alsatimer_event_data_tick_get_ticks:
- * @self: A #ALSATimerEventDataTick.
+ * @self: A [struct@EventDataTick].
  * @ticks: (out): The tick count since the last event.
  *
  * Get the tick count since the last event.

--- a/src/timer/event-data-tstamp.c
+++ b/src/timer/event-data-tstamp.c
@@ -2,15 +2,12 @@
 #include "privates.h"
 
 /**
- * SECTION: event-data-tstamp
- * @Title: ALSATimerEventDataTstamp
- * @Short_description: A boxed object to represent event of timer with
- *                     tstamp
+ * ALSATimerEventDataTstamp:
+ * A boxed object to represent event of timer with tstamp.
  *
- * A #ALSATimerEventDataTstamp is a boxed object to represent event of timer
- * with tstamp.
+ * A [struct@EventDataTstamp] is a boxed object to represent event of timer with tstamp.
  *
- * The object wraps 'struct snd_timer_tread' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_timer_tread` in UAPI of Linux sound subsystem.
  */
 ALSATimerEventDataTstamp *timer_event_data_tstamp_copy(const ALSATimerEventDataTstamp *self)
 {
@@ -29,8 +26,8 @@ G_DEFINE_BOXED_TYPE(ALSATimerEventDataTstamp, alsatimer_event_data_tstamp, timer
 
 /**
  * alsatimer_event_data_tstamp_get_event:
- * @self: A #ALSATimerEventDataTstamp.
- * @event: (out): The type of tstamp event, one of ALSATimerEventType.
+ * @self: A [struct@EventDataTstamp].
+ * @event: (out): The type of tstamp event, one of [enum@EventType].
  *
  * Get the kind of event for the timestamp event.
  */
@@ -42,10 +39,9 @@ void alsatimer_event_data_tstamp_get_event(const ALSATimerEventDataTstamp *self,
 
 /**
  * alsatimer_event_data_tstamp_get_tstamp:
- * @self: A #ALSATimerEventDataTstamp.
- * @tstamp: (array fixed-size=2)(inout): The array with two elements for the
- *          seconds and nanoseconds part of timestamp when the instance queues
- *          the timestamp event.
+ * @self: A [struct@EventDataTstamp].
+ * @tstamp: (array fixed-size=2)(inout): The array with two elements for the seconds and
+ *          nanoseconds part of timestamp when the instance queues the timestamp event.
  *
  * Get the seconds and nanoseconds part for the timestamp event.
  */
@@ -58,7 +54,7 @@ void alsatimer_event_data_tstamp_get_tstamp(const ALSATimerEventDataTstamp *self
 
 /**
  * alsatimer_event_data_tstamp_get_val:
- * @self: A #ALSATimerEventDataTstamp.
+ * @self: A [struct@EventDataTstamp].
  * @val: (out): The value depending on the type of timestamp event.
  *
  * Get the value depending on the type of timestamp event.

--- a/src/timer/event.c
+++ b/src/timer/event.c
@@ -2,15 +2,13 @@
 #include "privates.h"
 
 /**
- * SECTION: event
- * @Title: ALSATimerEvent
- * @Short_description: A boxed object to represent event of timer
+ * ALSATimerEvent:
+ * A boxed object to represent event of timer.
  *
- * A #ALSATimerEvent is a boxed object to represent event of timer. The
- * instance of object uses single storage for two types of event data;
- * #ALSATimerEventDataTick for and #ALSATimerEventDataTstamp. Applications can
- * decide to use one of the two by passing one of #ALSATimerEventType to the
- * call of alsatimer_user_instance_attach().
+ * A [struct@Event] is a boxed object to represent event of timer. The instance of object uses
+ * single storage for two types of event data; [struct@EventDataTick] for and
+ * [struct@EventDataTstamp]. Applications can decide to use one of the two by passing one of
+ * [enum@EventType] to the call of [method@UserInstance.attach].
  */
 ALSATimerEvent *timer_event_copy(const ALSATimerEvent *self)
 {
@@ -30,9 +28,9 @@ G_DEFINE_BOXED_TYPE(ALSATimerEvent, alsatimer_event, timer_event_copy, g_free)
 /**
  * alsatimer_event_new:
  *
- * Allocate and return the instance of #ALSATimerEvent.
+ * Allocate and return the instance of [struct@Event].
  *
- * Returns: A #ALSATimerEvent.
+ * Returns: An instance of [struct@Event].
  */
 ALSATimerEvent *alsatimer_event_new()
 {
@@ -41,10 +39,10 @@ ALSATimerEvent *alsatimer_event_new()
 
 /**
  * alsatimer_event_get_tick_data:
- * @self: A #ALSATimerEvent.
- * @tick: (out)(transfer none): The instance of #ALSATimerEventDataTick.
+ * @self: A [struct@Event].
+ * @tick: (out)(transfer none): The instance of [struct@EventDataTick].
  *
- * Refer to the instance of #ALSATimerEventDataTick.
+ * Refer to the instance of [struct@EventDataTick].
  */
 void alsatimer_event_get_tick_data(ALSATimerEvent *self,
                                    const ALSATimerEventDataTick **tick)
@@ -54,10 +52,10 @@ void alsatimer_event_get_tick_data(ALSATimerEvent *self,
 
 /**
  * alsatimer_event_get_tstamp_data:
- * @self: A #ALSATimerEvent.
- * @tstamp: (out)(transfer none): The instance of #ALSATimerEventDataTstamp.
+ * @self: A [struct@Event].
+ * @tstamp: (out)(transfer none): The instance of [struct@EventDataTstamp].
  *
- * Refer to the instance of #ALSATimerEventDataTstamp.
+ * Refer to the instance of [struct@EventDataTstamp].
  */
 void alsatimer_event_get_tstamp_data(ALSATimerEvent *self,
                                      const ALSATimerEventDataTstamp **tstamp)

--- a/src/timer/instance-info.c
+++ b/src/timer/instance-info.c
@@ -2,16 +2,14 @@
 #include "privates.h"
 
 /**
- * SECTION: instance-info
- * @Title: ALSATimerInstanceInfo
- * @Short_description: A GObject-derived object to represent information of
- *                     user instance
+ * ALSATimerInstanceInfo:
+ * A GObject-derived object to represent information of user instance.
  *
- * A #ALSATimerInstanceInfo is a GObject-derived object to represent information
- * of user instance attached to any timer device or the other instance as slave.
- * The call of alsatimer_user_instance_get_info() returns the instance of object.
+ * A [class@InstanceInfo] is a GObject-derived object to represent information of user instance
+ * attached to any timer device or the other instance as slave. The call of
+ * [method@UserInstance.get_info] returns the instance of object.
  *
- * The object wraps 'struct snd_timer_info' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_timer_info` in UAPI of Linux sound subsystem.
  */
 typedef struct {
     struct snd_timer_info info;

--- a/src/timer/instance-params.c
+++ b/src/timer/instance-params.c
@@ -4,17 +4,14 @@
 #include <errno.h>
 
 /**
- * SECTION: instance-params
- * @Title: ALSATimerInstanceParams
- * @Short_description: A GObject-derived object to represent parameters of user
- *                     instance
+ * ALSATimerInstanceParams:
+ * A GObject-derived object to represent parameters of user instance.
  *
- * A #ALSATimerInstanceParams is a GObject-derived object to represent
- * parameters of user instance attached to any timer device or the other
- * instance as slave. The call of alsatimer_user_instance_set_params() requires
- * the instance of object.
+ * A [class@InstanceParams] is a GObject-derived object to represent parameters of user instance
+ * attached to any timer device or the other instance as slave. The call of
+ * [method@UserInstance.set_params] requires the instance of object.
  *
- * The object wraps 'struct snd_timer_params' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_timer_params` in UAPI of Linux sound subsystem.
  */
 typedef struct {
     struct snd_timer_params params;
@@ -117,7 +114,9 @@ static void alsatimer_instance_params_init(ALSATimerInstanceParams *self)
 /**
  * alsatimer_instance_params_new:
  *
- * Allocate and return an instance of ALSATimerInstanceParams.
+ * Allocate and return an instance of [class@InstanceParams].
+ *
+ * Returns: An instance of [class@InstanceParams].
  */
 ALSATimerInstanceParams *alsatimer_instance_params_new()
 {
@@ -126,14 +125,13 @@ ALSATimerInstanceParams *alsatimer_instance_params_new()
 
 /**
  * alsatimer_instance_params_set_event_filter:
- * @self: A #ALSATimerInstanceParams.
- * @entries: (array length=entry_count): The array with elements for entries of
- *           #ALSATimerEventType.
+ * @self: A [class@InstanceParams].
+ * @entries: (array length=entry_count): The array with elements for entries of [enum@EventType].
  * @entry_count: The number of elements in the above array.
- * @error: A #GError at failure.
+ * @error: A [struct@GLib.Error] at failure.
  *
- * Set the list of ALSATimerEventType to filter events. This parameter is only
- * effective for target instance with ALSATimerEventDataType.TIMESTAMP.
+ * Set the list of [enum@EventType] to filter events. This parameter is effective only for target
+ * instance with [enum@EventDataType:TIMESTAMP].
  */
 void alsatimer_instance_params_set_event_filter(ALSATimerInstanceParams *self,
                                             const ALSATimerEventType *entries,
@@ -172,14 +170,13 @@ void alsatimer_instance_params_set_event_filter(ALSATimerInstanceParams *self,
 
 /**
  * alsatimer_instance_params_get_event_filter:
- * @self: A #ALSATimerInstanceParams.
- * @entries: (array length=entry_count)(out): The array with elements for
- *           entries of #ALSATimerEventType.
+ * @self: A [class@InstanceParams].
+ * @entries: (array length=entry_count)(out): The array with elements for entries of [enum@EventType].
  * @entry_count: The number of elements in the above array.
- * @error: A #GError at failure.
+ * @error: A [struct@GLib.Error] at failure.
  *
- * Get the list of ALSATimerEventType to filter events. This parameter is only
- * effective for target instance with ALSATimerEventDataType.TIMESTAMP.
+ * Get the list of ALSATimerEventType to filter events. This parameter is effective only for target
+ * instance with [enum@EventDataType:TIMESTAMP].
  */
 void alsatimer_instance_params_get_event_filter(ALSATimerInstanceParams *self,
                                             ALSATimerEventType **entries,

--- a/src/timer/instance-status.c
+++ b/src/timer/instance-status.c
@@ -2,17 +2,14 @@
 #include "privates.h"
 
 /**
- * SECTION: instance-status
- * @Title: ALSATimerInstanceStatus
- * @Short_description: A GObject-derived object to represent status of user
- *                     instance
+ * ALSATimerInstanceStatus:
+ * A GObject-derived object to represent status of user instance.
  *
- * A #ALSATimerInstanceStatus is a GObject-derived object to represent status
- * of user instance attached to any timer device or the other instance as slave.
- * The call of alsatimer_user_instance_get_status() returns the instance of
- * object.
+ * A [class@InstanceStatus] is a GObject-derived object to represent status of user instance
+ * attached to any timer device or the other instance as slave. The call of
+ * [method@UserInstance.get_status] returns the instance of object.
  *
- * The object wraps 'struct snd_timer_status' in UAPI of Linux sound subsystem.
+ * The object wraps `struct snd_timer_status` in UAPI of Linux sound subsystem.
  */
 typedef struct {
     struct snd_timer_status status;
@@ -101,10 +98,9 @@ static void alsatimer_instance_status_init(ALSATimerInstanceStatus *self)
 
 /**
  * alsatimer_instance_status_get_tstamp:
- * @self: A #ALSATimerInstanceStatus.
- * @tstamp: (array fixed-size=2)(out)(transfer none): The array with two
- *          elements for the seconds and nanoseconds parts of timestamp
- *          when the instance queues the latest event.
+ * @self: A [class@InstanceStatus].
+ * @tstamp: (array fixed-size=2)(out)(transfer none): The array with two elements for the seconds
+ *          and nanoseconds parts of timestamp when the instance queues the latest event.
  *
  * Get timestamp for the latest event.
  */
@@ -127,9 +123,9 @@ void alsatimer_instance_status_get_tstamp(ALSATimerInstanceStatus *self,
 /**
  * alsatimer_instance_status_new:
  *
- * Allocate and return an instance of #ALSATimerInstanceStatus.
+ * Allocate and return an instance of [class@InstanceStatus].
  *
- * Returns: A #ALSATimerInstanceStatus.
+ * Returns: A [class@InstanceStatus].
  */
 ALSATimerInstanceStatus *alsatimer_instance_status_new()
 {

--- a/src/timer/query.c
+++ b/src/timer/query.c
@@ -13,19 +13,12 @@
 
 #include <time.h>
 
-/**
- * SECTION: query
- * @Title: Global functions in ALSATimer
- * @Short_description: Global functions available without holding any
- *                     file descriptor
- */
-
 #define SYSFS_SND_TIMER_NODE    "/sys/module/snd_timer/"
 
 /**
  * alsatimer_get_sysname:
  * @sysname: (out): The string for sysname of ALSA Timer.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
  * Allocate sysname for ALSA Timer and return it when it exists.
  *
@@ -46,7 +39,7 @@ void alsatimer_get_sysname(char **sysname, GError **error)
 /**
  * alsatimer_get_devnode:
  * @devnode: (out): The string for devnode of ALSA Timer.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
  * Allocate string of devnode for ALSA Timer and return it if exists.
  *
@@ -83,14 +76,13 @@ static int open_fd(GError **error)
 
 /**
  * alsatimer_get_device_id_list:
- * @entries: (element-type ALSATimer.DeviceId)(out): The array with
- *           entries of ALSATimerId.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @entries: (element-type ALSATimer.DeviceId)(out): The array with entries of [struct@DeviceId].
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
  * Get the list of existent timer device.
  *
- * The call of function executes open(2), close(2), and ioctl(2) system call
- * with SNDRV_TIMER_IOCTL_NEXT_DEVICE command for ALSA timer character device.
+ * The call of function executes `open(2)`, `close(2)`, and `ioctl(2)` system call with
+ * `SNDRV_TIMER_IOCTL_NEXT_DEVICE` command for ALSA timer character device.
  */
 void alsatimer_get_device_id_list(GList **entries, GError **error)
 {
@@ -125,14 +117,14 @@ void alsatimer_get_device_id_list(GList **entries, GError **error)
 
 /**
  * alsatimer_get_device_info:
- * @device_id: A #ALSATimerDeviceId to identify the timer device.
+ * @device_id: A [struct@DeviceId] to identify the timer device.
  * @device_info: (out): The information of timer device.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
  * Get the information of timer device.
  *
- * The call of function executes open(2), close(2), and ioctl(2) system call
- * with SNDRV_TIMER_IOCTL_GINFO command for ALSA timer character device.
+ * The call of function executes `open(2)`, `close(2)`, and `ioctl(2)` system call with
+ * `SNDRV_TIMER_IOCTL_GINFO` command for ALSA timer character device.
  */
 void alsatimer_get_device_info(ALSATimerDeviceId *device_id,
                                ALSATimerDeviceInfo **device_info,
@@ -163,14 +155,14 @@ void alsatimer_get_device_info(ALSATimerDeviceId *device_id,
 
 /**
  * alsatimer_get_device_status:
- * @device_id: A #ALSATimerDeviceId to identify the timer device.
+ * @device_id: A [struct@DeviceId] to identify the timer device.
  * @device_status: (inout): The status of timer device.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
  * Get the status of timer device.
  *
- * The call of function executes open(2), close(2), and ioctl(2) system call
- * with SNDRV_TIMER_IOCTL_GSTATUS command for ALSA timer character device.
+ * The call of function executes `open(2)`, `close(2)`, and `ioctl(2)` system call with
+ * `SNDRV_TIMER_IOCTL_GSTATUS` command for ALSA timer character device.
  */
 void alsatimer_get_device_status(ALSATimerDeviceId *device_id,
                                  ALSATimerDeviceStatus *const *device_status,
@@ -200,14 +192,14 @@ void alsatimer_get_device_status(ALSATimerDeviceId *device_id,
 
 /**
  * alsatimer_set_device_params:
- * @device_id: A #ALSATimerDeviceId to identify the timer device.
+ * @device_id: A [struct@DeviceId] to identify the timer device.
  * @device_params: The parameters of timer device.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
  * Set the given parameters to the timer indicated by the identifier.
  *
- * The call of function executes open(2), close(2), and ioctl(2) system call
- * with SNDRV_TIMER_IOCTL_GPARAMS command for ALSA timer character device.
+ * The call of function executes `open(2)`, `close(2)`, and `ioctl(2)` system call with
+ * `SNDRV_TIMER_IOCTL_GPARAMS` command for ALSA timer character device.
  */
 void alsatimer_set_device_params(ALSATimerDeviceId *device_id,
                                  const ALSATimerDeviceParams *device_params,
@@ -268,19 +260,18 @@ end:
 
 /**
  * alsatimer_get_tstamp_source:
- * @clock_id: (out): The clock source for timestamp. The value of CLOCK_XXX in
- *                   UAPI of Linux kernel.
- * @error: A #GError. Error is generated with domain of #g_file_error_quark().
+ * @clock_id: (out): The clock source for timestamp. The value of `CLOCK_XXX` in UAPI of Linux
+ *            kernel.
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `GLib.FileError`.
  *
- * Get the clock source for timestamp when #ALSATimerUserInstance is configured
- * to receive event with timestamp. The source is selected according to
- * parameter of 'snd-timer' kernel module, and the call of function is just to
- * refer to it.
+ * Get the clock source for timestamp when [class@UserInstance] is configured to receive event
+ * with timestamp. The source is selected according to parameter of `snd-timer` kernel module,
+ * and the call of function is just to refer to it.
  *
- * 0 means CLOCK_REALTIME is used. 1 means CLOCK_MONOTONIC is used.
+ * `0` means `CLOCK_REALTIME` is used. `1` means `CLOCK_MONOTONIC` is used.
  *
- * The call of function executes open(2), read(2), close(2) system calls for
- * the sysfs node corresponding to 'snd-timer' kernel module.
+ * The call of function executes `open(2)`, `read(2)`, `close(2)` system calls for the sysfs node
+ * corresponding to `snd-timer` kernel module.
  */
 void alsatimer_get_tstamp_source(int *clock_id, GError **error)
 {

--- a/src/timer/user-instance.c
+++ b/src/timer/user-instance.c
@@ -11,17 +11,14 @@
 #include <errno.h>
 
 /**
- * SECTION: user-instance
- * @Title: ALSATimerUserInstance
- * @Short_description: A GObject-derived object to represent user instance
+ * ALSATimerUserInstance:
+ * A GObject-derived object to represent user instance.
  *
- * A #ALSATimerUserInstance is a GObject-derived object to represent information
- * of user instance attached to any timer device or the other instance as slave.
- * After calling alsatimer_user_instance_open(), the object maintains file
- * descriptor till object destruction. After calling
- * alsatimer_user_instance_attach() or alsatimer_user_instance_attach_as_slave(),
- * the user instance is attached to any timer device or the other instance as
- * slave.
+ * A [class@UserInstance] is a GObject-derived object to represent information of user instance
+ * attached to any timer device or the other instance as slave. After calling
+ * [method@UserInstance.open], the object maintains file descriptor till object destruction. After
+ * calling [method@UserInstance.attach] or [method@UserInstance.attach_as_slave], the user instance
+ * is attached to any timer device or the other instance as slave.
  */
 typedef struct {
     int fd;
@@ -33,9 +30,10 @@ G_DEFINE_TYPE_WITH_PRIVATE(ALSATimerUserInstance, alsatimer_user_instance, G_TYP
 /**
  * alsatimer_user_instance_error_quark:
  *
- * Return the GQuark for error domain of GError which has code in #ALSATimerUserInstanceError enumerations.
+ * Return the [alias@GLib.Quark] for [struct@GLib.Error] which has code in [enum@UserInstanceError]
+ * enumerations.
  *
- * Returns: A #GQuark.
+ * Returns: A [alias@GLib.Quark].
  */
 G_DEFINE_QUARK(alsatimer-user-instance-error-quark, alsatimer_user_instance_error)
 
@@ -87,10 +85,10 @@ static void alsatimer_user_instance_class_init(ALSATimerUserInstanceClass *klass
 
     /**
      * ALSATimerUserInstance::handle-event:
-     * @self: A #ALSATimerUserInstance.
-     * @event: (transfer none): The instance of #ALSATimerEvent.
+     * @self: A [class@UserInstance].
+     * @event: (transfer none): The instance of [struct@Event].
      *
-     * When event occurs for any element, this signal is emit.
+     * Emitted when event occurs.
      */
     timer_user_instance_sigs[TIMER_USER_INSTANCE_SIG_HANDLE_EVENT] =
         g_signal_new("handle-event",
@@ -103,12 +101,11 @@ static void alsatimer_user_instance_class_init(ALSATimerUserInstanceClass *klass
 
     /**
      * ALSATimerUserInstance::handle-disconnection:
-     * @self: A #ALSATimerUserInstance.
+     * @self: A [class@UserInstance].
      *
-     * When the attached timer device is not available anymore due to unbinding
-     * driver or hot unplugging, this signal is emit. The owner of this object
-     * should call g_object_free() as quickly as possible to release ALSA timer
-     * character device.
+     * Emitted when the attached timer device is not available anymore due to unbinding driver or
+     * hot unplugging. The owner of this object should call [method@GObject.Object.unref] as quickly
+     * as possible to release ALSA timer character device.
      */
     timer_user_instance_sigs[TIMER_USER_INSTANCE_SIG_HANDLE_DISCONNECTION] =
         g_signal_new("handle-disconnection",
@@ -130,15 +127,14 @@ static void alsatimer_user_instance_init(ALSATimerUserInstance *self)
 
 /**
  * alsatimer_user_instance_open:
- * @self: A #ALSATimerUserInstance.
- * @open_flag: The flag of open(2) system call. O_RDONLY is forced to fulfil internally.
- * @error: A #GError. Error is generated with two domains; #g_file_error_quark() and
- *         #alsatimer_user_instance_error_quark().
+ * @self: A [class@UserInstance].
+ * @open_flag: The flag of `open(2)` system call. `O_RDONLY` is forced to fulfil internally.
+ * @error: A [struct@GLib.Error]. Error is generated with two domains; `GLib.FileError` and
+ *         `ALSATimer.UserInstanceError`.
  *
  * Open ALSA Timer character device to allocate queue.
  *
- * The call of function executes open(2) system call for ALSA timer character
- * device.
+ * The call of function executes `open(2)` system call for ALSA timer character device.
  */
 void alsatimer_user_instance_open(ALSATimerUserInstance *self, gint open_flag,
                                   GError **error)
@@ -184,6 +180,13 @@ void alsatimer_user_instance_open(ALSATimerUserInstance *self, gint open_flag,
     priv->proto_ver_triplet[2] = SNDRV_PROTOCOL_MICRO(proto_ver);
 }
 
+/**
+ * alsatimer_user_instance_new:
+ *
+ * Allocate and return an instance of [class@UserInstance].
+ *
+ * Returns: An instance of [class@UserInstance].
+ */
 ALSATimerUserInstance *alsatimer_user_instance_new()
 {
     return g_object_new(ALSATIMER_TYPE_USER_INSTANCE, NULL);
@@ -191,15 +194,14 @@ ALSATimerUserInstance *alsatimer_user_instance_new()
 
 /**
  * alsatimer_user_instance_get_protocol_version:
- * @self: A #ALSATimerUserInstance.
- * @proto_ver_triplet: (array fixed-size=3)(out)(transfer none): The version of
- *                     protocol currently used.
- * @error: A #GError.
+ * @self: A [class@UserInstance].
+ * @proto_ver_triplet: (array fixed-size=3)(out)(transfer none): The version of protocol currently
+ *                     used.
+ * @error: A [struct@GLib.Error].
  *
- * Get the version of timer protocol currently used. The version is
- * represented as the array with three elements; major, minor, and micro version
- * in the order. The length of major version is 16 bit, the length of minor
- * and micro version is 8 bit each.
+ * Get the version of timer protocol currently used. The version is represented as the array with
+ * three elements; major, minor, and micro version in the order. The length of major version is
+ * 16 bit, the length of minor and micro version is 8 bit each.
  */
 void alsatimer_user_instance_get_protocol_version(ALSATimerUserInstance *self,
                                         const guint16 *proto_ver_triplet[3],
@@ -219,18 +221,18 @@ void alsatimer_user_instance_get_protocol_version(ALSATimerUserInstance *self,
 
 /**
  * alsatimer_user_instance_choose_event_data_type:
- * @self: A #ALSATimerUserInstance.
- * @event_data_type: The type of event data, one of ALSATimerEventDataType.
- * @error: A #GError. Error is generated with domain of #alsatimer_user_instance_error_quark().
+ * @self: A [class@UserInstance].
+ * @event_data_type: The type of event data, one of [enum@EventDataType].
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSATimer.UserInstanceError`.
  *
  * Choose the type of event data to receive.
  *
- * The call of function is successful just before the instance is not attached
- * yet. ALSATIMER_EVENT_DATA_TYPE_TICK is used as a default if the function is
- * not called for ALSATIMER_EVENT_DATA_TYPE_TSTAMP explicitly.
+ * The call of function is successful just before the instance is not attached yet.
+ * [enum@EventDataType:TICK] is used as a default if the function is not called for
+ * [enum@EventDataType:TSTAMP] explicitly.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_TIMER_IOCTL_TREAD command for ALSA timer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_TIMER_IOCTL_TREAD` command
+ * for ALSA timer character device.
  */
 void alsatimer_user_instance_choose_event_data_type(ALSATimerUserInstance *self,
                                         ALSATimerEventDataType event_data_type,
@@ -257,15 +259,15 @@ void alsatimer_user_instance_choose_event_data_type(ALSATimerUserInstance *self,
 
 /**
  * alsatimer_user_instance_attach:
- * @self: A #ALSATimerUserInstance.
- * @device_id: A #ALSATimerDeviceId to which the instance is attached.
- * @error: A #GError. Error is generated with domain of #alsatimer_user_instance_error_quark.
+ * @self: A [class@UserInstance].
+ * @device_id: A [struct@DeviceId] to which the instance is attached.
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSATimer.UserInstanceError`.
  *
- * Attach the instance to the timer device. If the given device_id is for
- * absent timer device, the instance can be detached with error.
+ * Attach the instance to the timer device. If the given device_id is for absent timer device, the
+ * instance can be detached with error.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_TIMER_IOCTL_SELECT command for ALSA timer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_TIMER_IOCTL_SELECT` command
+ * for ALSA timer character device.
  */
 void alsatimer_user_instance_attach(ALSATimerUserInstance *self,
                                     ALSATimerDeviceId *device_id,
@@ -291,21 +293,18 @@ void alsatimer_user_instance_attach(ALSATimerUserInstance *self,
 
 /**
  * alsatimer_user_instance_attach_as_slave:
- * @self: A #ALSATimerUserInstance.
- * @slave_class: The class identifier of master instance, one of
- *               #ALSATimerSlaveClass.
- * @slave_id: The numerical identifier of master instance.
- * @error: A #GError. Error is generated with domain of #alsatimer_user_instance_error_quark.
+ * @self: A [class@UserInstance].
+ * @slave_class: The class identifier of master instance, one of [enum@SlaveClass].
+ * @slave_id: The numeric identifier of master instance.
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSATimer.UserInstanceError`.
  *
- * Attach the instance as an slave to another instance indicated by a pair of
- * slave_class and slave_id. If the slave_class is for application
- * (=ALSATIMER_SLAVE_CLASS_APPLICATION), the slave_id is for the PID of
+ * Attach the instance as an slave to another instance indicated by a pair of slave_class and
+ * slave_id. If the slave_class is [enum@SlaveClass:APPLICATION], the slave_id is for the PID of
  * application process which owns the instance of timer. If the slave_class is
- * for ALSA sequencer (=ALSATIMER_SLAVE_CLASS_SEQUENCER), the slave_id is the
- * numerical ID of queue bound for timer device.
+ * [enum@SlaveClass:SEQUENCER], the slave_id is the numeric ID of queue bound for timer device.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_TIMER_IOCTL_SELECT command for ALSA timer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_TIMER_IOCTL_SELECT` command
+ * for ALSA timer character device.
  */
 void alsatimer_user_instance_attach_as_slave(ALSATimerUserInstance *self,
                                         ALSATimerSlaveClass slave_class,
@@ -329,14 +328,14 @@ void alsatimer_user_instance_attach_as_slave(ALSATimerUserInstance *self,
 
 /**
  * alsatimer_user_instance_get_info:
- * @self: A #ALSATimerUserInstance.
- * @instance_info: (out): A #ALSATimerInstanceInfo.
- * @error: A #GError. Error is generated with domain of #alsatimer_user_instance_error_quark.
+ * @self: A [class@UserInstance].
+ * @instance_info: (out): A [class@InstanceInfo].
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSATimer.UserInstanceError`.
  *
  * Return the information of device if attached to the instance.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_TIMER_IOCTL_INFO command for ALSA timer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_TIMER_IOCTL_INFO` command for
+ * ALSA timer character device.
  */
 void alsatimer_user_instance_get_info(ALSATimerUserInstance *self,
                                       ALSATimerInstanceInfo **instance_info,
@@ -365,14 +364,14 @@ void alsatimer_user_instance_get_info(ALSATimerUserInstance *self,
 
 /**
  * alsatimer_user_instance_set_params:
- * @self: A #ALSATimerUserInstance.
- * @instance_params: (inout): A #ALSATimerInstanceParams.
- * @error: A #GError. Error is generated with domain of #alsatimer_user_instance_error_quark.
+ * @self: A [class@UserInstance].
+ * @instance_params: (inout): A [class@InstanceParams].
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSATimer.UserInstanceError`.
  *
  * Configure the instance with the parameters and return the latest parameters.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_TIMER_IOCTL_PARAMS command for ALSA timer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_TIMER_IOCTL_PARAMS` command
+ * for ALSA timer character device.
  */
 void alsatimer_user_instance_set_params(ALSATimerUserInstance *self,
                                 ALSATimerInstanceParams *const *instance_params,
@@ -399,14 +398,14 @@ void alsatimer_user_instance_set_params(ALSATimerUserInstance *self,
 
 /**
  * alsatimer_user_instance_get_status:
- * @self: A #ALSATimerUserInstance.
- * @instance_status: (inout): A #ALSATimerInstanceStatus.
- * @error: A #GError. Error is generated with domain of #alsatimer_user_instance_error_quark.
+ * @self: A [class@UserInstance].
+ * @instance_status: (inout): A [class@InstanceStatus].
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSATimer.UserInstanceError`.
  *
  * Get the latest status of instance.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_TIMER_IOCTL_STATUS command for ALSA timer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_TIMER_IOCTL_STATUS` command
+ * for ALSA timer character device.
  */
 void alsatimer_user_instance_get_status(ALSATimerUserInstance *self,
                                 ALSATimerInstanceStatus *const *instance_status,
@@ -511,14 +510,14 @@ static void timer_user_instance_finalize_src(GSource *gsrc)
 
 /**
  * alsatimer_user_instance_create_source:
- * @self: A #ALSATimerUserInstance.
- * @gsrc: (out): A #GSource to handle events from ALSA timer character device.
- * @error: A #GError.
+ * @self: A [class@UserInstance].
+ * @gsrc: (out): A [struct@GLib.Source] to handle events from ALSA timer character device.
+ * @error: A [struct@GLib.Error].
  *
- * Allocate GSource structure to handle events from ALSA timer character
- * device. In each iteration of GMainContext, the read(2) system call is
- * executed to dispatch timer event for 'handle-event' signal, according to
- * the result of poll(2) system call.
+ * Allocate [struct@GLib.Source] structure to handle events from ALSA timer character device. In
+ * each iteration of [struct@GLib.MainContext], the `read(2)` system call is executed to dispatch
+ * timer event for [signal@UserInstance::handle-event] signal, according to the result of `poll(2)`
+ * system call.
  */
 void alsatimer_user_instance_create_source(ALSATimerUserInstance *self,
                                          GSource **gsrc, GError **error)
@@ -557,13 +556,13 @@ void alsatimer_user_instance_create_source(ALSATimerUserInstance *self,
 
 /**
  * alsatimer_user_instance_start:
- * @self: A #ALSATimerUserInstance.
- * @error: A #GError. Error is generated with domain of #alsatimer_user_instance_error_quark.
+ * @self: A [class@UserInstance].
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSATimer.UserInstanceError`.
  *
  * Start timer event emission.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_TIMER_IOCTL_START command for ALSA timer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_TIMER_IOCTL_START` command
+ * for ALSA timer character device.
  */
 void alsatimer_user_instance_start(ALSATimerUserInstance *self, GError **error)
 {
@@ -584,13 +583,13 @@ void alsatimer_user_instance_start(ALSATimerUserInstance *self, GError **error)
 
 /**
  * alsatimer_user_instance_stop:
- * @self: A #ALSATimerUserInstance.
- * @error: A #GError. Error is generated with domain of #alsatimer_user_instance_error_quark.
+ * @self: A [class@UserInstance].
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSATimer.UserInstanceError`.
  *
  * Stop timer event emission.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_TIMER_IOCTL_STOP command for ALSA timer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_TIMER_IOCTL_STOP` command
+ * for ALSA timer character device.
  */
 void alsatimer_user_instance_stop(ALSATimerUserInstance *self, GError **error)
 {
@@ -611,13 +610,13 @@ void alsatimer_user_instance_stop(ALSATimerUserInstance *self, GError **error)
 
 /**
  * alsatimer_user_instance_pause:
- * @self: A #ALSATimerUserInstance.
- * @error: A #GError. Error is generated with domain of #alsatimer_user_instance_error_quark.
+ * @self: A [class@UserInstance].
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSATimer.UserInstanceError`.
  *
  * Pause timer event emission.
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_TIMER_IOCTL_PAUSE command for ALSA timer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_TIMER_IOCTL_PAUSE` command
+ * for ALSA timer character device.
  */
 void alsatimer_user_instance_pause(ALSATimerUserInstance *self, GError **error)
 {
@@ -638,13 +637,13 @@ void alsatimer_user_instance_pause(ALSATimerUserInstance *self, GError **error)
 
 /**
  * alsatimer_user_instance_continue:
- * @self: A #ALSATimerUserInstance.
- * @error: A #GError. Error is generated with domain of #alsatimer_user_instance_error_quark.
+ * @self: A [class@UserInstance].
+ * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSATimer.UserInstanceError`.
  *
- * Continue timer event emission paused by alsatimer_user_instance_pause().
+ * Continue timer event emission paused by [method@UserInstance.pause].
  *
- * The call of function executes ioctl(2) system call with
- * SNDRV_TIMER_IOCTL_CONTINUE command for ALSA timer character device.
+ * The call of function executes `ioctl(2)` system call with `SNDRV_TIMER_IOCTL_CONTINUE` command
+ * for ALSA timer character device.
  */
 void alsatimer_user_instance_continue(ALSATimerUserInstance *self,
                                       GError **error)

--- a/src/timer/user-instance.h
+++ b/src/timer/user-instance.h
@@ -20,22 +20,19 @@ struct _ALSATimerUserInstanceClass {
 
     /**
      * ALSATimerUserInstanceClass::handle_event:
-     * @self: A #ALSATimerUserInstance.
-     * @event: (transfer none): An object derived from #ALSATimerEvent.
+     * @self: A [class@UserInstance].
+     * @event: (transfer none): An object derived from [struct@Event].
      *
-     * When event occurs, this signal is emit.
+     * Class closure for the [signal@UserInstance::handle-event] signal.
      */
     void (*handle_event)(ALSATimerUserInstance *self,
                          const ALSATimerEvent *event);
 
     /**
      * ALSATimerUserInstanceClass::handle_disconnection:
-     * @self: A #ALSATimerUserInstance.
+     * @self: A [class@UserInstance].
      *
-     * When the attached timer device is not available anymore due to unbinding
-     * driver or hot unplugging, this signal is emit. The owner of this object
-     * should call g_object_free() as quickly as possible to release ALSA timer
-     * character device.
+     * Class closure for the [signal@UserInstance::handle-disconnection] signal.
      */
     void (*handle_disconnection)(ALSATimerUserInstance *self);
 };


### PR DESCRIPTION
The gi-docgen supports enhancement of inter-document link:

  *  https://gnome.pages.gitlab.gnome.org/gi-docgen/linking.html

This patchset is optimization to it.

```
Takashi Sakamoto (55):
  rawmidi: fix wrong handling of open flag
  fix installation path for documents in README
  Split dependency section with requirements section in README
  markup URI correctly in README
  hwdep/rawmidi: enums: rename enumerators with enumerations
  ctl: enums: link optimization to gi-docgen
  ctl: query: link optimization to gi-docgen
  ctl: card: link optimization to gi-docgen
  ctl: card_info: link optimization to gi-docgen
  ctl: elem_id: link optimization to gi-docgen
  ctl: elem_info: link optimization to gi-docgen
  ctl: elem_value: link optimization to gi-docgen
  hwdep: query: link optimization to gi-docgen
  hwdep: device_info: link optimization to gi-docgen
  rawmidi: enums: link optimization to gi-docgen
  rawmidi: query: link optimization to gi-docgen
  rawmidi; stream_pair: link optimization to gi-docgen
  rawmidi: substream_info: link optimization to gi-docgen
  rawmidi: substream_params: link optimization to gi-docgen
  rawmidi: substream_status: link optimization to gi-docgen
  timer: enums: link optimization to gi-docgen
  timer: query: link optimization to gi-docgen
  timer: device_id: link optimization to gi-docgen
  timer: device_info: link optimization to gi-docgen
  timer: device_params: link optimization to gi-docgen
  timer: device_status: link optimization to gi-docgen
  timer: user_instance: link optimization to gi-docgen
  timer: instance_info: link optimization to gi-docgen
  timer: instance_params: link optimization to gi-docgen
  timer: instance_status: link optimization to gi-docgen
  timer: event: link optimization to gi-docgen
  timer: event_data_tick: link optimization to gi-docgen
  timer: event_data_tstamp: link optimization to gi-docgen
  seq: enum: link optimization to gi-docgen
  seq: query: link optimization to gi-docgen
  seq: addr: link optimization to gi-docgen
  seq: system_info: link optimization to gi-docgen
  seq: client_info: link optimization to gi-docgen
  seq: port_info: link optimization to gi-docgen
  seq: client_pool: link optimization to gi-docgen
  seq: subscribe_data: link optimization to gi-docgen
  seq: queue_info: link optimization to gi-docgen
  seq: queue_status: link optimization to gi-docgen
  seq: user_client: link optimization to gi-docgen
  seq: tstamp: link optimization to gi-docgen
  seq: remove_filter: link optimization to gi-docgen
  seq: queue_tempo: link optimization to gi-docgen
  seq: queue_timer_data_alsa: link optimization to gi-docgen
  seq: queue_timer_data_alsa: link optimization to gi-docgen
  seq: event_cntr: link optimization to gi-docgen
  seq: event_data_connect: link optimization to gi-docgen
  seq: event_data_ctl: link optimization to gi-docgen
  seq: event_data_note: link optimization to gi-docgen
  seq: event_data_queue: link optimization to gi-docgen
  seq: event_data_result: link optimization to gi-docgen

 README.rst                           |  30 +--
 src/ctl/alsactl-enum-types.h         |   2 +-
 src/ctl/card-info.c                  |  13 +-
 src/ctl/card.c                       | 276 ++++++++++++-------------
 src/ctl/card.h                       |  15 +-
 src/ctl/elem-id.c                    |  60 +++---
 src/ctl/elem-info.c                  | 127 +++++-------
 src/ctl/elem-info.h                  |  22 +-
 src/ctl/elem-value.c                 | 137 ++++++------
 src/ctl/query.c                      |  30 +--
 src/hwdep/alsahwdep-enum-types.h     |   2 +-
 src/hwdep/device-info.c              |  13 +-
 src/hwdep/query.c                    |  36 ++--
 src/rawmidi/alsarawmidi-enum-types.h |   4 +-
 src/rawmidi/query.c                  |  65 +++---
 src/rawmidi/stream-pair.c            | 207 +++++++++----------
 src/rawmidi/stream-pair.h            |  11 +-
 src/rawmidi/substream-info.c         |  23 +--
 src/rawmidi/substream-params.c       |  19 +-
 src/rawmidi/substream-params.h       |   1 +
 src/rawmidi/substream-status.c       |  18 +-
 src/seq/addr.c                       |  35 ++--
 src/seq/alsaseq-enum-types.h         |   2 +-
 src/seq/client-info.c                |  35 ++--
 src/seq/client-pool.c                |  17 +-
 src/seq/event-cntr.c                 | 232 ++++++++++-----------
 src/seq/event-data-connect.c         |  23 +--
 src/seq/event-data-ctl.c             |  23 +--
 src/seq/event-data-note.c            |  31 ++-
 src/seq/event-data-queue.c           |  79 ++++---
 src/seq/event-data-result.c          |  19 +-
 src/seq/port-info.c                  |  18 +-
 src/seq/query.c                      | 154 ++++++--------
 src/seq/queue-info.c                 |  21 +-
 src/seq/queue-status.c               |  26 ++-
 src/seq/queue-tempo.c                |  26 ++-
 src/seq/queue-timer-data-alsa.c      |  27 ++-
 src/seq/queue-timer.c                |  29 ++-
 src/seq/remove-filter.c              | 124 +++++------
 src/seq/subscribe-data.c             |  20 +-
 src/seq/system-info.c                |  13 +-
 src/seq/tstamp.c                     |  29 ++-
 src/seq/user-client.c                | 299 +++++++++++++--------------
 src/seq/user-client.h                |   4 +-
 src/timer/alsatimer-enum-types.h     |   2 +-
 src/timer/device-id.c                |  49 +++--
 src/timer/device-info.c              |  14 +-
 src/timer/device-params.c            |  17 +-
 src/timer/device-status.c            |  15 +-
 src/timer/event-data-tick.c          |  15 +-
 src/timer/event-data-tstamp.c        |  24 +--
 src/timer/event.c                    |  30 ++-
 src/timer/instance-info.c            |  14 +-
 src/timer/instance-params.c          |  41 ++--
 src/timer/instance-status.c          |  26 +--
 src/timer/query.c                    |  63 +++---
 src/timer/user-instance.c            | 199 +++++++++---------
 src/timer/user-instance.h            |  13 +-
 58 files changed, 1353 insertions(+), 1566 deletions(-)
```