### PR TITLE
[PATCH 00/23] tests: refine test implementation

### DIFF
--- a/tests/alsactl-card
+++ b/tests/alsactl-card
@@ -31,6 +31,8 @@ methods = (
     'write_elem_value',
     'read_elem_value',
     'create_source',
+)
+vmethods = (
     'do_handle_elem_event',
     'do_handle_disconnection',
 )
@@ -39,5 +41,5 @@ signals = (
     'handle-disconnection',
 )
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsactl-card
+++ b/tests/alsactl-card
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSACtl', '0.0')
@@ -39,5 +39,5 @@ signals = (
     'handle-disconnection',
 )
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsactl-card
+++ b/tests/alsactl-card
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSACtl', '0.0')
 from gi.repository import ALSACtl
 
-target = ALSACtl.Card()
+target_type = ALSACtl.Card
 props = (
     'devnode',
     'subscribed',
@@ -39,5 +39,5 @@ signals = (
     'handle-disconnection',
 )
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsactl-card-info
+++ b/tests/alsactl-card-info
@@ -20,7 +20,8 @@ props = (
     'components',
 )
 methods = ()
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsactl-card-info
+++ b/tests/alsactl-card-info
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSACtl', '0.0')
@@ -22,5 +22,5 @@ props = (
 methods = ()
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsactl-card-info
+++ b/tests/alsactl-card-info
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSACtl', '0.0')
 from gi.repository import ALSACtl
 
-target = ALSACtl.CardInfo()
+target_type = ALSACtl.CardInfo
 props = (
     'card-id',
     'id',
@@ -22,5 +22,5 @@ props = (
 methods = ()
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsactl-elem-id
+++ b/tests/alsactl-elem-id
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSACtl', '0.0')
@@ -22,5 +22,5 @@ methods = (
 )
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsactl-elem-id
+++ b/tests/alsactl-elem-id
@@ -3,24 +3,22 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test_object
+from helper import test_struct
 
 import gi
 gi.require_version('ALSACtl', '0.0')
 from gi.repository import ALSACtl
 
-target = ALSACtl.ElemId()
-props = ()
+target_type = ALSACtl.ElemId
 methods = (
     'get_numid',
     'get_iface',
-    'get_device',
-    'get_subdevice',
+    'get_device_id',
+    'get_subdevice_id',
     'get_name',
     'get_index',
-    'equals',
+    'equal',
 )
-signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_struct(target_type, methods):
     exit(ENXIO)

--- a/tests/alsactl-elem-info-boolean
+++ b/tests/alsactl-elem-info-boolean
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSACtl', '0.0')
@@ -22,5 +22,5 @@ methods = (
 )
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsactl-elem-info-boolean
+++ b/tests/alsactl-elem-info-boolean
@@ -11,6 +11,7 @@ from gi.repository import ALSACtl
 
 target_type = ALSACtl.ElemInfoBoolean
 props = (
+    # From interfaces.
     'elem-id',
     'elem-type',
     'access',

--- a/tests/alsactl-elem-info-boolean
+++ b/tests/alsactl-elem-info-boolean
@@ -20,7 +20,8 @@ props = (
 methods = (
     'new',
 )
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsactl-elem-info-boolean
+++ b/tests/alsactl-elem-info-boolean
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSACtl', '0.0')
 from gi.repository import ALSACtl
 
-target = ALSACtl.ElemInfoBoolean.new()
+target_type = ALSACtl.ElemInfoBoolean
 props = (
     'elem-id',
     'elem-type',
@@ -22,5 +22,5 @@ methods = (
 )
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsactl-elem-info-bytes
+++ b/tests/alsactl-elem-info-bytes
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSACtl', '0.0')
 from gi.repository import ALSACtl
 
-target = ALSACtl.ElemInfoBytes.new()
+target_type = ALSACtl.ElemInfoBytes
 props = (
     'elem-id',
     'elem-type',
@@ -22,5 +22,5 @@ methods = (
 )
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsactl-elem-info-bytes
+++ b/tests/alsactl-elem-info-bytes
@@ -11,6 +11,7 @@ from gi.repository import ALSACtl
 
 target_type = ALSACtl.ElemInfoBytes
 props = (
+    # From interfaces.
     'elem-id',
     'elem-type',
     'access',

--- a/tests/alsactl-elem-info-bytes
+++ b/tests/alsactl-elem-info-bytes
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSACtl', '0.0')
@@ -22,5 +22,5 @@ methods = (
 )
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsactl-elem-info-bytes
+++ b/tests/alsactl-elem-info-bytes
@@ -20,7 +20,8 @@ props = (
 methods = (
     'new',
 )
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsactl-elem-info-common
+++ b/tests/alsactl-elem-info-common
@@ -9,19 +9,14 @@ import gi
 gi.require_version('ALSACtl', '0.0')
 from gi.repository import ALSACtl
 
-target_type = ALSACtl.ElemInfoEnumerated
+target_type = ALSACtl.ElemInfoCommon
 props = (
-    'labels',
-    # From interfaces.
     'elem-id',
     'elem-type',
     'access',
     'owner',
-    'value-count',
 )
-methods = (
-    'new',
-)
+methods = ()
 vmethods = ()
 signals = ()
 

--- a/tests/alsactl-elem-info-enumerated
+++ b/tests/alsactl-elem-info-enumerated
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSACtl', '0.0')
@@ -23,5 +23,5 @@ methods = (
 )
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsactl-elem-info-enumerated
+++ b/tests/alsactl-elem-info-enumerated
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSACtl', '0.0')
 from gi.repository import ALSACtl
 
-target = ALSACtl.ElemInfoEnumerated.new()
+target_type = ALSACtl.ElemInfoEnumerated
 props = (
     'elem-id',
     'elem-type',
@@ -23,5 +23,5 @@ methods = (
 )
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsactl-elem-info-enumerated
+++ b/tests/alsactl-elem-info-enumerated
@@ -21,7 +21,8 @@ props = (
 methods = (
     'new',
 )
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsactl-elem-info-iec60958
+++ b/tests/alsactl-elem-info-iec60958
@@ -11,6 +11,7 @@ from gi.repository import ALSACtl
 
 target_type = ALSACtl.ElemInfoIec60958
 props = (
+    # From interfaces.
     'elem-id',
     'elem-type',
     'access',

--- a/tests/alsactl-elem-info-iec60958
+++ b/tests/alsactl-elem-info-iec60958
@@ -19,7 +19,8 @@ props = (
 methods = (
     'new',
 )
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsactl-elem-info-iec60958
+++ b/tests/alsactl-elem-info-iec60958
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSACtl', '0.0')
@@ -21,5 +21,5 @@ methods = (
 )
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsactl-elem-info-iec60958
+++ b/tests/alsactl-elem-info-iec60958
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSACtl', '0.0')
 from gi.repository import ALSACtl
 
-target = ALSACtl.ElemInfoIec60958.new()
+target_type = ALSACtl.ElemInfoIec60958
 props = (
     'elem-id',
     'elem-type',
@@ -21,5 +21,5 @@ methods = (
 )
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsactl-elem-info-integer
+++ b/tests/alsactl-elem-info-integer
@@ -23,7 +23,8 @@ props = (
 methods = (
     'new',
 )
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsactl-elem-info-integer
+++ b/tests/alsactl-elem-info-integer
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSACtl', '0.0')
@@ -25,5 +25,5 @@ methods = (
 )
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsactl-elem-info-integer
+++ b/tests/alsactl-elem-info-integer
@@ -11,14 +11,15 @@ from gi.repository import ALSACtl
 
 target_type = ALSACtl.ElemInfoInteger
 props = (
+    'value-min',
+    'value-max',
+    'value-step',
+    # From interfaces.
     'elem-id',
     'elem-type',
     'access',
     'owner',
     'value-count',
-    'value-min',
-    'value-max',
-    'value-step',
 )
 methods = (
     'new',

--- a/tests/alsactl-elem-info-integer
+++ b/tests/alsactl-elem-info-integer
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSACtl', '0.0')
 from gi.repository import ALSACtl
 
-target = ALSACtl.ElemInfoInteger.new()
+target_type = ALSACtl.ElemInfoInteger
 props = (
     'elem-id',
     'elem-type',
@@ -25,5 +25,5 @@ methods = (
 )
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsactl-elem-info-integer64
+++ b/tests/alsactl-elem-info-integer64
@@ -23,7 +23,8 @@ props = (
 methods = (
     'new',
 )
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsactl-elem-info-integer64
+++ b/tests/alsactl-elem-info-integer64
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSACtl', '0.0')
@@ -25,5 +25,5 @@ methods = (
 )
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsactl-elem-info-integer64
+++ b/tests/alsactl-elem-info-integer64
@@ -11,14 +11,15 @@ from gi.repository import ALSACtl
 
 target_type = ALSACtl.ElemInfoInteger64
 props = (
+    'value-min',
+    'value-max',
+    'value-step',
+    # From interfaces.
     'elem-id',
     'elem-type',
     'access',
     'owner',
     'value-count',
-    'value-min',
-    'value-max',
-    'value-step',
 )
 methods = (
     'new',

--- a/tests/alsactl-elem-info-integer64
+++ b/tests/alsactl-elem-info-integer64
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSACtl', '0.0')
 from gi.repository import ALSACtl
 
-target = ALSACtl.ElemInfoInteger64.new()
+target_type = ALSACtl.ElemInfoInteger64
 props = (
     'elem-id',
     'elem-type',
@@ -25,5 +25,5 @@ methods = (
 )
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsactl-elem-info-single-array
+++ b/tests/alsactl-elem-info-single-array
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_object
+
+import gi
+gi.require_version('ALSACtl', '0.0')
+from gi.repository import ALSACtl
+
+target_type = ALSACtl.ElemInfoSingleArray
+props = (
+    'value-count',
+)
+methods = ()
+vmethods = ()
+signals = ()
+
+if not test_object(target_type, props, methods, vmethods, signals):
+    exit(ENXIO)

--- a/tests/alsactl-elem-value
+++ b/tests/alsactl-elem-value
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSACtl', '0.0')
@@ -33,5 +33,5 @@ methods = (
 )
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsactl-elem-value
+++ b/tests/alsactl-elem-value
@@ -31,7 +31,8 @@ methods = (
     'get_int64',
     'equal',
 )
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsactl-elem-value
+++ b/tests/alsactl-elem-value
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSACtl', '0.0')
 from gi.repository import ALSACtl
 
-target = ALSACtl.ElemValue()
+target_type = ALSACtl.ElemValue
 props = (
     'elem-id',
 )
@@ -33,5 +33,5 @@ methods = (
 )
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsactl-enums
+++ b/tests/alsactl-enums
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 
 from sys import exit
+
 import gi
 gi.require_version('ALSACtl', '0.0')
 from gi.repository import ALSACtl
+
+from helper import test_enums
 
 elem_types = (
     'NONE',
@@ -70,8 +73,6 @@ types = {
     ALSACtl.CardError:      card_error_types,
 }
 
-for obj, types in types.items():
-    for t in types:
-        if not hasattr(obj, t):
-            print('Enumerator {0} is not produced.'.format(t))
-            exit(1)
+for target_type, enumerations in types.items():
+    if not test_enums(target_type, enumerations):
+        exit(1)

--- a/tests/alsactl-functions
+++ b/tests/alsactl-functions
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+import gi
+gi.require_version('ALSACtl', '0.0')
+from gi.repository import ALSACtl
+
+from helper import test_functions
+
+entries = {
+    ALSACtl: (
+        'get_card_id_list',
+        'get_card_sysname',
+        'get_control_sysname',
+        'get_control_devnode',
+    ),
+    ALSACtl.CardError: (
+        'quark',
+    ),
+}
+
+for target_type, functions in entries.items():
+    if not test_functions(target_type, functions):
+        exit(ENXIO)

--- a/tests/alsahwdep-device-common
+++ b/tests/alsahwdep-device-common
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_object
+
+import gi
+gi.require_version('ALSAHwdep', '0.0')
+from gi.repository import ALSAHwdep
+
+target_type = ALSAHwdep.DeviceCommon
+props = ()
+methods = (
+    'open',
+    'get_protocol_version',
+    'get_device_info',
+    'create_source',
+)
+vmethods = (
+    'do_open',
+    'do_get_protocol_version',
+    'do_get_device_info',
+    'do_create_source',
+    'do_handle_disconnection',
+)
+signals = (
+    'handle-disconnection',
+)
+
+if not test_object(target_type, props, methods, vmethods, signals):
+    exit(ENXIO)

--- a/tests/alsahwdep-device-info
+++ b/tests/alsahwdep-device-info
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSAHwdep', '0.0')
 from gi.repository import ALSAHwdep
 
-target = ALSAHwdep.DeviceInfo()
+target_type = ALSAHwdep.DeviceInfo
 props = (
     'device-id',
     'card-id',
@@ -20,5 +20,5 @@ props = (
 methods = ()
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsahwdep-device-info
+++ b/tests/alsahwdep-device-info
@@ -18,7 +18,8 @@ props = (
     'iface',
 )
 methods = ()
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsahwdep-device-info
+++ b/tests/alsahwdep-device-info
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSAHwdep', '0.0')
@@ -20,5 +20,5 @@ props = (
 methods = ()
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsahwdep-enums
+++ b/tests/alsahwdep-enums
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 
 from sys import exit
+
 import gi
 gi.require_version('ALSAHwdep', '0.0')
 from gi.repository import ALSAHwdep
+
+from helper import test_enums
 
 iface_types = (
     'OPL2',
@@ -49,8 +52,6 @@ types = {
     ALSAHwdep.DeviceCommonError: device_common_error_types,
 }
 
-for obj, types in types.items():
-    for t in types:
-        if not hasattr(obj, t):
-            print('Enumerator {0} is not produced.'.format(t))
-            exit(1)
+for target_type, enumerations in types.items():
+    if not test_enums(target_type, enumerations):
+        exit(1)

--- a/tests/alsahwdep-functions
+++ b/tests/alsahwdep-functions
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+import gi
+gi.require_version('ALSAHwdep', '0.0')
+from gi.repository import ALSAHwdep
+
+from helper import test_functions
+
+entries = {
+    ALSAHwdep: (
+        'get_device_id_list',
+        'get_hwdep_sysname',
+        'get_hwdep_devnode',
+        'get_device_info',
+    ),
+    ALSAHwdep.DeviceCommonError: (
+        'quark',
+        'to_label',
+    ),
+}
+
+for target_type, functions in entries.items():
+    if not test_functions(target_type, functions):
+        exit(ENXIO)

--- a/tests/alsarawmidi-enums
+++ b/tests/alsarawmidi-enums
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 
 from sys import exit
+
 import gi
 gi.require_version('ALSARawmidi', '0.0')
 from gi.repository import ALSARawmidi
+
+from helper import test_enums
 
 stream_direction_types = (
     'OUTPUT',
@@ -27,8 +30,6 @@ types = {
     ALSARawmidi.StreamPairError:    stream_pair_error_types,
 }
 
-for obj, types in types.items():
-    for t in types:
-        if not hasattr(obj, t):
-            print('Enumerator {0} is not produced.'.format(t))
-            exit(1)
+for target_type, enumerations in types.items():
+    if not test_enums(target_type, enumerations):
+        exit(1)

--- a/tests/alsarawmidi-functions
+++ b/tests/alsarawmidi-functions
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+import gi
+gi.require_version('ALSARawmidi', '0.0')
+from gi.repository import ALSARawmidi
+
+from helper import test_functions
+
+entries = {
+    ALSARawmidi: (
+        'get_device_id_list',
+        'get_rawmidi_sysname',
+        'get_rawmidi_devnode',
+        'get_subdevice_id_list',
+        'get_substream_info',
+    ),
+    ALSARawmidi.StreamPairError: (
+        'quark',
+    ),
+}
+
+for target_type, functions in entries.items():
+    if not test_functions(target_type, functions):
+        exit(ENXIO)

--- a/tests/alsarawmidi-stream-pair
+++ b/tests/alsarawmidi-stream-pair
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSARawmidi', '0.0')
@@ -33,5 +33,5 @@ signals = (
     'handle-disconnection',
 )
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsarawmidi-stream-pair
+++ b/tests/alsarawmidi-stream-pair
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSARawmidi', '0.0')
 from gi.repository import ALSARawmidi
 
-target = ALSARawmidi.StreamPair()
+target_type = ALSARawmidi.StreamPair
 props = (
     'devnode',
 )
@@ -33,5 +33,5 @@ signals = (
     'handle-disconnection',
 )
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsarawmidi-stream-pair
+++ b/tests/alsarawmidi-stream-pair
@@ -25,6 +25,8 @@ methods = (
     'drain_substream',
     'drop_substream',
     'create_source',
+)
+vmethods = (
     'do_handle_messages',
     'do_handle_disconnection',
 )
@@ -33,5 +35,5 @@ signals = (
     'handle-disconnection',
 )
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsarawmidi-substream-info
+++ b/tests/alsarawmidi-substream-info
@@ -23,7 +23,8 @@ props = (
     'subdevices-avail',
 )
 methods = ()
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsarawmidi-substream-info
+++ b/tests/alsarawmidi-substream-info
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSARawmidi', '0.0')
@@ -25,5 +25,5 @@ props = (
 methods = ()
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsarawmidi-substream-info
+++ b/tests/alsarawmidi-substream-info
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSARawmidi', '0.0')
 from gi.repository import ALSARawmidi
 
-target = ALSARawmidi.SubstreamInfo()
+target_type = ALSARawmidi.SubstreamInfo
 props = (
     'device-id',
     'subdevice-id',
@@ -25,5 +25,5 @@ props = (
 methods = ()
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsarawmidi-substream-params
+++ b/tests/alsarawmidi-substream-params
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSARawmidi', '0.0')
@@ -20,5 +20,5 @@ methods = (
 )
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsarawmidi-substream-params
+++ b/tests/alsarawmidi-substream-params
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSARawmidi', '0.0')
 from gi.repository import ALSARawmidi
 
-target = ALSARawmidi.SubstreamParams()
+target_type = ALSARawmidi.SubstreamParams
 props = (
     'buffer-size',
     'avail-min',
@@ -20,5 +20,5 @@ methods = (
 )
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsarawmidi-substream-params
+++ b/tests/alsarawmidi-substream-params
@@ -18,7 +18,8 @@ props = (
 methods = (
     'new',
 )
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsarawmidi-substream-status
+++ b/tests/alsarawmidi-substream-status
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSARawmidi', '0.0')
@@ -19,5 +19,5 @@ methods = (
 )
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsarawmidi-substream-status
+++ b/tests/alsarawmidi-substream-status
@@ -17,7 +17,8 @@ props = (
 methods = (
     'new',
 )
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsarawmidi-substream-status
+++ b/tests/alsarawmidi-substream-status
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSARawmidi', '0.0')
 from gi.repository import ALSARawmidi
 
-target = ALSARawmidi.SubstreamStatus()
+target_type = ALSARawmidi.SubstreamStatus
 props = (
     'avail',
     'xruns',
@@ -19,5 +19,5 @@ methods = (
 )
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-addr
+++ b/tests/alsaseq-addr
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_struct
+
+import gi
+gi.require_version('ALSASeq', '0.0')
+from gi.repository import ALSASeq
+
+target_type = ALSASeq.Addr
+methods = (
+    'new',
+    'get_client_id',
+    'get_port_id',
+    'equal',
+)
+
+if not test_struct(target_type, methods):
+    exit(ENXIO)

--- a/tests/alsaseq-client-info
+++ b/tests/alsaseq-client-info
@@ -26,7 +26,8 @@ methods = (
     'set_event_filter',
     'get_event_filter',
 )
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-client-info
+++ b/tests/alsaseq-client-info
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSASeq', '0.0')
 from gi.repository import ALSASeq
 
-target = ALSASeq.ClientInfo()
+target_type = ALSASeq.ClientInfo
 props = (
     'client-id',
     'type',
@@ -28,5 +28,5 @@ methods = (
 )
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-client-info
+++ b/tests/alsaseq-client-info
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSASeq', '0.0')
@@ -28,5 +28,5 @@ methods = (
 )
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-client-pool
+++ b/tests/alsaseq-client-pool
@@ -19,7 +19,8 @@ props = (
     'input-free',
 )
 methods = ()
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-client-pool
+++ b/tests/alsaseq-client-pool
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSASeq', '0.0')
 from gi.repository import ALSASeq
 
-target = ALSASeq.ClientPool()
+target_type = ALSASeq.ClientPool
 props = (
     'client-id',
     'output-pool',
@@ -21,5 +21,5 @@ props = (
 methods = ()
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-client-pool
+++ b/tests/alsaseq-client-pool
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSASeq', '0.0')
@@ -21,5 +21,5 @@ props = (
 methods = ()
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-enums
+++ b/tests/alsaseq-enums
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 
 from sys import exit
+
 import gi
 gi.require_version('ALSASeq', '0.0')
 from gi.repository import ALSASeq
+
+from helper import test_enums
 
 specific_address_types = (
     'UNKNOWN',
@@ -11,7 +14,7 @@ specific_address_types = (
     'BROADCAST',
 )
 
-specific_client_id_types= (
+specific_client_id_types = (
     'SYSTEM',
     'DUMMY',
     'OSS',
@@ -193,8 +196,6 @@ types = {
     ALSASeq.EventError:         event_error_types,
 }
 
-for obj, types in types.items():
-    for t in types:
-        if not hasattr(obj, t):
-            print('Enumerator {0} is not produced.'.format(t))
-            exit(1)
+for target_type, enumerations in types.items():
+    if not test_enums(target_type, enumerations):
+        exit(1)

--- a/tests/alsaseq-event
+++ b/tests/alsaseq-event
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_struct
+
+import gi
+gi.require_version('ALSASeq', '0.0')
+from gi.repository import ALSASeq
+
+target_type = ALSASeq.Event
+methods = (
+    'new',
+    'get_event_type',
+    'get_length_mode',
+    'get_tstamp_mode',
+    'get_time_mode',
+    'set_time_mode',
+    'get_priority_mode',
+    'set_priority_mode',
+    'get_tag',
+    'set_tag',
+    'get_queue_id',
+    'set_queue_id',
+    'get_source',
+    'set_source',
+    'get_destination',
+    'set_destination',
+    'get_tick_time',
+    'set_tick_time',
+    'get_real_time',
+    'set_real_time',
+    'get_note_data',
+    'set_note_data',
+    'get_ctl_data',
+    'set_ctl_data',
+    'get_byte_data',
+    'set_byte_data',
+    'get_quadlet_data',
+    'set_quadlet_data',
+    'get_blob_data',
+    'set_blob_data',
+    'get_pointer_data',
+    'set_pointer_data',
+    'get_queue_data',
+    'set_queue_data',
+    'get_tick_time_data',
+    'set_tick_time_data',
+    'get_real_time_data',
+    'set_real_time_data',
+    'get_addr_data',
+    'set_addr_data',
+    'get_connect_data',
+    'set_connect_data',
+    'get_result_data',
+    'set_result_data',
+)
+
+if not test_struct(target_type, methods):
+    exit(ENXIO)

--- a/tests/alsaseq-event-cntr
+++ b/tests/alsaseq-event-cntr
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_struct
+
+import gi
+gi.require_version('ALSASeq', '0.0')
+from gi.repository import ALSASeq
+
+target_type = ALSASeq.EventCntr
+methods = (
+    'deserialize',
+)
+
+if not test_struct(target_type, methods):
+    exit(ENXIO)

--- a/tests/alsaseq-event-data-connect
+++ b/tests/alsaseq-event-data-connect
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_struct
+
+import gi
+gi.require_version('ALSASeq', '0.0')
+from gi.repository import ALSASeq
+
+target_type = ALSASeq.EventDataConnect
+methods = (
+    'get_src',
+    'set_src',
+    'get_dst',
+    'set_dst',
+)
+
+if not test_struct(target_type, methods):
+    exit(ENXIO)

--- a/tests/alsaseq-event-data-ctl
+++ b/tests/alsaseq-event-data-ctl
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_struct
+
+import gi
+gi.require_version('ALSASeq', '0.0')
+from gi.repository import ALSASeq
+
+target_type = ALSASeq.EventDataCtl
+methods = (
+    'get_channel',
+    'set_channel',
+    'get_param',
+    'set_param',
+    'get_value',
+    'set_value',
+)
+
+if not test_struct(target_type, methods):
+    exit(ENXIO)

--- a/tests/alsaseq-event-data-note
+++ b/tests/alsaseq-event-data-note
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_struct
+
+import gi
+gi.require_version('ALSASeq', '0.0')
+from gi.repository import ALSASeq
+
+target_type = ALSASeq.EventDataNote
+methods = (
+    'get_channel',
+    'set_channel',
+    'get_note',
+    'set_note',
+    'get_velocity',
+    'set_velocity',
+    'get_off_velocity',
+    'set_off_velocity',
+    'get_duration',
+    'set_duration',
+)
+
+if not test_struct(target_type, methods):
+    exit(ENXIO)

--- a/tests/alsaseq-event-data-queue
+++ b/tests/alsaseq-event-data-queue
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_struct
+
+import gi
+gi.require_version('ALSASeq', '0.0')
+from gi.repository import ALSASeq
+
+target_type = ALSASeq.EventDataQueue
+methods = (
+    'get_queue_id',
+    'set_queue_id',
+    'get_value_param',
+    'set_value_param',
+    'get_tick_time_param',
+    'set_tick_time_param',
+    'get_real_time_param',
+    'set_real_time_param',
+    'get_position_param',
+    'set_position_param',
+    'get_skew_param',
+    'set_skew_param',
+    'get_quadlet_param',
+    'set_quadlet_param',
+    'get_byte_param',
+    'set_byte_param',
+)
+
+if not test_struct(target_type, methods):
+    exit(ENXIO)

--- a/tests/alsaseq-event-data-result
+++ b/tests/alsaseq-event-data-result
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_struct
+
+import gi
+gi.require_version('ALSASeq', '0.0')
+from gi.repository import ALSASeq
+
+target_type = ALSASeq.EventDataResult
+methods = (
+    'get_event',
+    'set_event',
+    'get_result',
+    'set_result',
+)
+
+if not test_struct(target_type, methods):
+    exit(ENXIO)

--- a/tests/alsaseq-functions
+++ b/tests/alsaseq-functions
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+import gi
+gi.require_version('ALSASeq', '0.0')
+from gi.repository import ALSASeq
+
+from helper import test_functions
+
+entries = {
+    ALSASeq: (
+        'get_seq_sysname',
+        'get_seq_devnode',
+        'get_system_info',
+        'get_client_id_list',
+        'get_client_info',
+        'get_port_id_list',
+        'get_port_info',
+        'get_client_pool',
+        'get_subscription_list',
+        'get_queue_id_list',
+        'get_queue_info_by_id',
+        'get_queue_info_by_name',
+        'get_queue_status',
+    ),
+    ALSASeq.UserClientError: (
+        'quark',
+    ),
+}
+
+for target_type, functions in entries.items():
+    if not test_functions(target_type, functions):
+        exit(ENXIO)

--- a/tests/alsaseq-port-info
+++ b/tests/alsaseq-port-info
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSASeq', '0.0')
@@ -28,5 +28,5 @@ methods = (
 )
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-port-info
+++ b/tests/alsaseq-port-info
@@ -26,7 +26,8 @@ props = (
 methods = (
     'new',
 )
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-port-info
+++ b/tests/alsaseq-port-info
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSASeq', '0.0')
 from gi.repository import ALSASeq
 
-target = ALSASeq.PortInfo()
+target_type = ALSASeq.PortInfo
 props = (
     'name',
     'caps',
@@ -28,5 +28,5 @@ methods = (
 )
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-queue-info
+++ b/tests/alsaseq-queue-info
@@ -19,7 +19,8 @@ props = (
 methods = (
     'new',
 )
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-queue-info
+++ b/tests/alsaseq-queue-info
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSASeq', '0.0')
@@ -21,5 +21,5 @@ methods = (
 )
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-queue-info
+++ b/tests/alsaseq-queue-info
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSASeq', '0.0')
 from gi.repository import ALSASeq
 
-target = ALSASeq.QueueInfo()
+target_type = ALSASeq.QueueInfo
 props = (
     'queue-id',
     'client-id',
@@ -21,5 +21,5 @@ methods = (
 )
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-queue-status
+++ b/tests/alsaseq-queue-status
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSASeq', '0.0')
 from gi.repository import ALSASeq
 
-target = ALSASeq.QueueStatus()
+target_type = ALSASeq.QueueStatus
 props = (
     'queue-id',
     'event-count',
@@ -22,5 +22,5 @@ methods = (
 )
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-queue-status
+++ b/tests/alsaseq-queue-status
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSASeq', '0.0')
@@ -22,5 +22,5 @@ methods = (
 )
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-queue-status
+++ b/tests/alsaseq-queue-status
@@ -20,7 +20,8 @@ methods = (
     'get_tick_time',
     'get_real_time',
 )
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-queue-tempo
+++ b/tests/alsaseq-queue-tempo
@@ -20,7 +20,8 @@ methods = (
     'get_skew',
     'set_skew',
 )
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-queue-tempo
+++ b/tests/alsaseq-queue-tempo
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSASeq', '0.0')
 from gi.repository import ALSASeq
 
-target = ALSASeq.QueueTempo()
+target_type = ALSASeq.QueueTempo
 props = (
     'queue-id',
     'tempo',
@@ -22,5 +22,5 @@ methods = (
 )
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-queue-tempo
+++ b/tests/alsaseq-queue-tempo
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSASeq', '0.0')
@@ -22,5 +22,5 @@ methods = (
 )
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-queue-timer-alsa
+++ b/tests/alsaseq-queue-timer-alsa
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSASeq', '0.0')
 from gi.repository import ALSASeq
 
-target = ALSASeq.QueueTimerAlsa()
+target_type = ALSASeq.QueueTimerAlsa
 props = (
     'queue-id',
     'timer-type',
@@ -23,5 +23,5 @@ methods = (
 
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-queue-timer-alsa
+++ b/tests/alsaseq-queue-timer-alsa
@@ -16,12 +16,11 @@ props = (
     'device-id',
     'resolution-ticks',
 )
-
 methods = (
     'new',
 )
-
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-queue-timer-alsa
+++ b/tests/alsaseq-queue-timer-alsa
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSASeq', '0.0')
@@ -23,5 +23,5 @@ methods = (
 
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-queue-timer-common
+++ b/tests/alsaseq-queue-timer-common
@@ -9,17 +9,12 @@ import gi
 gi.require_version('ALSASeq', '0.0')
 from gi.repository import ALSASeq
 
-target_type = ALSASeq.QueueTimerAlsa
+target_type = ALSASeq.QueueTimerCommon
 props = (
-    'device-id',
-    'resolution-ticks',
-    # From interface.
     'queue-id',
     'timer-type',
 )
-methods = (
-    'new',
-)
+methods = ()
 vmethods = ()
 signals = ()
 

--- a/tests/alsaseq-remove-filter
+++ b/tests/alsaseq-remove-filter
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_struct
+
+import gi
+gi.require_version('ALSASeq', '0.0')
+from gi.repository import ALSASeq
+
+target_type = ALSASeq.RemoveFilter
+methods = (
+    'new_with_dest_addr',
+    'new_with_note_channel',
+    'new_with_event_type',
+    'new_with_note',
+    'new_with_tag',
+    'new_with_tick_time',
+    'new_with_real_time',
+)
+
+if not test_struct(target_type, methods):
+    exit(ENXIO)

--- a/tests/alsaseq-subscribe-data
+++ b/tests/alsaseq-subscribe-data
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSASeq', '0.0')
@@ -23,5 +23,5 @@ methods = (
 )
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-subscribe-data
+++ b/tests/alsaseq-subscribe-data
@@ -21,7 +21,8 @@ props = (
 methods = (
     'new',
 )
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-subscribe-data
+++ b/tests/alsaseq-subscribe-data
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSASeq', '0.0')
 from gi.repository import ALSASeq
 
-target = ALSASeq.SubscribeData()
+target_type = ALSASeq.SubscribeData
 props = (
     'sender',
     'dest',
@@ -23,5 +23,5 @@ methods = (
 )
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-system-info
+++ b/tests/alsaseq-system-info
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSASeq', '0.0')
 from gi.repository import ALSASeq
 
-target = ALSASeq.SystemInfo()
+target_type = ALSASeq.SystemInfo
 props = (
     'maximum-queue-count',
     'maximum-client-count',
@@ -21,5 +21,5 @@ props = (
 methods = ()
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-system-info
+++ b/tests/alsaseq-system-info
@@ -19,7 +19,8 @@ props = (
     'current-queue-count',
 )
 methods = ()
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-system-info
+++ b/tests/alsaseq-system-info
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSASeq', '0.0')
@@ -21,5 +21,5 @@ props = (
 methods = ()
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-user-client
+++ b/tests/alsaseq-user-client
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSASeq', '0.0')
@@ -42,5 +42,5 @@ methods = (
 )
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-user-client
+++ b/tests/alsaseq-user-client
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSASeq', '0.0')
 from gi.repository import ALSASeq
 
-target = ALSASeq.UserClient()
+target_type = ALSASeq.UserClient
 props = (
     'client-id',
 )
@@ -42,5 +42,5 @@ methods = (
 )
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsaseq-user-client
+++ b/tests/alsaseq-user-client
@@ -40,7 +40,12 @@ methods = (
     'remove_events',
     'schedule_events',
 )
-signals = ()
+vmethods = (
+    'do_handle_event',
+)
+signals = (
+    'handle-event',
+)
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsatimer-device-id
+++ b/tests/alsatimer-device-id
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSATimer', '0.0')
@@ -22,5 +22,5 @@ methods = (
 )
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsatimer-device-id
+++ b/tests/alsatimer-device-id
@@ -3,24 +3,20 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test_object
+from helper import test_struct
 
 import gi
 gi.require_version('ALSATimer', '0.0')
 from gi.repository import ALSATimer
 
-target = ALSATimer.DeviceId()
-props = (
-    'class',
-    'slave-class',
-    'card-id',
-    'device-id',
-    'subdevice-id',
-)
+target_type = ALSATimer.DeviceId
 methods = (
     'new',
+    'get_class',
+    'get_card_id',
+    'get_device_id',
+    'get_subdevice_id',
 )
-signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_struct(target_type, methods):
     exit(ENXIO)

--- a/tests/alsatimer-device-info
+++ b/tests/alsatimer-device-info
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSATimer', '0.0')
@@ -23,5 +23,5 @@ props = (
 methods = ()
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsatimer-device-info
+++ b/tests/alsatimer-device-info
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSATimer', '0.0')
 from gi.repository import ALSATimer
 
-target = ALSATimer.DeviceInfo()
+target_type = ALSATimer.DeviceInfo
 props = (
     'flags',
     'card-id',
@@ -23,5 +23,5 @@ props = (
 methods = ()
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsatimer-device-info
+++ b/tests/alsatimer-device-info
@@ -21,7 +21,8 @@ props = (
     'instance-count',
 )
 methods = ()
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsatimer-device-params
+++ b/tests/alsatimer-device-params
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSATimer', '0.0')
@@ -19,5 +19,5 @@ methods = (
 )
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsatimer-device-params
+++ b/tests/alsatimer-device-params
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSATimer', '0.0')
 from gi.repository import ALSATimer
 
-target = ALSATimer.DeviceParams()
+target_type = ALSATimer.DeviceParams
 props = (
     'period-numerator',
     'period-denominator',
@@ -19,5 +19,5 @@ methods = (
 )
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsatimer-device-params
+++ b/tests/alsatimer-device-params
@@ -17,7 +17,8 @@ props = (
 methods = (
     'new',
 )
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsatimer-device-status
+++ b/tests/alsatimer-device-status
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSATimer', '0.0')
 from gi.repository import ALSATimer
 
-target = ALSATimer.DeviceStatus()
+target_type = ALSATimer.DeviceStatus
 props = (
     'resolution',
     'resolution-numerator',
@@ -20,5 +20,5 @@ methods = (
 )
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsatimer-device-status
+++ b/tests/alsatimer-device-status
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSATimer', '0.0')
@@ -20,5 +20,5 @@ methods = (
 )
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsatimer-device-status
+++ b/tests/alsatimer-device-status
@@ -18,7 +18,8 @@ props = (
 methods = (
     'new',
 )
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsatimer-enums
+++ b/tests/alsatimer-enums
@@ -5,6 +5,8 @@ import gi
 gi.require_version('ALSATimer', '0.0')
 from gi.repository import ALSATimer
 
+from helper import test_enums
+
 class_types = (
     'NONE',
     'GLOBAL',
@@ -74,8 +76,6 @@ types = {
     ALSATimer.UserInstanceError:    user_instance_error_types,
 }
 
-for obj, types in types.items():
-    for t in types:
-        if not hasattr(obj, t):
-            print('Enumerator {0} is not produced.'.format(t))
-            exit(1)
+for target_type, enumerations in types.items():
+    if not test_enums(target_type, enumerations):
+        exit(1)

--- a/tests/alsatimer-functions
+++ b/tests/alsatimer-functions
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+import gi
+gi.require_version('ALSATimer', '0.0')
+from gi.repository import ALSATimer
+
+from helper import test_functions
+
+entries = {
+    ALSATimer: (
+        'get_sysname',
+        'get_devnode',
+        'get_device_id_list',
+        'get_device_info',
+        'get_device_status',
+        'set_device_params',
+        'get_tstamp_source',
+    ),
+    ALSATimer.UserInstanceError: (
+        'quark',
+    ),
+}
+
+for target_type, functions in entries.items():
+    if not test_functions(target_type, functions):
+        exit(ENXIO)

--- a/tests/alsatimer-instance-info
+++ b/tests/alsatimer-instance-info
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSATimer', '0.0')
@@ -20,5 +20,5 @@ props = (
 methods = ()
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsatimer-instance-info
+++ b/tests/alsatimer-instance-info
@@ -18,7 +18,8 @@ props = (
     'resolution',
 )
 methods = ()
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsatimer-instance-info
+++ b/tests/alsatimer-instance-info
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSATimer', '0.0')
 from gi.repository import ALSATimer
 
-target = ALSATimer.InstanceInfo()
+target_type = ALSATimer.InstanceInfo
 props = (
     'flags',
     'card-id',
@@ -20,5 +20,5 @@ props = (
 methods = ()
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsatimer-instance-params
+++ b/tests/alsatimer-instance-params
@@ -20,7 +20,8 @@ methods = (
     'set_event_filter',
     'get_event_filter',
 )
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsatimer-instance-params
+++ b/tests/alsatimer-instance-params
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSATimer', '0.0')
@@ -22,5 +22,5 @@ methods = (
 )
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsatimer-instance-params
+++ b/tests/alsatimer-instance-params
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSATimer', '0.0')
 from gi.repository import ALSATimer
 
-target = ALSATimer.InstanceParams()
+target_type = ALSATimer.InstanceParams
 props = (
     'flags',
     'interval',
@@ -22,5 +22,5 @@ methods = (
 )
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsatimer-instance-status
+++ b/tests/alsatimer-instance-status
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSATimer', '0.0')
 from gi.repository import ALSATimer
 
-target = ALSATimer.InstanceStatus()
+target_type = ALSATimer.InstanceStatus
 props = (
     'interval',
     'lost',
@@ -22,5 +22,5 @@ methods = (
 )
 signals = ()
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsatimer-instance-status
+++ b/tests/alsatimer-instance-status
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSATimer', '0.0')
@@ -22,5 +22,5 @@ methods = (
 )
 signals = ()
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsatimer-instance-status
+++ b/tests/alsatimer-instance-status
@@ -20,7 +20,8 @@ methods = (
     'new',
     'get_tstamp',
 )
+vmethods = ()
 signals = ()
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/alsatimer-tick-event
+++ b/tests/alsatimer-tick-event
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_struct
+
+import gi
+gi.require_version('ALSATimer', '0.0')
+from gi.repository import ALSATimer
+
+target_type = ALSATimer.TickEvent
+methods = (
+    'get_resolution',
+    'get_ticks',
+)
+
+if not test_struct(target_type, methods):
+    exit(ENXIO)

--- a/tests/alsatimer-tstamp-event
+++ b/tests/alsatimer-tstamp-event
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_struct
+
+import gi
+gi.require_version('ALSATimer', '0.0')
+from gi.repository import ALSATimer
+
+target_type = ALSATimer.TstampEvent
+methods = (
+    'get_event',
+    'get_tstamp',
+    'get_val',
+)
+
+if not test_struct(target_type, methods):
+    exit(ENXIO)

--- a/tests/alsatimer-user-instance
+++ b/tests/alsatimer-user-instance
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('ALSATimer', '0.0')
@@ -36,5 +36,5 @@ signals = (
     'handle-disconnection',
 )
 
-if not test(target, props, methods, signals):
+if not test_object(target, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsatimer-user-instance
+++ b/tests/alsatimer-user-instance
@@ -9,7 +9,7 @@ import gi
 gi.require_version('ALSATimer', '0.0')
 from gi.repository import ALSATimer
 
-target = ALSATimer.UserInstance()
+target_type = ALSATimer.UserInstance
 props = ()
 methods = (
     'new',
@@ -36,5 +36,5 @@ signals = (
     'handle-disconnection',
 )
 
-if not test_object(target, props, methods, signals):
+if not test_object(target_type, props, methods, signals):
     exit(ENXIO)

--- a/tests/alsatimer-user-instance
+++ b/tests/alsatimer-user-instance
@@ -22,13 +22,15 @@ methods = (
     'set_params',
     'get_status',
     'create_source',
-    'do_handle_tick_event',
-    'do_handle_tstamp_event',
-    'do_handle_disconnection',
     'start',
     'stop',
     'pause',
     'continue_',
+)
+vmethods = (
+    'do_handle_tick_event',
+    'do_handle_tstamp_event',
+    'do_handle_disconnection',
 )
 signals = (
     'handle-tick-event',
@@ -36,5 +38,5 @@ signals = (
     'handle-disconnection',
 )
 
-if not test_object(target_type, props, methods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -52,3 +52,11 @@ def test_struct(target_type: object, methods: tuple[str]) -> bool:
             print('Method {0} is not produced.'.format(method))
             return False
     return True
+
+
+def test_functions(target_type: object, functions: tuple[str]) -> bool:
+    for function in functions:
+        if not hasattr(target_type, function):
+            print('Function {0} is not produced.'.format(function))
+            return False
+    return True

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,5 +1,5 @@
 def test_object(target_type: object, props: tuple[str], methods: tuple[str],
-                signals: tuple[str]) -> bool:
+                vmethods: tuple[str], signals: tuple[str]) -> bool:
     # All of available methods are put into the list of attribute.
     for method in methods:
         if not hasattr(target_type, method):
@@ -9,6 +9,7 @@ def test_object(target_type: object, props: tuple[str], methods: tuple[str],
     # The properties, virtual methods, and signals in interface are not put
     # into the list of attribute in object implementing the interface.
     prop_labels = []
+    vmethod_labels = []
     signal_labels = []
 
     # The  gi.ObjectInfo and gi.InterfaceInfo keeps them. Let's traverse them.
@@ -16,12 +17,18 @@ def test_object(target_type: object, props: tuple[str], methods: tuple[str],
         if hasattr(info, '__info__'):
             for prop in info.__info__.get_properties():
                 prop_labels.append(prop.get_name())
+            for vfunc in info.__info__.get_vfuncs():
+                vmethod_labels.append('do_' + vfunc.get_name())
             for signal in info.__info__.get_signals():
                 signal_labels.append(signal.get_name())
 
     for prop in props:
         if prop not in prop_labels:
             print('Property {0} is not produced.'.format(prop))
+            return False
+    for vmethod in vmethods:
+        if vmethod not in vmethod_labels:
+            print('Vmethod {0} is not produced.'.format(vmethod))
             return False
     for signal in signals:
         if signal not in signal_labels:

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -27,3 +27,11 @@ def test_enums(target_type: object, enumerations: tuple[str]) -> bool:
                 enumeration, target_type))
             return False
     return True
+
+
+def test_struct(target_type: object, methods: tuple[str]) -> bool:
+    for method in methods:
+        if not hasattr(target_type, method):
+            print('Method {0} is not produced.'.format(method))
+            return False
+    return True

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,20 +1,30 @@
-import gi
-gi.require_version('GObject', '2.0')
-from gi.repository import GObject
-
-def test_object(target, props, methods, signals) ->bool:
-    labels = [prop.name for prop in target.props]
-    for prop in props:
-        if prop not in labels:
-            print('Property {0} is not produced.'.format(prop))
-            return False
+def test_object(target_type: object, props: tuple[str], methods: tuple[str],
+                signals: tuple[str]) -> bool:
+    # All of available methods are put into the list of attribute.
     for method in methods:
-        if not hasattr(target, method):
+        if not hasattr(target_type, method):
             print('Method {0} is not produced.'.format(method))
             return False
-    labels = GObject.signal_list_names(target)
+
+    # The properties, virtual methods, and signals in interface are not put
+    # into the list of attribute in object implementing the interface.
+    prop_labels = []
+    signal_labels = []
+
+    # The  gi.ObjectInfo and gi.InterfaceInfo keeps them. Let's traverse them.
+    for info in target_type.__mro__:
+        if hasattr(info, '__info__'):
+            for prop in info.__info__.get_properties():
+                prop_labels.append(prop.get_name())
+            for signal in info.__info__.get_signals():
+                signal_labels.append(signal.get_name())
+
+    for prop in props:
+        if prop not in prop_labels:
+            print('Property {0} is not produced.'.format(prop))
+            return False
     for signal in signals:
-        if signal not in labels:
+        if signal not in signal_labels:
             print('Signal {0} is not produced.'.format(signal))
             return False
     return True

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -2,7 +2,7 @@ import gi
 gi.require_version('GObject', '2.0')
 from gi.repository import GObject
 
-def test(target, props, methods, signals) ->bool:
+def test_object(target, props, methods, signals) ->bool:
     labels = [prop.name for prop in target.props]
     for prop in props:
         if prop not in labels:

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -18,3 +18,12 @@ def test_object(target, props, methods, signals) ->bool:
             print('Signal {0} is not produced.'.format(signal))
             return False
     return True
+
+
+def test_enums(target_type: object, enumerations: tuple[str]) -> bool:
+    for enumeration in enumerations:
+        if not hasattr(target_type, enumeration):
+            print('Enumeration {0} is not produced for {1}.'.format(
+                enumeration, target_type))
+            return False
+    return True

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -43,6 +43,7 @@ tests = {
     'alsaseq-addr',
     'alsaseq-event-cntr',
     'alsaseq-event',
+    'alsaseq-event-data-connect',
   ],
   'hwdep': [
     'alsahwdep-enums',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -42,6 +42,7 @@ tests = {
     'alsaseq-queue-timer-alsa',
     'alsaseq-addr',
     'alsaseq-event-cntr',
+    'alsaseq-event',
   ],
   'hwdep': [
     'alsahwdep-enums',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -46,6 +46,7 @@ tests = {
     'alsaseq-event-data-connect',
     'alsaseq-event-data-ctl',
     'alsaseq-event-data-note',
+    'alsaseq-event-data-queue',
   ],
   'hwdep': [
     'alsahwdep-enums',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -47,6 +47,7 @@ tests = {
     'alsaseq-event-data-ctl',
     'alsaseq-event-data-note',
     'alsaseq-event-data-queue',
+    'alsaseq-event-data-result',
   ],
   'hwdep': [
     'alsahwdep-enums',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -44,6 +44,7 @@ tests = {
     'alsaseq-event-cntr',
     'alsaseq-event',
     'alsaseq-event-data-connect',
+    'alsaseq-event-data-ctl',
   ],
   'hwdep': [
     'alsahwdep-enums',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -45,6 +45,7 @@ tests = {
     'alsaseq-event',
     'alsaseq-event-data-connect',
     'alsaseq-event-data-ctl',
+    'alsaseq-event-data-note',
   ],
   'hwdep': [
     'alsahwdep-enums',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -16,6 +16,7 @@ tests = {
     'alsactl-elem-id',
     'alsactl-elem-info-common',
     'alsactl-elem-info-single-array',
+    'alsactl-functions',
   ],
   'timer': [
     'alsatimer-enums',
@@ -29,6 +30,7 @@ tests = {
     'alsatimer-device-id',
     'alsatimer-tick-event',
     'alsatimer-tstamp-event',
+    'alsatimer-functions',
   ],
   'seq': [
     'alsaseq-enums',
@@ -52,11 +54,13 @@ tests = {
     'alsaseq-event-data-result',
     'alsaseq-remove-filter',
     'alsaseq-queue-timer-common',
+    'alsaseq-functions',
   ],
   'hwdep': [
     'alsahwdep-enums',
     'alsahwdep-device-info',
     'alsahwdep-device-common',
+    'alsahwdep-functions',
   ],
   'rawmidi': [
     'alsarawmidi-enums',
@@ -64,6 +68,7 @@ tests = {
     'alsarawmidi-stream-pair',
     'alsarawmidi-substream-params',
     'alsarawmidi-substream-status',
+    'alsarawmidi-functions',
   ],
 }
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -40,6 +40,7 @@ tests = {
     'alsaseq-queue-status',
     'alsaseq-queue-tempo',
     'alsaseq-queue-timer-alsa',
+    'alsaseq-addr',
   ],
   'hwdep': [
     'alsahwdep-enums',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -48,6 +48,7 @@ tests = {
     'alsaseq-event-data-note',
     'alsaseq-event-data-queue',
     'alsaseq-event-data-result',
+    'alsaseq-remove-filter',
   ],
   'hwdep': [
     'alsahwdep-enums',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -14,6 +14,7 @@ tests = {
     'alsactl-elem-info-enumerated',
     'alsactl-elem-value',
     'alsactl-elem-id',
+    'alsactl-elem-info-common',
   ],
   'timer': [
     'alsatimer-enums',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -41,6 +41,7 @@ tests = {
     'alsaseq-queue-tempo',
     'alsaseq-queue-timer-alsa',
     'alsaseq-addr',
+    'alsaseq-event-cntr',
   ],
   'hwdep': [
     'alsahwdep-enums',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -55,6 +55,7 @@ tests = {
   'hwdep': [
     'alsahwdep-enums',
     'alsahwdep-device-info',
+    'alsahwdep-device-common',
   ],
   'rawmidi': [
     'alsarawmidi-enums',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -26,6 +26,7 @@ tests = {
     'alsatimer-instance-status',
     'alsatimer-device-id',
     'alsatimer-tick-event',
+    'alsatimer-tstamp-event',
   ],
   'seq': [
     'alsaseq-enums',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -15,6 +15,7 @@ tests = {
     'alsactl-elem-value',
     'alsactl-elem-id',
     'alsactl-elem-info-common',
+    'alsactl-elem-info-single-array',
   ],
   'timer': [
     'alsatimer-enums',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -13,6 +13,7 @@ tests = {
     'alsactl-elem-info-integer64',
     'alsactl-elem-info-enumerated',
     'alsactl-elem-value',
+    'alsactl-elem-id',
   ],
   'timer': [
     'alsatimer-enums',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -25,6 +25,7 @@ tests = {
     'alsatimer-instance-params',
     'alsatimer-instance-status',
     'alsatimer-device-id',
+    'alsatimer-tick-event',
   ],
   'seq': [
     'alsaseq-enums',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -24,6 +24,7 @@ tests = {
     'alsatimer-instance-info',
     'alsatimer-instance-params',
     'alsatimer-instance-status',
+    'alsatimer-device-id',
   ],
   'seq': [
     'alsaseq-enums',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -51,6 +51,7 @@ tests = {
     'alsaseq-event-data-queue',
     'alsaseq-event-data-result',
     'alsaseq-remove-filter',
+    'alsaseq-queue-timer-common',
   ],
   'hwdep': [
     'alsahwdep-enums',


### PR DESCRIPTION
Current implementation of test just supports GObject-derived object,
enumerations, and flags. It's not possible to test the other types of
glib/gobject elements such as boxed structure.

This patchset refines test implementation. Some helper functions for
boxed structure and namespace/object functions are added. The existent
helper function is renamed as 'test_object' and rewritten to walk through
Python MRO hierarchy to check properties, virtual methods, and signals,
defined by both GObject-derived objects and interfaces.

I note that the tests are not done to execute actual symbols. They are just
to check they are available or not via interface described in metadata of
GObject Introspection.

```
Takashi Sakamoto (23):
  tests: rename helper function to test object interface
  tests: add helper function to test enumerations and flags
  tests: add test script for ALSACtl.ElemId boxed structure
  tests: add test script for ALSATimer.DeviceId boxed structure
  tests: add test script for ALSATimer.TickEvent boxed structure
  tests: add test script for ALSATimer.TstampEvent boxed structure
  tests: add test script for ALSASeq.Addr boxed structure
  tests: add test script for ALSASeq.EventCntr boxed structure
  tests: add test script for ALSASeq.Event boxed structure
  tests: add test script for ALSASeq.EventDataConnect boxed object
  tests: add test script for ALSASeq.EventDataCtl boxed structure
  tests: add test script for ALSASeq.EventDataNote boxed structure
  tests: add test script for ALSASeq.EventDataQueue boxed structure
  tests: add test script for ALSASeq.EventDataResult boxed structure
  tests: add test script for ALSASeq.RemoveFilter boxed structure
  tests: test object type instead of its instance
  tests: refine helper function to test object
  tests: test virtual functions in object
  tests: add test script for ALSACtl.ElemInfoCommon interface
  tests: add test script for ALSACtl.ElemInfoSingleArray interface
  tests: add test script for ALSAHwdep.DeviceCommon interface
  tests: add test script for ALSASeq.QueueTimerCommon interface
  tests: add test scripts for namespace functions

 tests/alsactl-card                   |  8 ++--
 tests/alsactl-card-info              |  7 +--
 tests/alsactl-elem-id                | 14 +++---
 tests/alsactl-elem-info-boolean      |  8 ++--
 tests/alsactl-elem-info-bytes        |  8 ++--
 tests/alsactl-elem-info-common       | 24 +++++++++++
 tests/alsactl-elem-info-enumerated   | 10 +++--
 tests/alsactl-elem-info-iec60958     |  8 ++--
 tests/alsactl-elem-info-integer      | 14 +++---
 tests/alsactl-elem-info-integer64    | 14 +++---
 tests/alsactl-elem-info-single-array | 21 +++++++++
 tests/alsactl-elem-value             |  7 +--
 tests/alsactl-enums                  | 11 ++---
 tests/alsactl-functions              | 26 +++++++++++
 tests/alsahwdep-device-common        | 32 ++++++++++++++
 tests/alsahwdep-device-info          |  7 +--
 tests/alsahwdep-enums                | 11 ++---
 tests/alsahwdep-functions            | 27 ++++++++++++
 tests/alsarawmidi-enums              | 11 ++---
 tests/alsarawmidi-functions          | 27 ++++++++++++
 tests/alsarawmidi-stream-pair        |  8 ++--
 tests/alsarawmidi-substream-info     |  7 +--
 tests/alsarawmidi-substream-params   |  7 +--
 tests/alsarawmidi-substream-status   |  7 +--
 tests/alsaseq-addr                   | 21 +++++++++
 tests/alsaseq-client-info            |  7 +--
 tests/alsaseq-client-pool            |  7 +--
 tests/alsaseq-enums                  | 13 +++---
 tests/alsaseq-event                  | 61 ++++++++++++++++++++++++++
 tests/alsaseq-event-cntr             | 18 ++++++++
 tests/alsaseq-event-data-connect     | 21 +++++++++
 tests/alsaseq-event-data-ctl         | 23 ++++++++++
 tests/alsaseq-event-data-note        | 27 ++++++++++++
 tests/alsaseq-event-data-queue       | 33 ++++++++++++++
 tests/alsaseq-event-data-result      | 24 +++++++++++
 tests/alsaseq-functions              | 35 +++++++++++++++
 tests/alsaseq-port-info              |  7 +--
 tests/alsaseq-queue-info             |  7 +--
 tests/alsaseq-queue-status           |  7 +--
 tests/alsaseq-queue-tempo            |  7 +--
 tests/alsaseq-queue-timer-alsa       | 14 +++---
 tests/alsaseq-queue-timer-common     | 22 ++++++++++
 tests/alsaseq-remove-filter          | 21 +++++++++
 tests/alsaseq-subscribe-data         |  7 +--
 tests/alsaseq-system-info            |  7 +--
 tests/alsaseq-user-client            | 13 ++++--
 tests/alsatimer-device-id            | 18 +++-----
 tests/alsatimer-device-info          |  7 +--
 tests/alsatimer-device-params        |  7 +--
 tests/alsatimer-device-status        |  7 +--
 tests/alsatimer-enums                | 10 ++---
 tests/alsatimer-functions            | 29 +++++++++++++
 tests/alsatimer-instance-info        |  7 +--
 tests/alsatimer-instance-params      |  7 +--
 tests/alsatimer-instance-status      |  7 +--
 tests/alsatimer-tick-event           | 19 +++++++++
 tests/alsatimer-tstamp-event         | 20 +++++++++
 tests/alsatimer-user-instance        | 14 +++---
 tests/helper.py                      | 64 +++++++++++++++++++++++-----
 tests/meson.build                    | 22 ++++++++++
 60 files changed, 800 insertions(+), 164 deletions(-)
 create mode 100644 tests/alsactl-elem-info-common
 create mode 100644 tests/alsactl-elem-info-single-array
 create mode 100644 tests/alsactl-functions
 create mode 100644 tests/alsahwdep-device-common
 create mode 100644 tests/alsahwdep-functions
 create mode 100644 tests/alsarawmidi-functions
 create mode 100644 tests/alsaseq-addr
 create mode 100644 tests/alsaseq-event
 create mode 100644 tests/alsaseq-event-cntr
 create mode 100644 tests/alsaseq-event-data-connect
 create mode 100644 tests/alsaseq-event-data-ctl
 create mode 100644 tests/alsaseq-event-data-note
 create mode 100644 tests/alsaseq-event-data-queue
 create mode 100644 tests/alsaseq-event-data-result
 create mode 100644 tests/alsaseq-functions
 create mode 100644 tests/alsaseq-queue-timer-common
 create mode 100644 tests/alsaseq-remove-filter
 create mode 100644 tests/alsatimer-functions
 create mode 100644 tests/alsatimer-tick-event
 create mode 100644 tests/alsatimer-tstamp-event
```