### PR TITLE
ctl/hwdep/seq: optimize to gi-docgen 2023.3 or later

### DIFF
--- a/src/ctl/elem-info-common.c
+++ b/src/ctl/elem-info-common.c
@@ -7,7 +7,7 @@
  *
  * A [iface@ElemInfoCommon] should be implemented by any type of element information.
  *
- * Since: 0.3.
+ * Since: 0.3
  */
 
 static void alsactl_elem_info_common_default_init(ALSACtlElemInfoCommonInterface *iface);
@@ -21,7 +21,7 @@ static void alsactl_elem_info_common_default_init(ALSACtlElemInfoCommonInterface
      *
      * The identifier of element.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     g_object_interface_install_property(iface,
         g_param_spec_boxed(ELEM_ID_PROP_NAME, ELEM_ID_PROP_NAME,
@@ -34,7 +34,7 @@ static void alsactl_elem_info_common_default_init(ALSACtlElemInfoCommonInterface
      *
      * The type of element, one of [enum@ElemType].
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     g_object_interface_install_property(iface,
         g_param_spec_enum(ELEM_TYPE_PROP_NAME, ELEM_TYPE_PROP_NAME,
@@ -48,7 +48,7 @@ static void alsactl_elem_info_common_default_init(ALSACtlElemInfoCommonInterface
      *
      * The access permission for the element with [flags@ElemAccessFlag].
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     g_object_interface_install_property(iface,
         g_param_spec_flags(ACCESS_PROP_NAME, ACCESS_PROP_NAME,
@@ -62,7 +62,7 @@ static void alsactl_elem_info_common_default_init(ALSACtlElemInfoCommonInterface
      *
      * The value of PID for process to own the element.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     g_object_interface_install_property(iface,
         g_param_spec_int(OWNER_PROP_NAME, OWNER_PROP_NAME,

--- a/src/ctl/elem-info-enumerated.c
+++ b/src/ctl/elem-info-enumerated.c
@@ -91,7 +91,7 @@ static void alsactl_elem_info_enumerated_class_init(ALSACtlElemInfoEnumeratedCla
      *  - The length of label including terminator should be within 64 bytes.
      *  - The total length of labels including terminators should be within (64 * 1024) bytes.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     g_object_class_install_property(gobject_class, ELEM_INFO_ENUMERATED_PROP_LABELS,
         g_param_spec_boxed("labels", "labels",

--- a/src/ctl/elem-info-integer.c
+++ b/src/ctl/elem-info-integer.c
@@ -90,7 +90,7 @@ static void alsactl_elem_info_integer_class_init(ALSACtlElemInfoIntegerClass *kl
      *
      * The minimum value of element in value array for the element.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     g_object_class_install_property(gobject_class, ELEM_INFO_INTEGER_PROP_MIN,
         g_param_spec_int("value-min", "value-min",
@@ -103,7 +103,7 @@ static void alsactl_elem_info_integer_class_init(ALSACtlElemInfoIntegerClass *kl
      *
      * The maximum value of element in value array for the element.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     g_object_class_install_property(gobject_class, ELEM_INFO_INTEGER_PROP_MAX,
         g_param_spec_int("value-max", "value-max",
@@ -116,7 +116,7 @@ static void alsactl_elem_info_integer_class_init(ALSACtlElemInfoIntegerClass *kl
      *
      * The step value of element in value array for the element.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     g_object_class_install_property(gobject_class, ELEM_INFO_INTEGER_PROP_STEP,
         g_param_spec_int("value-step", "value-step",

--- a/src/ctl/elem-info-integer64.c
+++ b/src/ctl/elem-info-integer64.c
@@ -90,7 +90,7 @@ static void alsactl_elem_info_integer64_class_init(ALSACtlElemInfoInteger64Class
      *
      * The minimum value of element in value array for the element.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     g_object_class_install_property(gobject_class, ELEM_INFO_INTEGER64_PROP_MIN,
         g_param_spec_int64("value-min", "value-min",
@@ -103,7 +103,7 @@ static void alsactl_elem_info_integer64_class_init(ALSACtlElemInfoInteger64Class
      *
      * The maximum value of element in value array for the element.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     g_object_class_install_property(gobject_class, ELEM_INFO_INTEGER64_PROP_MAX,
         g_param_spec_int64("value-max", "value-max",
@@ -116,7 +116,7 @@ static void alsactl_elem_info_integer64_class_init(ALSACtlElemInfoInteger64Class
      *
      * The step value of element in value array for the element.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     g_object_class_install_property(gobject_class, ELEM_INFO_INTEGER64_PROP_STEP,
         g_param_spec_int64("value-step", "value-step",

--- a/src/ctl/elem-info-single-array.c
+++ b/src/ctl/elem-info-single-array.c
@@ -8,7 +8,7 @@
  * A [iface@ElemInfoSingleArray] should be implemented by the type of information for element
  * whieh has single value array.
  *
- * Since: 0.3.
+ * Since: 0.3
  */
 
 static void alsactl_elem_info_single_array_default_init(ALSACtlElemInfoSingleArrayInterface *iface);
@@ -23,7 +23,7 @@ static void alsactl_elem_info_single_array_default_init(ALSACtlElemInfoSingleArr
      *
      * The count of elements in value array of the element.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     g_object_interface_install_property(iface,
         g_param_spec_uint(VALUE_COUNT_PROP_NAME, VALUE_COUNT_PROP_NAME,

--- a/src/hwdep/device-common.c
+++ b/src/hwdep/device-common.c
@@ -7,7 +7,7 @@
  *
  * A [iface@DeviceCommon] should be implemented by any type of ALSA HwDep device.
  *
- * Since: 0.3.
+ * Since: 0.3
  */
 
 static void alsahwdep_device_common_default_init(ALSAHwdepDeviceCommonInterface *iface);

--- a/src/seq/port-info.c
+++ b/src/seq/port-info.c
@@ -156,7 +156,7 @@ static void alsaseq_port_info_class_init(ALSASeqPortInfoClass *klass)
      *
      * The address of port.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_port_info_props[SEQ_PORT_INFO_PROP_ADDR] =
         g_param_spec_boxed("addr", "addr",
@@ -169,7 +169,7 @@ static void alsaseq_port_info_class_init(ALSASeqPortInfoClass *klass)
      *
      * The name of port.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_port_info_props[SEQ_PORT_INFO_PROP_NAME] =
         g_param_spec_string("name", "name",
@@ -182,7 +182,7 @@ static void alsaseq_port_info_class_init(ALSASeqPortInfoClass *klass)
      *
      * The capabilities of port, a set of [flags@PortCapFlag].
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_port_info_props[SEQ_PORT_INFO_PROP_CAPS] =
         g_param_spec_flags("caps", "caps",
@@ -196,7 +196,7 @@ static void alsaseq_port_info_class_init(ALSASeqPortInfoClass *klass)
      *
      * The attributes of port, a set of [flags@PortAttrFlag].
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_port_info_props[SEQ_PORT_INFO_PROP_ATTRS] =
         g_param_spec_flags("attrs", "attrs",
@@ -210,7 +210,7 @@ static void alsaseq_port_info_class_init(ALSASeqPortInfoClass *klass)
      *
      * The number of channels per MIDI port.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_port_info_props[SEQ_PORT_INFO_PROP_MIDI_CHANNELS] =
         g_param_spec_int("midi-channels", "midi-channels",
@@ -224,7 +224,7 @@ static void alsaseq_port_info_class_init(ALSASeqPortInfoClass *klass)
      *
      * The number of voices per MIDI port.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_port_info_props[SEQ_PORT_INFO_PROP_MIDI_VOICES] =
         g_param_spec_int("midi-voices", "midi-voices",
@@ -238,7 +238,7 @@ static void alsaseq_port_info_class_init(ALSASeqPortInfoClass *klass)
      *
      * The number of voices per synth port.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_port_info_props[SEQ_PORT_INFO_PROP_SYNTH_VOICES] =
         g_param_spec_int("synth-voices", "synth-voices",
@@ -252,7 +252,7 @@ static void alsaseq_port_info_class_init(ALSASeqPortInfoClass *klass)
      *
      * The current number of subscribers to read.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_port_info_props[SEQ_PORT_INFO_PROP_READ_USERS] =
         g_param_spec_int("read-users", "read-users",
@@ -266,7 +266,7 @@ static void alsaseq_port_info_class_init(ALSASeqPortInfoClass *klass)
      *
      * The current number of subscribers to write.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_port_info_props[SEQ_PORT_INFO_PROP_WRITE_USERS] =
         g_param_spec_int("write-users", "write-users",
@@ -280,7 +280,7 @@ static void alsaseq_port_info_class_init(ALSASeqPortInfoClass *klass)
      *
      * The mode whether to overwrite time stamp for event when the event is delivered from the port.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_port_info_props[SEQ_PORT_INFO_PROP_TSTAMP_OVERWRITE] =
         g_param_spec_boolean("tstamp-overwrite", "tstamp-overwrite",
@@ -295,7 +295,7 @@ static void alsaseq_port_info_class_init(ALSASeqPortInfoClass *klass)
      * The mode of time stamp. This is effective when the [property@PortInfo:tstamp-overwrite] is
      * enabled.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_port_info_props[SEQ_PORT_INFO_PROP_TSTAMP_MODE] =
         g_param_spec_enum("tstamp-mode", "tstamp-mode",
@@ -311,7 +311,7 @@ static void alsaseq_port_info_class_init(ALSASeqPortInfoClass *klass)
      * The numeric ID of queue to update time stamp when [property@PortInfo:tstamp-overwrite] is
      * set to True. One of [enum@SpecificQueueId] is available as well.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_port_info_props[SEQ_PORT_INFO_PROP_TIME_QUEUE] =
         g_param_spec_uchar("queue-id", "queue-id",

--- a/src/seq/queue-timer-alsa.c
+++ b/src/seq/queue-timer-alsa.c
@@ -82,7 +82,7 @@ static void alsaseq_queue_timer_alsa_class_init(ALSASeqQueueTimerAlsaClass *klas
      *
      * The identifier of associated timer instance in ALSA Timer.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     g_object_class_install_property(gobject_class, QUEUE_TIMER_ALSA_PROP_DEVICE_ID,
         g_param_spec_boxed("device-id", "device-id",
@@ -95,7 +95,7 @@ static void alsaseq_queue_timer_alsa_class_init(ALSASeqQueueTimerAlsaClass *klas
      *
      * The number of ticks as resolution of timer.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     g_object_class_install_property(gobject_class, QUEUE_TIMER_ALSA_PROP_RESOLUTION_TICKS,
         g_param_spec_uint("resolution-ticks", "resolution-ticks",

--- a/src/seq/queue-timer-common.c
+++ b/src/seq/queue-timer-common.c
@@ -9,7 +9,7 @@
  *
  * The object wraps `struct snd_seq_queue_timer` in UAPI of Linux sound subsystem.
  *
- * Since: 0.3.
+ * Since: 0.3
  */
 
 static void alsaseq_queue_timer_common_default_init(ALSASeqQueueTimerCommonInterface *iface);
@@ -23,7 +23,7 @@ static void alsaseq_queue_timer_common_default_init(ALSASeqQueueTimerCommonInter
      *
      * The numeric identifier of queue. An entry of [enum@SpecificClientId] is available as well.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     g_object_interface_install_property(iface,
         g_param_spec_uchar(QUEUE_ID_PROP_NAME, QUEUE_ID_PROP_NAME,
@@ -36,7 +36,7 @@ static void alsaseq_queue_timer_common_default_init(ALSASeqQueueTimerCommonInter
      *
      * The type of timer for the queue, one of [enum@QueueTimerType].
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     g_object_interface_install_property(iface,
         g_param_spec_enum(TIMER_TYPE_PROP_NAME, TIMER_TYPE_PROP_NAME,

--- a/src/seq/remove-filter.c
+++ b/src/seq/remove-filter.c
@@ -107,7 +107,7 @@ static void alsaseq_remove_filter_class_init(ALSASeqRemoveFilterClass *klass)
      * The set of flags to filter events. They decide how to evaluate included data at call of
      * [method@UserClient.remove_events].
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_remove_filter_props[SEQ_REMOVE_FILTER_PROP_FLAGS] =
         g_param_spec_flags("flags", "flags",
@@ -122,7 +122,7 @@ static void alsaseq_remove_filter_class_init(ALSASeqRemoveFilterClass *klass)
      * The numeric identifier of queue as filter condition. This is always evaluated at call of
      * [method@UserClient.remove_events].
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_remove_filter_props[SEQ_REMOVE_FILTER_PROP_QUEUE_ID] =
         g_param_spec_uchar("queue-id", "queue-id",
@@ -137,7 +137,7 @@ static void alsaseq_remove_filter_class_init(ALSASeqRemoveFilterClass *klass)
      * The destionation of event as filter condition. This is evaluated with
      * [flags@RemoveFilterFlag].DEST at call of [method@UserClient.remove_events].
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_remove_filter_props[SEQ_REMOVE_FILTER_PROP_DST] =
         g_param_spec_boxed("destination", "destination",
@@ -151,7 +151,7 @@ static void alsaseq_remove_filter_class_init(ALSASeqRemoveFilterClass *klass)
      * The channel of event as filter condition. This is evaluated with
      * [flags@RemoveFilterFlag].DEST_CHANNEL at call of [method@UserClient.remove_events].
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_remove_filter_props[SEQ_REMOVE_FILTER_PROP_CHANNEL] =
         g_param_spec_uchar("channel", "channel",
@@ -166,7 +166,7 @@ static void alsaseq_remove_filter_class_init(ALSASeqRemoveFilterClass *klass)
      * The type of event as filter condition. This is evaluated with
      * [flags@RemoveFilterFlag].EVENT_TYPE at call of [method@UserClient.remove_events].
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_remove_filter_props[SEQ_REMOVE_FILTER_PROP_EVENT_TYPE] =
         g_param_spec_enum("event-type", "event-type",
@@ -181,7 +181,7 @@ static void alsaseq_remove_filter_class_init(ALSASeqRemoveFilterClass *klass)
      * The tag of event as filter condition. This is evaluated with
      * [flags@RemoveFilterFlag].TAG_MATCH at call of [method@UserClient.remove_events].
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_remove_filter_props[SEQ_REMOVE_FILTER_PROP_TAG] =
         g_param_spec_char("tag", "tag",

--- a/src/seq/subscribe-data.c
+++ b/src/seq/subscribe-data.c
@@ -124,7 +124,7 @@ static void alsaseq_subscribe_data_class_init(ALSASeqSubscribeDataClass *klass)
      *
      * The address of sender.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_subscribe_data_props[SEQ_SUBSCRIBE_DATA_PROP_SENDER] =
         g_param_spec_boxed("sender", "sender",
@@ -137,7 +137,7 @@ static void alsaseq_subscribe_data_class_init(ALSASeqSubscribeDataClass *klass)
      *
      * The address of destination.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_subscribe_data_props[SEQ_SUBSCRIBE_DATA_PROP_DEST] =
         g_param_spec_boxed("dest", "dest",
@@ -150,7 +150,7 @@ static void alsaseq_subscribe_data_class_init(ALSASeqSubscribeDataClass *klass)
      *
      * Whether the subscription can be changed by originator only,
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_subscribe_data_props[SEQ_SUBSCRIBE_DATA_PROP_IS_EXCLUSIVE] =
         g_param_spec_boolean("is-exclusive", "is-exclusive",
@@ -163,7 +163,7 @@ static void alsaseq_subscribe_data_class_init(ALSASeqSubscribeDataClass *klass)
      *
      * Any event for the subscription has time stamp,
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_subscribe_data_props[SEQ_SUBSCRIBE_DATA_PROP_HAS_TSTAMP] =
         g_param_spec_boolean("has-tstamp", "has-tstamp",
@@ -176,7 +176,7 @@ static void alsaseq_subscribe_data_class_init(ALSASeqSubscribeDataClass *klass)
      *
      * The type of time stamp. This is effective when the has-tstamp property enabled.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_subscribe_data_props[SEQ_SUBSCRIBE_DATA_PROP_TSTAMP_MODE] =
         g_param_spec_enum("tstamp-mode", "tstamp-mode",
@@ -192,7 +192,7 @@ static void alsaseq_subscribe_data_class_init(ALSASeqSubscribeDataClass *klass)
      * The numeric ID of queue to deliver. One of ALSASeqSpecificQueueId is available as well as
      * any numeric value.
      *
-     * Since: 0.3.
+     * Since: 0.3
      */
     seq_subscribe_data_props[SEQ_SUBSCRIBE_DATA_PROP_QUEUE_ID] =
         g_param_spec_uchar("queue-id", "queue-id",


### PR DESCRIPTION
The version of gi-docgen applies the restrict rule for the version expression. In the rule, the dot following to the number causes failure.

The series of changes in this MR solves the failure.