### PR TITLE
timer/seq: fix minor issues

### DIFF
--- a/src/seq/query.c
+++ b/src/seq/query.c
@@ -70,7 +70,7 @@ static gboolean open_fd(int *fd, GError **error)
     gboolean result;
 
     if (!alsaseq_get_seq_devnode(&devname, error))
-        return -1;
+        return FALSE;
 
     result = TRUE;
     *fd = open(devname, O_RDONLY);

--- a/src/timer/query.c
+++ b/src/timer/query.c
@@ -76,7 +76,7 @@ static gboolean open_fd(int *fd, GError **error)
     gboolean result;
 
     if (!alsatimer_get_devnode(&devname, error))
-        return -1;
+        return FALSE;
 
     result = TRUE;
     *fd = open(devname, O_RDONLY);

--- a/src/timer/user-instance.c
+++ b/src/timer/user-instance.c
@@ -332,9 +332,9 @@ gboolean alsatimer_user_instance_attach(ALSATimerUserInstance *self, ALSATimerDe
  * @error: A [struct@GLib.Error]. Error is generated with domain of `ALSATimer.UserInstanceError`.
  *
  * Attach the instance as an slave to another instance indicated by a pair of slave_class and
- * slave_id. If the slave_class is [enum@SlaveClass:APPLICATION], the slave_id is for the PID of
+ * slave_id. If the slave_class is [enum@SlaveClass].APPLICATION, the slave_id is for the PID of
  * application process which owns the instance of timer. If the slave_class is
- * [enum@SlaveClass:SEQUENCER], the slave_id is the numeric ID of queue bound for timer device.
+ * [enum@SlaveClass].SEQUENCER, the slave_id is the numeric ID of queue bound for timer device.
  *
  * The call of function executes `ioctl(2)` system call with `SNDRV_TIMER_IOCTL_SELECT` command
  * for ALSA timer character device.


### PR DESCRIPTION
As long as building on Ubuntu 25.04, some codes takes warnings from gcc 14 and gi-docgen 2025.3-1. This patchset includes some fixes to solve the codes.