### PR TITLE
Fix 'errno undeclared' compile error with older gcc versions

### DIFF
--- a/src/seq/query.c
+++ b/src/seq/query.c
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
+#include <errno.h>
 
 /**
  * alsaseq_get_seq_sysname:

--- a/src/timer/query.c
+++ b/src/timer/query.c
@@ -10,6 +10,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <stdbool.h>
+#include <errno.h>
 
 #include <time.h>
 


### PR DESCRIPTION
It looks like errno.h has to be included explicitly when compiling with older
gcc versions. This issue was encountered on the following system:
- Ubuntu 20.04 LTS
- Linux 5.4.0-156
- gcc 10.5.0
- Meson 0.53.2